### PR TITLE
go back to use deploader

### DIFF
--- a/gtnh-assets.json
+++ b/gtnh-assets.json
@@ -17222,7 +17222,7 @@
           "version_tag": "1.0.3",
           "tagged_at": "2015-07-05T13:33:06",
           "filename": "BuildCraftOilTweak-1.7.10-1.0.3.jar",
-          "download_url": "https://files.vexatos.com/BuildCraftOilTweak/BuildCraftOilTweak-1.7.10-1.0.3.jar",
+          "download_url": "http://downloads.gtnewhorizons.com/Mods_for_Twitch/BuildCraftOilTweak-1.7.10-1.0.3.jar",
           "browser_download_url": "https://files.vexatos.com/?dir=BuildCraftOilTweak"
         }
       ],

--- a/src/gtnh/assembler/curse.py
+++ b/src/gtnh/assembler/curse.py
@@ -237,8 +237,7 @@ class CurseAssembler(GenericAssembler):
             if not is_valid_curse_mod(mod, version):
                 url: Optional[str]
                 if is_mod_from_hidden_repo(mod):
-                    # get_maven_url(mod, version)
-                    print(get_maven_url(mod, version))
+                    url = get_maven_url(mod, version)
                 else:
                     url = version.download_url
                 assert url

--- a/src/gtnh/assembler/curse.py
+++ b/src/gtnh/assembler/curse.py
@@ -66,6 +66,25 @@ def is_mod_from_github(mod: GTNHModInfo | ExternalModInfo) -> bool:
     return isinstance(mod, GTNHModInfo)
 
 
+def get_maven_url(mod: GTNHModInfo | ExternalModInfo, version: GTNHVersion) -> str:
+    """
+    Returns the maven url for a github mod.
+
+    :param mod: the github mod
+    :param version: the mod version
+    :return: the url from the GT:NH maven
+    """
+    if not isinstance(mod, GTNHModInfo):
+        raise TypeError("Only github mods have a maven url")
+
+    url: str = (
+        "http://jenkins.usrv.eu:8081/nexus/service/local/repositories/releases/content/com/github/"
+        f"GTNewHorizons/{mod.name}/{version.version_tag}/{mod.name}-{version.version_tag}.jar"
+    )
+
+    return url
+
+
 class CurseAssembler(GenericAssembler):
     """
     Curse assembler class. Allows for the assembling of curse archives.
@@ -215,9 +234,13 @@ class CurseAssembler(GenericAssembler):
         version: GTNHVersion
         dep_json: List[Dict[str, str]] = []
         for mod, version in mod_list:
-            if not is_valid_curse_mod(mod, version) and not is_mod_from_github(mod):
-
-                url: Optional[str] = version.download_url
+            if not is_valid_curse_mod(mod, version):
+                url: Optional[str]
+                if is_mod_from_hidden_repo(mod):
+                    # get_maven_url(mod, version)
+                    print(get_maven_url(mod, version))
+                else:
+                    url = version.download_url
                 assert url
                 mod_obj: Dict[str, str] = {"path": f"mods/{version.filename}", "url": url}
 


### PR DESCRIPTION
according to @Dream-Master, archive is not uploadable, so to work around the private mods not being accessible from github, i used our maven links instead. The mod names will be slightly different, but that concerns only 3 mods so i think it's acceptable.