### PR TITLE
Give better names to the java 9 archives

### DIFF
--- a/src/gtnh/assembler/multi_poly.py
+++ b/src/gtnh/assembler/multi_poly.py
@@ -5,7 +5,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.assembler.generic_assembler import GenericAssembler
-from gtnh.defs import MMC_PACK_INSTANCE, MMC_PACK_JSON, RELEASE_MMC_DIR, Side
+from gtnh.defs import JAVA_9_ARCHIVE_SUFFIX, MMC_PACK_INSTANCE, MMC_PACK_JSON, RELEASE_MMC_DIR, Side
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
@@ -100,10 +100,10 @@ class MMCAssembler(GenericAssembler):
         self.add_changelog(archive, arcname=self.mmc_modpack_files / self.changelog_path.name)
 
     def get_archive_path(self, side: Side) -> Path:
-        j9suffix = ""
+        java_suffix = "_(MultiMC)"
         if side.is_java9():
-            j9suffix = "_Java9"
-        return RELEASE_MMC_DIR / f"GT_New_Horizons_{self.release.version}_(MMC){j9suffix}.zip"
+            java_suffix = "_(PrismLauncher)_" + JAVA_9_ARCHIVE_SUFFIX
+        return RELEASE_MMC_DIR / f"GT_New_Horizons_{self.release.version}{java_suffix}.zip"
 
     async def assemble(self, side: Side, verbose: bool = False) -> None:
         if side not in {Side.CLIENT, Side.CLIENT_JAVA9}:

--- a/src/gtnh/assembler/multi_poly.py
+++ b/src/gtnh/assembler/multi_poly.py
@@ -100,10 +100,10 @@ class MMCAssembler(GenericAssembler):
         self.add_changelog(archive, arcname=self.mmc_modpack_files / self.changelog_path.name)
 
     def get_archive_path(self, side: Side) -> Path:
-        java_suffix = "_(MultiMC)"
+        suffix = "_(MultiMC)"
         if side.is_java9():
-            java_suffix = "_(PrismLauncher)_" + JAVA_9_ARCHIVE_SUFFIX
-        return RELEASE_MMC_DIR / f"GT_New_Horizons_{self.release.version}{java_suffix}.zip"
+            suffix = f"_(PrismLauncher)_{JAVA_9_ARCHIVE_SUFFIX}"
+        return RELEASE_MMC_DIR / f"GT_New_Horizons_{self.release.version}{suffix}.zip"
 
     async def assemble(self, side: Side, verbose: bool = False) -> None:
         if side not in {Side.CLIENT, Side.CLIENT_JAVA9}:

--- a/src/gtnh/assembler/zip_assembler.py
+++ b/src/gtnh/assembler/zip_assembler.py
@@ -103,7 +103,7 @@ class ZipAssembler(GenericAssembler):
         self.add_changelog(archive)
 
     def get_archive_path(self, side: Side) -> Path:
-        return RELEASE_ZIP_DIR / f"GT_New_Horizons_{self.release.version}_{side.value}.zip"
+        return RELEASE_ZIP_DIR / f"GT_New_Horizons_{self.release.version}_{side.archive_name()}.zip"
 
     async def assemble(self, side: Side, verbose: bool = False, server_brand: ServerBrand = ServerBrand.forge) -> None:
         """

--- a/src/gtnh/defs.py
+++ b/src/gtnh/defs.py
@@ -91,6 +91,9 @@ notes=
 """
 
 
+JAVA_9_ARCHIVE_SUFFIX = "Java_17-19"
+
+
 class Side(str, Enum):
     SERVER = "SERVER"
     CLIENT = "CLIENT"
@@ -127,6 +130,14 @@ class Side(str, Enum):
 
     def is_client(self) -> bool:
         return self in {Side.CLIENT, Side.CLIENT_JAVA9}
+
+    def archive_name(self) -> str:
+        if self == Side.CLIENT_JAVA9:
+            return f"Client_{JAVA_9_ARCHIVE_SUFFIX}"
+        elif self == Side.SERVER_JAVA9:
+            return f"Server_{JAVA_9_ARCHIVE_SUFFIX}"
+        else:
+            return self.value.capitalize()
 
 
 class VersionableType(str, Enum):


### PR DESCRIPTION
Rename the java 9+ archives to:
 - `GT_New_Horizons_2.3.0-RC-3_(PrismLauncher)_Java_17-19.zip`
 - `GT_New_Horizons_2.3.0-RC-3_Server_Java_17-19.zip`

Also change CLIENT, SERVER to Client, Server.