### PR TITLE
Fixes

### DIFF
--- a/src/gtnh/assembler/zip_assembler.py
+++ b/src/gtnh/assembler/zip_assembler.py
@@ -103,7 +103,7 @@ class ZipAssembler(GenericAssembler):
         self.add_changelog(archive)
 
     def get_archive_path(self, side: Side) -> Path:
-        return RELEASE_ZIP_DIR / f"GT_New_Horizons_{self.release.version}_{side}.zip"
+        return RELEASE_ZIP_DIR / f"GT_New_Horizons_{self.release.version}_{side.value}.zip"
 
     async def assemble(self, side: Side, verbose: bool = False, server_brand: ServerBrand = ServerBrand.forge) -> None:
         """

--- a/src/gtnh/gui/gui.py
+++ b/src/gtnh/gui/gui.py
@@ -383,6 +383,9 @@ class Window(ThemedTk, Tk):
 
             await release_assembler.assemble(Side.CLIENT, verbose=True)
 
+            await self.assemble_release(Side.CLIENT_JAVA9, Archive.MMC)
+            await self.assemble_release(Side.SERVER_JAVA9, Archive.ZIP)
+
             # todo: redo the bar resets less hacky: they are update_all spread update_all over the place and it's inconsistent
             if release_assembler.current_task_reset_callback is not None:
                 release_assembler.current_task_reset_callback()

--- a/src/gtnh/gui/modpack/release_list.py
+++ b/src/gtnh/gui/modpack/release_list.py
@@ -165,7 +165,7 @@ class ReleaseList(LabelFrame, TtkLabelFrame):  # type: ignore
             self.rowconfigure(i, weight=1, pad=self.xpadding)
 
         self.listbox.grid(row=x, column=y, columnspan=2, sticky=Position.ALL)
-        self.loaded_version.grid(row=x + 1, column=y)
+        self.loaded_version.grid(row=x + 1, column=y, columnspan=2)
         self.btn_load.grid(row=x + 2, column=y)
         self.btn_del.grid(row=x + 2, column=y + 1)
         self.modpack.grid(row=x + 3, column=y)


### PR DESCRIPTION
- fix java 9 releases not being processed when pressing the "generate all releases" button
- fix wrong enum usage in zip archive path
- fix the release name not properly being displayed