### PR TITLE
Remove the UseShenandoahGC server flag as it doesn't work with GraalVM

### DIFF
--- a/server_assets/forge/startserver-java9.bat
+++ b/server_assets/forge/startserver-java9.bat
@@ -1,2 +1,2 @@
 rem don't forget to accept the EULA or it won't boot
-java -Xms6G -Xmx6G -XX:+UseShenandoahGC -Dfml.readTimeout=180 @java9args.txt nogui
+java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt nogui

--- a/server_assets/forge/startserver-java9.sh
+++ b/server_assets/forge/startserver-java9.sh
@@ -3,7 +3,7 @@
 # don't forget to accept the EULA or it won't boot
 while true
 do
-   java -Xms6G -Xmx6G -XX:+UseShenandoahGC -Dfml.readTimeout=180 @java9args.txt nogui
+   java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt nogui
     echo "If you want to completely stop the server process now, press Ctrl+C before the time is up!"
     echo "Rebooting in:"
     for i in 12 11 10 9 8 7 6 5 4 3 2 1


### PR DESCRIPTION
I included it originally because it is a better default for java 17+ but GraalVM still doesn't support it and it can cause a confusing crash, so it's probably better to leave gc flags to the users. The defaults also work fine with java 17/19 unlike java 8 which is suboptimal without extra tweaking.