### PR TITLE
Versioning Improvements

### DIFF
--- a/gtnh-assets.json
+++ b/gtnh-assets.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "name": "GT-New-Horizons-Modpack",
-    "latest_version": "2.1.2.4-29-pre",
+    "latest_version": "2.2.0.0-RC-1",
     "versions": [
       {
         "version_tag": "2.1.2.3qf-test",
@@ -177,6 +177,13 @@
         "filename": "2.1.2.4-29-pre.zip",
         "download_url": "https://api.github.com/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases/assets/76105656",
         "browser_download_url": "https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/releases/download/2.1.2.4-29-pre/2.1.2.4-29-pre.zip"
+      },
+      {
+        "version_tag": "2.2.0.0-RC-1",
+        "tagged_at": "2022-09-03T09:20:47+00:00",
+        "filename": "2.2.0.0-RC-1.zip",
+        "download_url": "https://api.github.com/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases/assets/76747652",
+        "browser_download_url": "https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/releases/download/2.2.0.0-RC-1/2.2.0.0-RC-1.zip"
       }
     ],
     "type": "config",
@@ -1033,7 +1040,7 @@
     },
     {
       "name": "bartworks",
-      "latest_version": "0.5.80",
+      "latest_version": "0.5.81-pre",
       "versions": [
         {
           "version_tag": "0.5.26",
@@ -1432,6 +1439,14 @@
           "filename": "bartworks-1.7.10-0.5.80.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/bartworks/releases/assets/76196131",
           "browser_download_url": "https://github.com/GTNewHorizons/bartworks/releases/download/0.5.80/bartworks-1.7.10-0.5.80.jar"
+        },
+        {
+          "version_tag": "0.5.81-pre",
+          "changelog": "## What's Changed\n* Spotless apply for branch radhatch for #195 by @github-actions in https://github.com/GTNewHorizons/bartworks/pull/196\n* Spotless apply for branch radhatch for #195 by @github-actions in https://github.com/GTNewHorizons/bartworks/pull/197\n* fix DT construct and survivalConstruct having wrong offset by @Glease in https://github.com/GTNewHorizons/bartworks/pull/198\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/bartworks/compare/0.5.80...0.5.81-pre",
+          "tagged_at": "2022-09-03T09:30:11+00:00",
+          "filename": "bartworks-1.7.10-0.5.81-pre.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/bartworks/releases/assets/76748089",
+          "browser_download_url": "https://github.com/GTNewHorizons/bartworks/releases/download/0.5.81-pre/bartworks-1.7.10-0.5.81-pre.jar"
         }
       ],
       "license": "GNU Lesser General Public License v3.0.",
@@ -1440,7 +1455,7 @@
     },
     {
       "name": "Battlegear2",
-      "latest_version": "1.1.1.10",
+      "latest_version": "1.1.1.9",
       "versions": [
         {
           "version_tag": "1.0.8.5",
@@ -1525,13 +1540,6 @@
           "filename": "battlegear2-1.7.10-1.1.1.9.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/Battlegear2/releases/assets/56516784",
           "browser_download_url": "https://github.com/GTNewHorizons/Battlegear2/releases/download/1.1.1.9/battlegear2-1.7.10-1.1.1.9.jar"
-        },
-        {
-          "version_tag": "1.1.1.10",
-          "tagged_at": "2022-02-11T15:28:11",
-          "filename": "battlegear2-1.7.10-1.1.1.10.jar",
-          "download_url": "https://api.github.com/repos/GTNewHorizons/Battlegear2/releases/assets/56519437",
-          "browser_download_url": "https://github.com/GTNewHorizons/Battlegear2/releases/download/1.1.1.10/battlegear2-1.7.10-1.1.1.10.jar"
         }
       ],
       "license": "GNU General Public License v3.0.",
@@ -2045,7 +2053,7 @@
     },
     {
       "name": "BloodMagic",
-      "latest_version": "1.3.12-pre",
+      "latest_version": "1.3.13",
       "versions": [
         {
           "version_tag": "1.3.3-29",
@@ -2132,6 +2140,14 @@
           "filename": "BloodMagic-1.7.10-1.3.12-pre.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/BloodMagic/releases/assets/74776646",
           "browser_download_url": "https://github.com/GTNewHorizons/BloodMagic/releases/download/1.3.12-pre/BloodMagic-1.7.10-1.3.12-pre.jar"
+        },
+        {
+          "version_tag": "1.3.13",
+          "changelog": "## What's Changed\n* Fix the Key of Binding in multiplayer by @guineawheek in https://github.com/GTNewHorizons/BloodMagic/pull/28\n* Move dim blacklist config to AlchemicalWizardry.java by @DianeXD in https://github.com/GTNewHorizons/BloodMagic/pull/29\n* Meteor NEI improvements by @miozune in https://github.com/GTNewHorizons/BloodMagic/pull/30\n* Add estimated amount display for meteor NEI by @miozune in https://github.com/GTNewHorizons/BloodMagic/pull/31\n\n## New Contributors\n* @guineawheek made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/28\n* @DianeXD made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/29\n\n**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.3.10...1.3.13",
+          "tagged_at": "2022-09-02T11:55:22+00:00",
+          "filename": "BloodMagic-1.7.10-1.3.13.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/BloodMagic/releases/assets/76667700",
+          "browser_download_url": "https://github.com/GTNewHorizons/BloodMagic/releases/download/1.3.13/BloodMagic-1.7.10-1.3.13.jar"
         }
       ],
       "license": "Creative Commons Attribution 4.0 International.",
@@ -3259,6 +3275,7 @@
     {
       "name": "Electro-Magic-Tools",
       "latest_version": "1.2.18-pre",
+      "needs_attention": true,
       "versions": [
         {
           "version_tag": "1.2.6.5",
@@ -3892,7 +3909,7 @@
     },
     {
       "name": "ExtraCells2",
-      "latest_version": "2.5.20",
+      "latest_version": "2.5.22",
       "versions": [
         {
           "version_tag": "2.3.1-17",
@@ -4067,6 +4084,22 @@
           "filename": "ExtraCells-1.7.10-2.5.20.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/ExtraCells2/releases/assets/75683475",
           "browser_download_url": "https://github.com/GTNewHorizons/ExtraCells2/releases/download/2.5.20/ExtraCells-1.7.10-2.5.20.jar"
+        },
+        {
+          "version_tag": "2.5.21",
+          "changelog": "## What's Changed\n* Update some features by @asdflj in https://github.com/GTNewHorizons/ExtraCells2/pull/67\n\n## New Contributors\n* @asdflj made their first contribution in https://github.com/GTNewHorizons/ExtraCells2/pull/67\n\n**Full Changelog**: https://github.com/GTNewHorizons/ExtraCells2/compare/2.5.20...2.5.21",
+          "tagged_at": "2022-09-01T11:44:53+00:00",
+          "filename": "ExtraCells-1.7.10-2.5.21.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/ExtraCells2/releases/assets/76545306",
+          "browser_download_url": "https://github.com/GTNewHorizons/ExtraCells2/releases/download/2.5.21/ExtraCells-1.7.10-2.5.21.jar"
+        },
+        {
+          "version_tag": "2.5.22",
+          "changelog": "## What's Changed\n* Fixed fluid in terminal showing negative numbers by @asdflj in https://github.com/GTNewHorizons/ExtraCells2/pull/68\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/ExtraCells2/compare/2.5.21...2.5.22",
+          "tagged_at": "2022-09-02T11:52:53+00:00",
+          "filename": "ExtraCells-1.7.10-2.5.22.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/ExtraCells2/releases/assets/76667505",
+          "browser_download_url": "https://github.com/GTNewHorizons/ExtraCells2/releases/download/2.5.22/ExtraCells-1.7.10-2.5.22.jar"
         }
       ],
       "license": "MIT License.",
@@ -4075,7 +4108,7 @@
     },
     {
       "name": "FindIt",
-      "latest_version": "1.0.10",
+      "latest_version": "1.0.11",
       "versions": [
         {
           "version_tag": "1.0.3",
@@ -4135,6 +4168,14 @@
           "filename": "findit-1.7.10-1.0.10.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/FindIt/releases/assets/76429094",
           "browser_download_url": "https://github.com/GTNewHorizons/FindIt/releases/download/1.0.10/findit-1.7.10-1.0.10.jar"
+        },
+        {
+          "version_tag": "1.0.11",
+          "changelog": "## What's Changed\n* Fix inventory slots not being highlighted by @miozune in https://github.com/GTNewHorizons/FindIt/pull/9\n\n## New Contributors\n* @miozune made their first contribution in https://github.com/GTNewHorizons/FindIt/pull/9\n\n**Full Changelog**: https://github.com/GTNewHorizons/FindIt/compare/1.0.10...1.0.11",
+          "tagged_at": "2022-09-01T14:14:43+00:00",
+          "filename": "findit-1.7.10-1.0.11.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/FindIt/releases/assets/76560472",
+          "browser_download_url": "https://github.com/GTNewHorizons/FindIt/releases/download/1.0.11/findit-1.7.10-1.0.11.jar"
         }
       ],
       "license": "MIT License.",
@@ -4848,7 +4889,7 @@
     },
     {
       "name": "GoodGenerator",
-      "latest_version": "0.4.21",
+      "latest_version": "0.4.22",
       "versions": [
         {
           "version_tag": "v0.0.2-QF1",
@@ -5107,6 +5148,14 @@
           "filename": "GoodGenerator-1.7.10-0.4.21.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/GoodGenerator/releases/assets/76059638",
           "browser_download_url": "https://github.com/GTNewHorizons/GoodGenerator/releases/download/0.4.21/GoodGenerator-1.7.10-0.4.21.jar"
+        },
+        {
+          "version_tag": "0.4.22",
+          "changelog": "## What's Changed\n* Fix incorrect circuit tier for YOT cells by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/77\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GoodGenerator/compare/0.4.21...0.4.22",
+          "tagged_at": "2022-09-03T09:19:09+00:00",
+          "filename": "GoodGenerator-1.7.10-0.4.22.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GoodGenerator/releases/assets/76747583",
+          "browser_download_url": "https://github.com/GTNewHorizons/GoodGenerator/releases/download/0.4.22/GoodGenerator-1.7.10-0.4.22.jar"
         }
       ],
       "license": "MIT License.",
@@ -5115,7 +5164,7 @@
     },
     {
       "name": "GT5-Unofficial",
-      "latest_version": "5.09.41.23",
+      "latest_version": "5.09.41.27",
       "versions": [
         {
           "version_tag": "5.09.40.01",
@@ -6055,6 +6104,38 @@
           "filename": "gregtech-1.7.10-5.09.41.23.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/GT5-Unofficial/releases/assets/76543800",
           "browser_download_url": "https://github.com/GTNewHorizons/GT5-Unofficial/releases/download/5.09.41.23/gregtech-1.7.10-5.09.41.23.jar"
+        },
+        {
+          "version_tag": "5.09.41.24",
+          "changelog": "## What's Changed\n* Super Tank Fluid Locking Fix by @Quarri6343 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1332\n* Add Drag-And-Drop support for digital tank by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1333\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.41.23...5.09.41.24",
+          "tagged_at": "2022-09-02T11:59:49+00:00",
+          "filename": "gregtech-1.7.10-5.09.41.24.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GT5-Unofficial/releases/assets/76668107",
+          "browser_download_url": "https://github.com/GTNewHorizons/GT5-Unofficial/releases/download/5.09.41.24/gregtech-1.7.10-5.09.41.24.jar"
+        },
+        {
+          "version_tag": "5.09.41.25",
+          "changelog": "## What's Changed\n* Fix oxygen dupe from chromium dioxide by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1334\n* fix rare occasion of zero sized empty cell in electrolyzer output by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1335\n* Fix reinforced glass by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1337\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.41.24...5.09.41.25",
+          "tagged_at": "2022-09-03T09:20:48+00:00",
+          "filename": "gregtech-1.7.10-5.09.41.25.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GT5-Unofficial/releases/assets/76747655",
+          "browser_download_url": "https://github.com/GTNewHorizons/GT5-Unofficial/releases/download/5.09.41.25/gregtech-1.7.10-5.09.41.25.jar"
+        },
+        {
+          "version_tag": "5.09.41.26",
+          "changelog": "## What's Changed\n* Fix oxygen dupe from chromium dioxide by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1334\n* fix rare occasion of zero sized empty cell in electrolyzer output by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1335\n* Fix reinforced glass by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1337\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.41.24...5.09.41.26",
+          "tagged_at": "2022-09-03T09:23:13+00:00",
+          "filename": "gregtech-1.7.10-5.09.41.26.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GT5-Unofficial/releases/assets/76747778",
+          "browser_download_url": "https://github.com/GTNewHorizons/GT5-Unofficial/releases/download/5.09.41.26/gregtech-1.7.10-5.09.41.26.jar"
+        },
+        {
+          "version_tag": "5.09.41.27",
+          "changelog": "## What's Changed\n* Fix chemical balance with Hydrogen Sulfide to Sulfuric Acid recipe by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1338\n* merge in ASM-ed in changes from gt++ by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1339\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.41.25...5.09.41.27",
+          "tagged_at": "2022-09-03T16:04:31+00:00",
+          "filename": "gregtech-1.7.10-5.09.41.27.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GT5-Unofficial/releases/assets/76769070",
+          "browser_download_url": "https://github.com/GTNewHorizons/GT5-Unofficial/releases/download/5.09.41.27/gregtech-1.7.10-5.09.41.27.jar"
         }
       ],
       "license": "GNU Lesser General Public License v3.0.",
@@ -6408,7 +6489,7 @@
     },
     {
       "name": "GTplusplus",
-      "latest_version": "1.7.84",
+      "latest_version": "1.7.85",
       "versions": [
         {
           "version_tag": "1.7.16",
@@ -6873,6 +6954,14 @@
           "filename": "GT-PlusPlus-1.7.10-1.7.84.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/GTplusplus/releases/assets/76539613",
           "browser_download_url": "https://github.com/GTNewHorizons/GTplusplus/releases/download/1.7.84/GT-PlusPlus-1.7.10-1.7.84.jar"
+        },
+        {
+          "version_tag": "1.7.85",
+          "changelog": "## What's Changed\n* Remove GT asm by @Glease in https://github.com/GTNewHorizons/GTplusplus/pull/333\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/GTplusplus/compare/1.7.83...1.7.85",
+          "tagged_at": "2022-09-03T16:17:30+00:00",
+          "filename": "GT-PlusPlus-1.7.10-1.7.85.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/GTplusplus/releases/assets/76770025",
+          "browser_download_url": "https://github.com/GTNewHorizons/GTplusplus/releases/download/1.7.85/GT-PlusPlus-1.7.10-1.7.85.jar"
         }
       ],
       "license": "GNU General Public License v3.0.",
@@ -7003,7 +7092,7 @@
     },
     {
       "name": "Hodgepodge",
-      "latest_version": "1.7.15-pre",
+      "latest_version": "1.7.17",
       "versions": [
         {
           "version_tag": "v1.2.0",
@@ -7227,6 +7316,22 @@
           "filename": "hodgepodge-1.7.10-1.7.15-pre.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/Hodgepodge/releases/assets/76431001",
           "browser_download_url": "https://github.com/GTNewHorizons/Hodgepodge/releases/download/1.7.15-pre/hodgepodge-1.7.10-1.7.15-pre.jar"
+        },
+        {
+          "version_tag": "1.7.16",
+          "changelog": "## What's Changed\n* Move animationsMode debug info to the right by @vlaetansky in https://github.com/GTNewHorizons/Hodgepodge/pull/88\n* fix animation of fluid in cell for the two most common fluid cell by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/93\n* various patches to optimize loading time by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/89\n* Fix vanilla potion effects rendering above the NEI tooltips in the inventory by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/91\n\n## New Contributors\n* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/91\n\n**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/1.7.13...1.7.16",
+          "tagged_at": "2022-09-01T12:05:10+00:00",
+          "filename": "hodgepodge-1.7.10-1.7.16.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/Hodgepodge/releases/assets/76547116",
+          "browser_download_url": "https://github.com/GTNewHorizons/Hodgepodge/releases/download/1.7.16/hodgepodge-1.7.10-1.7.16.jar"
+        },
+        {
+          "version_tag": "1.7.17",
+          "changelog": "## What's Changed\n* Prevent tall grass and such to affect the perspective camera by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/94\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/1.7.16...1.7.17",
+          "tagged_at": "2022-09-03T09:30:53+00:00",
+          "filename": "hodgepodge-1.7.10-1.7.17.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/Hodgepodge/releases/assets/76748149",
+          "browser_download_url": "https://github.com/GTNewHorizons/Hodgepodge/releases/download/1.7.17/hodgepodge-1.7.10-1.7.17.jar"
         }
       ],
       "license": "GNU Lesser General Public License v3.0.",
@@ -8051,7 +8156,7 @@
     },
     {
       "name": "KubaTech",
-      "latest_version": "0.5",
+      "latest_version": "0.5.1",
       "versions": [
         {
           "version_tag": "0.1",
@@ -8132,6 +8237,14 @@
           "filename": "kubatech-1.7.10-0.5.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/KubaTech/releases/assets/76175114",
           "browser_download_url": "https://github.com/GTNewHorizons/KubaTech/releases/download/0.5/kubatech-1.7.10-0.5.jar"
+        },
+        {
+          "version_tag": "0.5.1",
+          "changelog": "## What's Changed\n* Fix wrong Tea owner by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/12\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/KubaTech/compare/0.5...0.5.1",
+          "tagged_at": "2022-09-01T13:49:35+00:00",
+          "filename": "kubatech-1.7.10-0.5.1.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/KubaTech/releases/assets/76557491",
+          "browser_download_url": "https://github.com/GTNewHorizons/KubaTech/releases/download/0.5.1/kubatech-1.7.10-0.5.1.jar"
         }
       ],
       "license": "GNU Lesser General Public License v3.0",
@@ -8822,7 +8935,7 @@
     },
     {
       "name": "NaturesCompass",
-      "latest_version": "1.3.3-GTNH",
+      "latest_version": "1.3.4-GTNH",
       "versions": [
         {
           "version_tag": "1.3.2-GTNH",
@@ -8838,6 +8951,14 @@
           "filename": "naturescompass-1.7.10-1.3.3-GTNH.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/NaturesCompass/releases/assets/76537606",
           "browser_download_url": "https://github.com/GTNewHorizons/NaturesCompass/releases/download/1.3.3-GTNH/naturescompass-1.7.10-1.3.3-GTNH.jar"
+        },
+        {
+          "version_tag": "1.3.4-GTNH",
+          "changelog": "## What's Changed\n* biome list update and config setting by @bjin2000 in https://github.com/GTNewHorizons/NaturesCompass/pull/3\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/NaturesCompass/compare/1.3.3-GTNH...1.3.4-GTNH",
+          "tagged_at": "2022-09-03T09:28:58+00:00",
+          "filename": "naturescompass-1.7.10-1.3.4-GTNH.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/NaturesCompass/releases/assets/76748056",
+          "browser_download_url": "https://github.com/GTNewHorizons/NaturesCompass/releases/download/1.3.4-GTNH/naturescompass-1.7.10-1.3.4-GTNH.jar"
         }
       ],
       "license": "All Rights Reserved (fallback)",
@@ -8891,6 +9012,7 @@
     {
       "name": "NEI-Integration",
       "latest_version": "1.2.0",
+      "needs_attention": true,
       "versions": [
         {
           "version_tag": "1.1.3",
@@ -8989,7 +9111,7 @@
     },
     {
       "name": "NewHorizonsCoreMod",
-      "latest_version": "1.9.65",
+      "latest_version": "1.9.68-pre",
       "versions": [
         {
           "version_tag": "1.9.11",
@@ -9388,6 +9510,30 @@
           "filename": "GTNewHorizonsCoreMod-1.7.10-1.9.65.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/NewHorizonsCoreMod/releases/assets/76539378",
           "browser_download_url": "https://github.com/GTNewHorizons/NewHorizonsCoreMod/releases/download/1.9.65/GTNewHorizonsCoreMod-1.7.10-1.9.65.jar"
+        },
+        {
+          "version_tag": "1.9.66",
+          "changelog": "## What's Changed\n* Add recipe for NC2 panel memory card by @greesyB in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/405\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/1.9.65...1.9.66",
+          "tagged_at": "2022-09-02T11:57:25+00:00",
+          "filename": "GTNewHorizonsCoreMod-1.7.10-1.9.66.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/NewHorizonsCoreMod/releases/assets/76667884",
+          "browser_download_url": "https://github.com/GTNewHorizons/NewHorizonsCoreMod/releases/download/1.9.66/GTNewHorizonsCoreMod-1.7.10-1.9.66.jar"
+        },
+        {
+          "version_tag": "1.9.67",
+          "changelog": "## What's Changed\n* add back the /dev/null by @boubou19 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/406\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/1.9.66...1.9.67",
+          "tagged_at": "2022-09-03T09:21:31+00:00",
+          "filename": "GTNewHorizonsCoreMod-1.7.10-1.9.67.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/NewHorizonsCoreMod/releases/assets/76747684",
+          "browser_download_url": "https://github.com/GTNewHorizons/NewHorizonsCoreMod/releases/download/1.9.67/GTNewHorizonsCoreMod-1.7.10-1.9.67.jar"
+        },
+        {
+          "version_tag": "1.9.68-pre",
+          "changelog": "**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/1.9.67...1.9.68-pre",
+          "tagged_at": "2022-09-03T16:26:00+00:00",
+          "filename": "GTNewHorizonsCoreMod-1.7.10-1.9.68-pre.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/NewHorizonsCoreMod/releases/assets/76770634",
+          "browser_download_url": "https://github.com/GTNewHorizons/NewHorizonsCoreMod/releases/download/1.9.68-pre/GTNewHorizonsCoreMod-1.7.10-1.9.68-pre.jar"
         }
       ],
       "license": "GNU General Public License v3.0.",
@@ -9493,6 +9639,7 @@
     {
       "name": "NotEnoughItems",
       "latest_version": "2.2.334-GTNH",
+      "needs_attention": true,
       "versions": [
         {
           "version_tag": "v2.0.0",
@@ -10001,7 +10148,7 @@
     },
     {
       "name": "Nuclear-Control",
-      "latest_version": "2.4.14",
+      "latest_version": "2.4.15",
       "versions": [
         {
           "version_tag": "2.4.7",
@@ -10063,6 +10210,14 @@
           "filename": "IC2NuclearControl-1.7.10-2.4.14.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/Nuclear-Control/releases/assets/75292393",
           "browser_download_url": "https://github.com/GTNewHorizons/Nuclear-Control/releases/download/2.4.14/IC2NuclearControl-1.7.10-2.4.14.jar"
+        },
+        {
+          "version_tag": "2.4.15",
+          "changelog": "## What's Changed\n* Add information panel memory card by @greesyB in https://github.com/GTNewHorizons/Nuclear-Control/pull/13\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.4.14...2.4.15",
+          "tagged_at": "2022-09-01T15:19:49+00:00",
+          "filename": "IC2NuclearControl-1.7.10-2.4.15.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/Nuclear-Control/releases/assets/76568452",
+          "browser_download_url": "https://github.com/GTNewHorizons/Nuclear-Control/releases/download/2.4.15/IC2NuclearControl-1.7.10-2.4.15.jar"
         }
       ],
       "license": "Original code with a custom license allowing edit and redistribution, GTNH changes licensed under the GNU Lesser General Public Library v3.0.",
@@ -10910,6 +11065,7 @@
     {
       "name": "Schematica",
       "latest_version": "1.8.8-GTNH-pre",
+      "needs_attention": true,
       "versions": [
         {
           "version_tag": "1.8.0-GTNH",
@@ -11178,6 +11334,7 @@
     {
       "name": "SpiceOfLife",
       "latest_version": "2.0.4-carrot",
+      "needs_attention": true,
       "versions": [
         {
           "version_tag": "v2.0.0-carrot-beta1",
@@ -11282,7 +11439,7 @@
     },
     {
       "name": "StandardQuestingPack",
-      "latest_version": "3.0.195-GTNH",
+      "latest_version": "3.0.197-GTNH",
       "versions": [
         {
           "version_tag": "3.0.187-GTNH",
@@ -11348,6 +11505,22 @@
           "filename": "StandardExpansion-1.7.10-3.0.195-GTNH.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/StandardQuestingPack/releases/assets/75464655",
           "browser_download_url": "https://github.com/GTNewHorizons/StandardQuestingPack/releases/download/3.0.195-GTNH/StandardExpansion-1.7.10-3.0.195-GTNH.jar"
+        },
+        {
+          "version_tag": "3.0.196-GTNH",
+          "changelog": "## What's Changed\n* Fix NEI interaction not playing sound by @miozune in https://github.com/GTNewHorizons/StandardQuestingPack/pull/23\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/StandardQuestingPack/compare/3.0.195-GTNH...3.0.196-GTNH",
+          "tagged_at": "2022-09-02T11:53:21+00:00",
+          "filename": "StandardExpansion-1.7.10-3.0.196-GTNH.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/StandardQuestingPack/releases/assets/76667543",
+          "browser_download_url": "https://github.com/GTNewHorizons/StandardQuestingPack/releases/download/3.0.196-GTNH/StandardExpansion-1.7.10-3.0.196-GTNH.jar"
+        },
+        {
+          "version_tag": "3.0.197-GTNH",
+          "changelog": "## What's Changed\n* Add NEI recipe handler by @miozune in https://github.com/GTNewHorizons/StandardQuestingPack/pull/24\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/StandardQuestingPack/compare/3.0.196-GTNH...3.0.197-GTNH",
+          "tagged_at": "2022-09-03T09:17:16+00:00",
+          "filename": "StandardExpansion-1.7.10-3.0.197-GTNH.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/StandardQuestingPack/releases/assets/76747550",
+          "browser_download_url": "https://github.com/GTNewHorizons/StandardQuestingPack/releases/download/3.0.197-GTNH/StandardExpansion-1.7.10-3.0.197-GTNH.jar"
         }
       ],
       "license": "MIT License.",
@@ -11749,7 +11922,7 @@
     },
     {
       "name": "StructureLib",
-      "latest_version": "1.1.7",
+      "latest_version": "1.1.9",
       "versions": [
         {
           "version_tag": "1.0.11",
@@ -11849,6 +12022,22 @@
           "filename": "structurelib-1.7.10-1.1.7.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/StructureLib/releases/assets/76115844",
           "browser_download_url": "https://github.com/GTNewHorizons/StructureLib/releases/download/1.1.7/structurelib-1.7.10-1.1.7.jar"
+        },
+        {
+          "version_tag": "1.1.8",
+          "changelog": "## What's Changed\n* Add javadoc for APIs by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/10\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.1.7...1.1.8",
+          "tagged_at": "2022-09-02T11:55:41+00:00",
+          "filename": "structurelib-1.7.10-1.1.8.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/StructureLib/releases/assets/76667716",
+          "browser_download_url": "https://github.com/GTNewHorizons/StructureLib/releases/download/1.1.8/structurelib-1.7.10-1.1.8.jar"
+        },
+        {
+          "version_tag": "1.1.9",
+          "changelog": "## What's Changed\n* Update zh_CN.lang by @iouter in https://github.com/GTNewHorizons/StructureLib/pull/11\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.1.8...1.1.9",
+          "tagged_at": "2022-09-03T09:18:37+00:00",
+          "filename": "structurelib-1.7.10-1.1.9.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/StructureLib/releases/assets/76747568",
+          "browser_download_url": "https://github.com/GTNewHorizons/StructureLib/releases/download/1.1.9/structurelib-1.7.10-1.1.9.jar"
         }
       ],
       "license": "MIT License.",
@@ -12476,7 +12665,7 @@
     },
     {
       "name": "Thaumic_Exploration",
-      "latest_version": "1.1.90-GTNH",
+      "latest_version": "1.1.91-GTNH",
       "versions": [
         {
           "version_tag": "1.1.56",
@@ -12544,6 +12733,14 @@
           "filename": "Thaumic-Exploration-1.7.10-1.1.90-GTNH.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/Thaumic_Exploration/releases/assets/76343947",
           "browser_download_url": "https://github.com/GTNewHorizons/Thaumic_Exploration/releases/download/1.1.90-GTNH/Thaumic-Exploration-1.7.10-1.1.90-GTNH.jar"
+        },
+        {
+          "version_tag": "1.1.91-GTNH",
+          "changelog": "## What's Changed\n* add rus localization by @Pa4ok in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/19\n\n## New Contributors\n* @Pa4ok made their first contribution in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/19\n\n**Full Changelog**: https://github.com/GTNewHorizons/Thaumic_Exploration/compare/1.1.90-GTNH...1.1.91-GTNH",
+          "tagged_at": "2022-09-03T09:15:42+00:00",
+          "filename": "Thaumic-Exploration-1.7.10-1.1.91-GTNH.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/Thaumic_Exploration/releases/assets/76747463",
+          "browser_download_url": "https://github.com/GTNewHorizons/Thaumic_Exploration/releases/download/1.1.91-GTNH/Thaumic-Exploration-1.7.10-1.1.91-GTNH.jar"
         }
       ],
       "license": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International.",
@@ -12763,8 +12960,40 @@
     },
     {
       "name": "thaumicinsurgence",
-      "latest_version": "0.0.1",
+      "latest_version": "0.0.5",
       "versions": [
+        {
+          "version_tag": "0.0.0.1",
+          "changelog": "## What's Changed\n* Cleanup by @kuba6000 in https://github.com/GTNewHorizons/thaumicinsurgence/pull/5\n\n## New Contributors\n* @kuba6000 made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/5\n\n**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.0.1...0.0.0.1",
+          "tagged_at": "2022-08-31T21:09:02+00:00",
+          "filename": "thaumicinsurgence-1.7.10-0.0.0.1.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76469310",
+          "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.0.1/thaumicinsurgence-1.7.10-0.0.0.1.jar"
+        },
+        {
+          "version_tag": "0.0.0.2",
+          "changelog": "Just a minor change to update the release tag to how it's labeled in my code and everywhere else. (Just from the 0.0.0 ver labeling system to the 0.0.0.0 ver labeling system)\r\n\r\n## What's Changed\r\n* Cleanup by @kuba6000 in https://github.com/GTNewHorizons/thaumicinsurgence/pull/5\r\n\r\n## New Contributors\r\n* @kuba6000 made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/5\r\n\r\n**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.0.1...0.0.0.2",
+          "tagged_at": "2022-08-31T22:44:29+00:00",
+          "filename": "thaumicinsurgence-1.7.10-0.0.0.2.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76480997",
+          "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.0.2/thaumicinsurgence-1.7.10-0.0.0.2.jar"
+        },
+        {
+          "version_tag": "0.0.0.3",
+          "changelog": "## What's Changed\n* Just updating the readme to add a small changelog for the new release by @Alastors in https://github.com/GTNewHorizons/thaumicinsurgence/pull/10\n\n\n**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.0.0.1...0.0.0.3",
+          "tagged_at": "2022-09-01T11:38:41+00:00",
+          "filename": "thaumicinsurgence-1.7.10-0.0.0.3.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76544816",
+          "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.0.3/thaumicinsurgence-1.7.10-0.0.0.3.jar"
+        },
+        {
+          "version_tag": "0.0.0.4",
+          "changelog": "**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.0.0.3...0.0.0.4",
+          "tagged_at": "2022-09-02T19:29:56+00:00",
+          "filename": "thaumicinsurgence-1.7.10-0.0.0.4.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76702717",
+          "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.0.4/thaumicinsurgence-1.7.10-0.0.0.4.jar"
+        },
         {
           "version_tag": "0.0.1",
           "changelog": "## What's Changed\n* Adding a \"readme\" file by @Alastors in https://github.com/GTNewHorizons/thaumicinsurgence/pull/1\n* updating readme by @Alastors in https://github.com/GTNewHorizons/thaumicinsurgence/pull/3\n* I forgot to add in a line giving credit to the Arcana team. by @Alastors in https://github.com/GTNewHorizons/thaumicinsurgence/pull/4\n\n## New Contributors\n* @Alastors made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/1\n\n**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/commits/0.0.1",
@@ -12772,6 +13001,14 @@
           "filename": "thaumicinsurgence-1.7.10-0.0.1.jar",
           "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76102286",
           "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.1/thaumicinsurgence-1.7.10-0.0.1.jar"
+        },
+        {
+          "version_tag": "0.0.5",
+          "changelog": "**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.0.0.3...0.0.5",
+          "tagged_at": "2022-09-03T16:47:35+00:00",
+          "filename": "thaumicinsurgence-1.7.10-0.0.5.jar",
+          "download_url": "https://api.github.com/repos/GTNewHorizons/thaumicinsurgence/releases/assets/76771674",
+          "browser_download_url": "https://github.com/GTNewHorizons/thaumicinsurgence/releases/download/0.0.5/thaumicinsurgence-1.7.10-0.0.5.jar"
         }
       ],
       "license": "GNU General Public License v3.0",

--- a/src/gtnh/cli/remove_version.py
+++ b/src/gtnh/cli/remove_version.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import asyncclick as click
+import httpx
+from colorama import init
+from structlog import get_logger
+
+from gtnh.modpack_manager import GTNHModpackManager
+
+log = get_logger(__name__)
+
+init(autoreset=True)
+
+
+class NoReleasesException(Exception):
+    pass
+
+
+@click.argument("version_tag", type=click.types.STRING)
+@click.argument("mod_name", type=click.types.STRING)
+@click.command()
+async def remove_version(mod_name: str, version_tag: str) -> None:
+    async with httpx.AsyncClient(http2=True) as client:
+        log.info(f"Attemting to remove {version_tag} from {mod_name}")
+
+        m = GTNHModpackManager(client)
+
+        mod = m.assets.get_github_mod(mod_name)
+        if not mod:
+            log.error(f"Mod not found {mod_name}")
+            return
+
+        version_reset = mod.remove_version_tag(version_tag) or mod.reset_latest()
+
+        if not version_reset:
+            log.warn(f"Version tag {version_tag} not found")
+        else:
+            log.info(f"Version tag {version_tag} removed, latest version is: {mod.latest_version}")
+            m.save_assets()
+
+
+if __name__ == "__main__":
+    remove_version()

--- a/src/gtnh/cli/update_check.py
+++ b/src/gtnh/cli/update_check.py
@@ -15,12 +15,7 @@ class NoReleasesException(Exception):
     pass
 
 
-@click.option(
-    "--mods",
-    is_flag=False,
-    metavar="<mods>",
-    type=click.types.STRING,
-)
+@click.option("--mods", is_flag=False, metavar="<mods>", type=click.types.STRING)
 @click.command()
 async def update_check(mods: str | None = None) -> None:
     async with httpx.AsyncClient(http2=True) as client:


### PR DESCRIPTION
* function to remove a version (or tag)
* functionality to complain if the latest release has a version LOWER than the current highest version we have pinned.  Sets `needs_attention` on the mod.
* CLI to remove a version tag, and reset latest version.  (Does NOT do any other updates, use update_check for that!