### PR TITLE
add support for entire folder exclusions

### DIFF
--- a/gtnh-modpack.json
+++ b/gtnh-modpack.json
@@ -29,7 +29,7 @@
     "resourcepacks/Realistic Sky GT New Horizons.zip",
     "scripts/ZZ-Client-Only.zs",
     "servers.json",
-    "config/txloader"
+    "config/txloader/"
   ],
   "client_exclusions": [
     ".gitattributes",

--- a/gtnh-modpack.json
+++ b/gtnh-modpack.json
@@ -28,7 +28,8 @@
     "LICENSE",
     "README.md",
     "resourcepacks/Realistic Sky GT New Horizons.zip",
-    "servers.json"
+    "servers.json",
+    "config/txloader/"
   ],
   "client_exclusions": [
     ".gitignore",

--- a/gtnh-modpack.json
+++ b/gtnh-modpack.json
@@ -14,31 +14,31 @@
     "nightly"
   ],
   "server_exclusions": [
+    ".gitattributes",
+    ".gitignore",
+    "CODEOWNERS",
+    "LICENSE",
+    "README.md",
+    "mods/OpenSecurity/sounds/alarms/StargateAtlantisTheme.ogg",
     "mods/OpenSecurity/sounds/alarms/alarm-SG1.ogg",
     "mods/OpenSecurity/sounds/alarms/alarm-SG1evac.ogg",
     "mods/OpenSecurity/sounds/alarms/alarm-SGA.ogg",
     "mods/OpenSecurity/sounds/alarms/alarm-SGAoffworld.ogg",
     "mods/OpenSecurity/sounds/alarms/klaxon1.ogg",
     "mods/OpenSecurity/sounds/alarms/klaxon2.ogg",
-    "mods/OpenSecurity/sounds/alarms/StargateAtlantisTheme.ogg",
-    "scripts/ZZ-Client-Only.zs",
-    ".gitignore",
-    ".gitattributes",
-    "CODEOWNERS",
-    "LICENSE",
-    "README.md",
     "resourcepacks/Realistic Sky GT New Horizons.zip",
+    "scripts/ZZ-Client-Only.zs",
     "servers.json",
-    "config/txloader/"
+    "config/txloader"
   ],
   "client_exclusions": [
-    ".gitignore",
     ".gitattributes",
+    ".gitignore",
     "CODEOWNERS",
     "LICENSE",
     "README.md",
-    "server.properties",
     "server-icon.png",
+    "server.properties",
     "servers.json"
   ]
 }

--- a/src/gtnh/assembler/exclusions.py
+++ b/src/gtnh/assembler/exclusions.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Iterable
+from typing import Iterable, List
 
 
 class Exclusions:
@@ -21,8 +21,8 @@ class Exclusions:
 
         return False
 
-    def append(self, exclusion:str):
+    def append(self, exclusion: str) -> None:
         self.exclusions.append(exclusion)
 
-    def extend(self, exclusions: Iterable[str]):
+    def extend(self, exclusions: Iterable[str]) -> None:
         self.exclusions.extend(exclusions)

--- a/src/gtnh/assembler/exclusions.py
+++ b/src/gtnh/assembler/exclusions.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from typing import List, Iterable
+
+
+class Exclusions:
+    exclusions: List[str]
+
+    def __init__(self, exclusions: List[str]) -> None:
+        self.exclusions = exclusions
+
+    def __contains__(self, item: str) -> bool:
+        obj = Path(item)
+        for exclu in self.exclusions:
+            if item == exclu:  # if the file is explicitely listed as excluded
+                return True
+            if Path(exclu) in obj.parents:  # if a file is in an excluded folder
+                return True
+
+            if exclu.endswith("*") and Path(exclu[:-1]) in obj.parents:
+                return True
+
+        return False
+
+    def append(self, exclusion:str):
+        self.exclusions.append(exclusion)
+
+    def extend(self, exclusions: Iterable[str]):
+        self.exclusions.extend(exclusions)

--- a/src/gtnh/assembler/generic_assembler.py
+++ b/src/gtnh/assembler/generic_assembler.py
@@ -7,6 +7,7 @@ from colorama import Fore
 from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
+from gtnh.assembler.exclusions import Exclusions
 from gtnh.defs import README_TEMPLATE, RELEASE_README_DIR, ModSource, Side
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
@@ -45,9 +46,9 @@ class GenericAssembler:
         self.task_progress_callback: Optional[Callable[[float, str], None]] = task_progress_callback
         self.changelog_path: Optional[Path] = changelog_path
 
-        self.exclusions: Dict[str, List[str]] = {
-            Side.CLIENT: self.modpack_manager.mod_pack.client_exclusions,
-            Side.SERVER: self.modpack_manager.mod_pack.server_exclusions,
+        self.exclusions: Dict[str, Exclusions] = {
+            Side.CLIENT: Exclusions(self.modpack_manager.mod_pack.client_exclusions),
+            Side.SERVER: Exclusions(self.modpack_manager.mod_pack.server_exclusions),
         }
         self.delta_progress: float = 0.0
 

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -901,6 +901,7 @@ class GTNHModpackManager:
 
     def delete_exclusion(self, side: str, exclusion: str) -> bool:
         if side == "client":
+            self.mod_pack.client_exclusions.sort()
             if exclusion not in self.mod_pack.client_exclusions:
                 log.warn(f"{Fore.YELLOW}{exclusion} is not in {side} side exclusions{Fore.RESET}")
                 return False
@@ -911,12 +912,13 @@ class GTNHModpackManager:
                 return True
 
         if side == "server":
+            self.mod_pack.server_exclusions.sort()
             if exclusion not in self.mod_pack.server_exclusions:
                 log.warn(f"{Fore.YELLOW}{exclusion} is not in {side} side exclusions{Fore.RESET}")
                 return False
             else:
-                position = index(self.mod_pack.client_exclusions, exclusion)
-                del self.mod_pack.client_exclusions[position]
+                position = index(self.mod_pack.server_exclusions, exclusion)
+                del self.mod_pack.server_exclusions[position]
                 log.info(f"{Fore.GREEN}{exclusion} has been removed from {side} side exclusions{Fore.RESET}")
                 return True
         else:


### PR DESCRIPTION
now exclusions will work for entire folders. Those are valid exclusions:
- `/folder/to/exclude` (will generate an empty folder tho)
- `/folder/to/exclude/`
- `/folder/to/exclude/*`

normal file exclusion is inchanged.