### PR TITLE
Fix mod list order and make mod type split clear in nightly summaries

### DIFF
--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -98,10 +98,19 @@ jobs:
         run: |
           echo "# GTNH Nightly build ${{ steps.date.outputs.today }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "## Github mods" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Mod | Version | Side |" >> "$GITHUB_STEP_SUMMARY"
           echo "| --- | ------- | ---- |" >> "$GITHUB_STEP_SUMMARY"
-          jq -r '.github_mods | keys[] as $k | ["", $k, .[$k].version, .[$k].side, ""] | join(" | ") | ltrimstr(" ")' releases/manifests/nightly.json >> "$GITHUB_STEP_SUMMARY"
-          jq -r '.external_mods | keys[] as $k | ["", $k, .[$k].version, .[$k].side, ""] | join(" | ") | ltrimstr(" ")' releases/manifests/nightly.json >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.github_mods | keys[] as $k | ["", $k, .[$k].version, .[$k].side, ""] | join(" | ") | ltrimstr(" ")' releases/manifests/nightly.json | sort >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "## External mods" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Mod | Version | Side |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ------- | ---- |" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.external_mods | keys[] as $k | ["", $k, .[$k].version, .[$k].side, ""] | join(" | ") | ltrimstr(" ")' releases/manifests/nightly.json | sort >> "$GITHUB_STEP_SUMMARY"
 
       - name: Relocate built zips
         shell: bash


### PR DESCRIPTION
- Splits the mod list into two separate tables for github&external mods
- Sorts the tables alphabetically instead of relying on the json ordering that sorted A-Z before a-z