### PR TITLE
Exclude the java 8 startup script in the java 9 server archive

### DIFF
--- a/gtnh-modpack.json
+++ b/gtnh-modpack.json
@@ -48,5 +48,9 @@
     "java9args.txt",
     "startserver-java9.bat",
     "startserver-java9.sh"
+  ],
+  "server_java9_exclusions": [
+    "startserver.bat",
+    "startserver.sh"
   ]
 }


### PR DESCRIPTION
At least a couple people on discord were confused and run the wrong script with the wrong java version