### PR TITLE
In-place pack mods updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 updated_mods.json
 releases/**/*.zip
 releases/curse/
+.inplace_mod_exclusions

--- a/releases/changelogs/changelog from 2.5.0 to nightly.md
+++ b/releases/changelogs/changelog from 2.5.0 to nightly.md
@@ -1,15 +1,34 @@
-# Updated AE2FluidCraft-Rework (1.1.73-gtnh@Side.BOTH --> 1.1.74-gtnh@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.1.71-gtnh...1.1.74-gtnh
+# New Mods:
+> * ServerUtilities
+# Updated AE2FluidCraft-Rework (1.1.73-gtnh@Side.BOTH --> 1.2.9-gtnh-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.1.71-gtnh...1.2.9-gtnh-pre
 >## What's Changed
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/188 (1.2.9-gtnh-pre)
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/188 (1.2.8-gtnh)
+> * Level Maintainer fulfills requests in a round robin pattern. by @AbdielKavash in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/187 (1.2.7-gtnh)
+> * Add null check to level terminal middle click by @Caedis in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/186 (1.2.6-gtnh)
+> * Fix ability to configure `TileLevelMaintainer` using OC by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/184 (1.2.5-gtnh)
+> * Correct split client-server code by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/183 (1.2.4-gtnh)
+> * Implement Interface Locking for Dual Interfaces by @TechnicianLP in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/182 (1.2.3-gtnh)
+> * Implement Interface Locking for Dual Interfaces by @TechnicianLP in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/182 (1.2.3-gtnh)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` (1.2.2-gtnh)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` (1.2.2-gtnh)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/179 (1.2.1-gtnh)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/179 (1.2.1-gtnh)
+> * Correct `stackSize` z order by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/178 (1.2.0-gtnh)
+> * Correct `stackSize` z order by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/178 (1.2.0-gtnh)
 > * Optimize CPacketFluidUpdate by @TechnicianLP in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/177 (1.1.73-gtnh)
 >
 >## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/187 (1.2.7-gtnh)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/186 (1.2.6-gtnh)
 > * @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/177 (1.1.73-gtnh)
 >
 
-# Updated AdventureBackpack2 (1.0.16-GTNH@Side.BOTH --> 1.0.17-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.0.14-GTNH...1.0.17-GTNH
+# Updated AdventureBackpack2 (1.0.16-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.0.14-GTNH...1.1.0-GTNH
 >## What's Changed
+> * Add name for rideableSpider by @bombcar in https://github.com/GTNewHorizons/AdventureBackpack2/pull/17 (1.1.0-GTNH)
 > * Show the wearing backpack in TConstruct tab by @ghostflyby in https://github.com/GTNewHorizons/AdventureBackpack2/pull/16 (1.0.16-GTNH)
 >
 >## New Contributors
@@ -20,199 +39,828 @@
 **Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.1.2...1.1.4
 >## What's Changed
 > * Force Fancy Graphics when rendering a Trophy displaying an Item by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/5 (1.1.4)
+> * Force Fancy Graphics when rendering a Trophy displaying an Item by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/5 (1.1.4)
 > * Use custom Material for Trophy Block by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/4 (1.1.3)
 >
 >## New Contributors
 > * @glowredman made their first contribution in https://github.com/GTNewHorizons/Amazing-Trophies/pull/4 (1.1.3)
 >
 
-# Updated Applied-Energistics-2-Unofficial (rv3-beta-291-GTNH@Side.BOTH --> rv3-beta-292-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-290-GTNH...rv3-beta-292-GTNH
+# Updated Applied-Energistics-2-Unofficial (rv3-beta-291-GTNH@Side.BOTH --> rv3-beta-307-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-290-GTNH...rv3-beta-307-GTNH
 >## What's Changed
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/449 (rv3-beta-307-GTNH)
+> * ME IO Port Tweaks by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/448 (rv3-beta-306-GTNH)
+> * add tooltips for block container cell,update zh_CN by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/447 (rv3-beta-305-GTNH)
+> * Backport Interface Locking Mode by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * Do not form `CraftingCPU` if storage overflow detected by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/443 (rv3-beta-304-GTNH)
+> * Add Priority Card by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/446 (rv3-beta-304-GTNH)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/445 (rv3-beta-304-GTNH)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/441 (rv3-beta-303-GTNH)
+> * Correct stackSize z order by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/440 (rv3-beta-302-GTNH)
+> * Respect interface settings by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/439 (rv3-beta-301-GTNH)
+> * Fix crash when opening disconnected interface terminal by @Caedis in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
+> * Backport Interface Locking Mode by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * Do not form `CraftingCPU` if storage overflow detected by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/443 (rv3-beta-304-GTNH)
+> * Add Priority Card by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/446 (rv3-beta-304-GTNH)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/445 (rv3-beta-304-GTNH)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/441 (rv3-beta-303-GTNH)
+> * Correct stackSize z order by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/440 (rv3-beta-302-GTNH)
+> * Respect interface settings by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/439 (rv3-beta-301-GTNH)
+> * Fix crash when opening disconnected interface terminal by @Caedis in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
 > * Support stack sizes larger than 127 when transferring from NEI by @tth05 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/435 (rv3-beta-291-GTNH)
 >
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/448 (rv3-beta-306-GTNH)
+> * @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
+> * @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
+>
 
-# Updated BetterQuesting (3.4.6-GTNH@Side.BOTH --> 3.4.7-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.4.5-GTNH...3.4.7-GTNH
+# Updated Avaritia (1.46@Side.BOTH --> 1.47@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.45...1.47
 >## What's Changed
+> * Fix Universium rendering with OptiFine by @UltraHex in https://github.com/GTNewHorizons/Avaritia/pull/37 (1.47)
+> * Workaround for world time error in shader by @catcatcatcaty in https://github.com/GTNewHorizons/Avaritia/pull/36 (1.46)
+>
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/37 (1.47)
+> * @catcatcatcaty made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/36 (1.46)
+>
+
+# Updated BetterQuesting (3.4.6-GTNH@Side.BOTH --> 3.5.2-GTNH-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.4.5-GTNH...3.5.2-GTNH-pre
+>## What's Changed
+> * fix inserting into empty tag list not setting tag type by @Glease in https://github.com/GTNewHorizons/BetterQuesting/pull/125 (3.5.1-GTNH)
+> * Fix quest notif hud rendering issue by @Alexdoru in https://github.com/GTNewHorizons/BetterQuesting/pull/124 (3.5.0-GTNH)
 > * Fix quest GUI persisting invalid screen to back by @miozune in https://github.com/GTNewHorizons/BetterQuesting/pull/123 (3.4.6-GTNH)
 >
 
-# Updated BlockRenderer6343 (1.0.5@Side.BOTH --> 1.0.6@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.0.4...1.0.6
-
-# Updated EnderCore (0.2.18@Side.BOTH --> 0.2.19@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/EnderCore/compare/0.2.17...0.2.19
+# Updated BlockRenderer6343 (1.0.5@Side.BOTH --> 1.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.0.4...1.1.1
 >## What's Changed
+> * Fix crash when switching tier after projecting a multiblock by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/9 (1.1.1)
+> * Fix preview not showing if multi isn't ISurvivalConstructable by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+> * Fix preview not showing if multi isn't ISurvivalConstructable by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+>
+
+# Updated BloodArsenal (1.2.11@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.2.10...1.3.0
+>## What's Changed
+> * Buff daggers and replace wildcard imports by @Quetz4l in https://github.com/GTNewHorizons/BloodArsenal/pull/20 (1.3.0)
+> * Upload ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/BloodArsenal/pull/21 (1.3.0)
+> * Spotless apply for branch fix-nei-tooltip-crash for #18 by @github-actions in https://github.com/GTNewHorizons/BloodArsenal/pull/19 (1.2.11)
+> * Fix Ritual Stone NEI tooltip crash by @wlhlm in https://github.com/GTNewHorizons/BloodArsenal/pull/18 (1.2.11)
+>
+>## New Contributors
+> * @Quetz4l made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/20 (1.3.0)
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/21 (1.3.0)
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/19 (1.2.11)
+> * @wlhlm made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/18 (1.2.11)
+>
+
+# Updated Botanic-horizons (1.0.19-GTNH@Side.BOTH --> 1.1.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.0.18-GTNH...1.1.1-GTNH
+>## What's Changed
+> * Fix minor code quality issues in #27 by @combusterf in https://github.com/GTNewHorizons/Botanic-horizons/pull/28 (1.1.1-GTNH)
+> * fix basalt chiselgroup name by @chochem in https://github.com/GTNewHorizons/Botanic-horizons/pull/27 (1.1.0-GTNH)
+>
+
+# Updated Chisel (2.12.3-GTNH@Side.BOTH --> 2.13.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.12.2-GTNH...2.13.2-GTNH
+>## What's Changed
+> * Another Obsidian harvestlevel fix by @chochem in https://github.com/GTNewHorizons/Chisel/pull/41 (2.13.2-GTNH)
+> * Add vanilla mining levels by @Caedis in https://github.com/GTNewHorizons/Chisel/pull/39 (2.13.1-GTNH)
+> * fix mining levels with iguana by @chochem in https://github.com/GTNewHorizons/Chisel/pull/40 (2.13.1-GTNH)
+> * Don't relocate CTMLib by @makamys in https://github.com/GTNewHorizons/Chisel/pull/37 (2.13.0-GTNH)
+> * Make Forge Multipart dependency optional by @makamys in https://github.com/GTNewHorizons/Chisel/pull/38 (2.13.0-GTNH)
+> * Fix more memory leaks by @Pelotrio in https://github.com/GTNewHorizons/Chisel/pull/36 (2.12.3-GTNH)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/39 (2.13.1-GTNH)
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/37 (2.13.0-GTNH)
+>
+
+# Updated CodeChickenCore (1.1.13@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenCore/compare/1.1.11...1.2.0
+>## What's Changed
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenCore/pull/12 (1.2.0)
+> * update BS and spotlessApply by @bombcar in https://github.com/GTNewHorizons/CodeChickenCore/pull/11 (1.1.13)
+>
+
+# Updated CodeChickenLib (1.1.10@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenLib/compare/1.1.9...1.2.0
+>## What's Changed
+> * Angelica Support - Static -> Instanced by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenLib/pull/14 (1.2.0)
+> * Fix incomplete patch for item id packet by @miozune in https://github.com/GTNewHorizons/CodeChickenLib/pull/13 (1.1.10)
+>
+
+# Updated CookingForBlockheads (1.2.16-GTNH@Side.BOTH --> 1.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.2.15-GTNH...1.3.0-GTNH
+>## What's Changed
+> * update buildscript and dependencies by @bombcar in https://github.com/GTNewHorizons/CookingForBlockheads/pull/41 (1.3.0-GTNH)
+> * Fix: TileEntity migration from old savefiles by @eigenraven in https://github.com/GTNewHorizons/CookingForBlockheads/pull/40 (1.2.16-GTNH)
+>
+>## New Contributors
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/CookingForBlockheads/pull/40 (1.2.16-GTNH)
+>
+
+# Updated Crops-plus-plus (1.5.12@Side.BOTH --> 1.6.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.5.11...1.6.1
+>## What's Changed
+> * Fix Potions by @glowredman in https://github.com/GTNewHorizons/Crops-plus-plus/pull/63 (1.6.1)
+> * Fix incorrect cactus drop. by @C0bra5 in https://github.com/GTNewHorizons/Crops-plus-plus/pull/64 (1.6.0)
+> * add back Space Flower uum recipe by @Dream-Master in https://github.com/GTNewHorizons/Crops-plus-plus/pull/62 (1.5.12)
+>
+
+# Updated Draconic-Evolution (1.2.1-GTNH@Side.BOTH --> 1.2.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.2.0-GTNH...1.2.2-GTNH
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Draconic-Evolution/pull/43 (1.2.2-GTNH)
+> * Fix memory leak by @Pelotrio in https://github.com/GTNewHorizons/Draconic-Evolution/pull/42 (1.2.1-GTNH)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/43 (1.2.2-GTNH)
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/42 (1.2.1-GTNH)
+>
+
+# Updated EnderCore (0.2.18@Side.BOTH --> 0.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderCore/compare/0.2.17...0.3.0
+>## What's Changed
+> * Fix for limited item filter by @Tu0rp in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
+> * Fix for limited item filter by @Tu0rp in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
 > * Get Empty container with drainFluidContainer by @ghostflyby in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.19)
 > * Get Empty container with drainFluidContainer by @ghostflyby in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.18)
 >
 >## New Contributors
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
 > * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.19)
 > * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.18)
 >
 
-# Updated EnderIO (2.5.8@Side.BOTH --> 2.5.9@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.5.6...2.5.9
+# Updated EnderIO (2.5.8@Side.BOTH --> 2.6.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.5.6...2.6.2
 >## What's Changed
+> * exchange existing Item filter icon from newer Ender io version by @Dream-Master in https://github.com/GTNewHorizons/EnderIO/pull/145 (2.6.2)
+> * Staff Of Traveling Keybind Feature by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/144 (2.6.1)
+> * Limited Item Filter by @Tu0rp in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * Add Config to allow servers to re-enable support for client-side 'hacks' like Staff Of Traveling Keybind mod. by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
+> * Limited Item Filter by @Tu0rp in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * Add Config to allow servers to re-enable support for client-side 'hacks' like Staff Of Traveling Keybind mod. by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
 > * Fix NBT Match where tag is empty but exists by @spacebuilder2020 in https://github.com/GTNewHorizons/EnderIO/pull/138 (2.5.8)
 > * Fix an edge case pertaining to freshly crafted tanks by @bearsdotzone in https://github.com/GTNewHorizons/EnderIO/pull/141 (2.5.8)
 >
 >## New Contributors
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * @TheUnderTaker11 made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * @TheUnderTaker11 made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
 > * @spacebuilder2020 made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/138 (2.5.8)
 > * @bearsdotzone made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/141 (2.5.8)
 >
 
-# Updated ForestryMC (4.7.0@Side.BOTH --> 4.7.1@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.6.14...4.7.1
+# Updated ForestryMC (4.7.0@Side.BOTH --> 4.8.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.6.14...4.8.1
 >## What's Changed
+> * Remove Version Checker by @glowredman in https://github.com/GTNewHorizons/ForestryMC/pull/60 (4.8.1)
+> * Add name for butterflyGE by @bombcar in https://github.com/GTNewHorizons/ForestryMC/pull/59 (4.8.0)
+> * Add name for butterflyGE by @bombcar in https://github.com/GTNewHorizons/ForestryMC/pull/59 (4.8.0)
 > * Mails are now checked for prohibited items by @DrParadox7 in https://github.com/GTNewHorizons/ForestryMC/pull/58 (4.7.0)
 >
 >## New Contributors
 > * @DrParadox7 made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/58 (4.7.0)
 >
 
-# Updated GT5-Unofficial (5.09.44.107@Side.BOTH --> 5.09.44.110@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.44.106...5.09.44.110
+# Updated ForgeMultipart (1.4.1@Side.BOTH --> 1.4.5@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.4.0...1.4.5
 >## What's Changed
-> * Remove IC2 iridium exploit by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2402 (5.09.44.107)
+> * update to support 1.2.0 CCL - needs work to be more performant by @bombcar in https://github.com/GTNewHorizons/ForgeMultipart/pull/21 (1.4.5)
+> * Fix ButtonPart.java crashes, tweaks to allow mods to hook it by @Roadhog360 in https://github.com/GTNewHorizons/ForgeMultipart/pull/20 (1.4.3)
+> * Potential Fix to some FMP stuff relating to Redstone parts not connecting to bottoms of machines. by @Cardinalstars in https://github.com/GTNewHorizons/ForgeMultipart/pull/18 (1.4.1)
+>
+>## New Contributors
+> * @Roadhog360 made their first contribution in https://github.com/GTNewHorizons/ForgeMultipart/pull/20 (1.4.3)
 >
 
-# Updated GTNH-Intergalactic (1.2.8@Side.BOTH --> 1.2.9@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Intergalactic/compare/1.2.7...1.2.9
+# Updated GT5-Unofficial (5.09.44.107@Side.BOTH --> 5.09.45.23@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.44.106...5.09.45.23
 >## What's Changed
+> * Merge MuTEMaster into Master by @BlueWeabo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2431 (5.09.45.23)
+> * Update ParallelHelper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2427 (5.09.45.22)
+> * fix GT oredict log by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2436 (5.09.45.19)
+> * Revert forge hammer recipe for plastic/rubber by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2437 (5.09.45.19)
+> * Let gt ignore more oredicts by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2438 (5.09.45.19)
+> * Improve shader compatibility for tool overlay by @UltraHex in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2425 (5.09.45.15)
+> * Cleanup deprecation by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2416 (5.09.45.14)
+> * Add connect/block to line of fluid pipes by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2407 (5.09.45.13)
+> * Add default impl to getToolTypeName and add a null check by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2430 (5.09.45.12)
+> * Fix muffler hatch numbers by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2433 (5.09.45.12)
+> * Fix RecipeMapBackend not indexing Alternate ItemStacks by @TechnicianLP in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2434 (5.09.45.12)
+> * Prevent loading hook on server by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2428 (5.09.45.11)
+> * Add modes to tools by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2423 (5.09.45.10)
+> * Change to the overclock logic of Fusion Reactor by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2422 (5.09.45.09)
+> * Restore the ability to use multiple ME hatches for one machine by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2426 (5.09.45.08)
+> * Rework the UI of singleblock pumps. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2420 (5.09.45.07)
+> * Allow a soldering iron to use soldering material from an IC2 Tool Box. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2421 (5.09.45.06)
+> * Fix z ordering for stack size in `Stocking Input` by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2419 (5.09.45.05)
+> * Fix CRIB adding null item inputs by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2415 (5.09.45.04)
+> * update deps by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2414 (5.09.45.04)
+> * Allow Oil Cracker to use an Input Bus for programmed circuit automation. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2413 (5.09.45.03)
+> * fix dep by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2405 (5.09.45.02)
+> * Fix logic with old OC calculation code by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2408 (5.09.45.02)
+> * Don't rotate block if player is sneaking by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2409 (5.09.45.02)
+> * Fix basic machine OC not using amperage by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2410 (5.09.45.02)
+> * update deps by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2411 (5.09.45.02)
+> * Fix: Show CRIB always in interface terminal by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2404 (5.09.45.01)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2403 (5.09.45.00)
+> * make quantum tanks not slow you down for later game players by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2393 (5.09.45.00)
+> * more detailed progress info in waila tooltip for basic machines by @iamblackornot in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2401 (5.09.45.00)
+> * Remove IC2 iridium exploit by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2402 (5.09.44.107)
+>
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2425 (5.09.45.15)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2413 (5.09.45.03)
+> * @Laiff made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2404 (5.09.45.01)
+>
+
+# Updated GTNH-Intergalactic (1.2.8@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Intergalactic/compare/1.2.7...1.3.0
+>## What's Changed
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTNH-Intergalactic/pull/56 (1.3.0)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTNH-Intergalactic/pull/56 (1.2.9)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTNH-Intergalactic/pull/56 (1.3.0)
 > * Fix space mining module not allowing insertion of plasma by @miozune in https://github.com/GTNewHorizons/GTNH-Intergalactic/pull/55 (1.2.8)
 >
 
-# Updated GTNH-Lanthanides (0.11.8@Side.BOTH --> 0.11.9@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Lanthanides/compare/0.11.7...0.11.9
-
-# Updated GTplusplus (1.10.53@Side.BOTH --> 1.10.54@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/GTplusplus/compare/1.10.52...1.10.54
+# Updated GTNH-Lanthanides (0.11.8@Side.BOTH --> 0.12.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Lanthanides/compare/0.11.7...0.12.3
 >## What's Changed
+> * add Digester and DissolutionTank survival construct method by @Nxer in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/81 (0.12.3)
+> * fix simple washer Pure Dust of Cerium and Samarium issue by @Nxer in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/80 (0.12.2)
+> * EuO chem balance fix by @chochem in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/79 (0.12.1)
+> * Remove now unneeded IMC handler by @miozune in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/78 (0.12.0)
+> * EuO chem balance fix by @chochem in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/79 (0.12.1)
+> * Remove now unneeded IMC handler by @miozune in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/78 (0.12.0)
+>
+
+# Updated GTplusplus (1.10.53@Side.BOTH --> 1.11.10@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTplusplus/compare/1.10.52...1.11.10
+>## What's Changed
+> * Fix Soldering Iron unable to set redstone output strength. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/819 (1.11.10)
+> * Thermal Boiler rework by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/815 (1.11.9)
+> * Fix chisel busses by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/817 (1.11.4)
+> * Add centrifuge recipes for dual and quad depleted fuel rods. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/816 (1.11.3)
+> * Allow emptying of fluid tanks by placing them anywhere in the crafting grid. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/814 (1.11.2)
+> * fix dep problems by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/811 (1.11.1)
+> * Fix superbus UHV recipes and localization by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/812 (1.11.1)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTplusplus/pull/809 (1.11.0)
+> * Fix asymmetry in the qft multiblock by @Pelotrio in https://github.com/GTNewHorizons/GTplusplus/pull/802 (1.11.0)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTplusplus/pull/809 (1.10.54)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTplusplus/pull/809 (1.11.0)
+> * Fix asymmetry in the qft multiblock by @Pelotrio in https://github.com/GTNewHorizons/GTplusplus/pull/802 (1.11.0)
 > * fix IOOBE when there is no fuel fluids by @boubou19 in https://github.com/GTNewHorizons/GTplusplus/pull/808 (1.10.53)
 >
-
-# Updated Galacticraft (3.0.74-GTNH@Side.BOTH --> 3.0.75-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.0.73-GTNH...3.0.75-GTNH
->## What's Changed
-> * Use llamalad7's MixinExtras by @glowredman in https://github.com/GTNewHorizons/Galacticraft/pull/80 (3.0.74-GTNH)
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GTplusplus/pull/814 (1.11.2)
 >
 
-# Updated Galaxy-Space-GTNH (1.2.14-GTNH@Side.BOTH --> 1.2.15-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.2.13-GTNH...1.2.15-GTNH
+# Updated Gadomancy (1.2.0@Side.BOTH --> 1.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.1.3...1.3.1
 >## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Gadomancy/pull/28 (1.3.1)
+> * Fixed dupe bug with Essentia condenser by @OneEyeMaker in https://github.com/GTNewHorizons/Gadomancy/pull/27 (1.3.0)
+> * Eldrich recipes by @EnderProyects in https://github.com/GTNewHorizons/Gadomancy/pull/25 (1.2.0)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/28 (1.3.1)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/27 (1.3.0)
+> * @EnderProyects made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/25 (1.2.0)
+>
+
+# Updated Galacticraft (3.0.74-GTNH@Side.BOTH --> 3.1.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.0.73-GTNH...3.1.1-GTNH
+>## What's Changed
+> * Update GC lang files to more modern usage for MobInfo by @bombcar in https://github.com/GTNewHorizons/Galacticraft/pull/83 (3.1.1-GTNH)
+> * Fix backwards-compatibility with other Galacticraft addons (e. g. ExtraPlanets) by @PT400C in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+> * Update GC lang files to more modern usage for MobInfo by @bombcar in https://github.com/GTNewHorizons/Galacticraft/pull/83 (3.1.1-GTNH)
+> * Fix backwards-compatibility with other Galacticraft addons (e. g. ExtraPlanets) by @PT400C in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+> * Use llamalad7's MixinExtras by @glowredman in https://github.com/GTNewHorizons/Galacticraft/pull/80 (3.0.74-GTNH)
+>
+>## New Contributors
+> * @PT400C made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+> * @PT400C made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+>
+
+# Updated Galaxy-Space-GTNH (1.2.14-GTNH@Side.BOTH --> 1.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.2.13-GTNH...1.3.0-GTNH
+>## What's Changed
+> * fix localization to match changes to GalacticCore by @bombcar in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/105 (1.3.0-GTNH)
+> * fix localization to match changes to GalacticCore by @bombcar in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/105 (1.3.0-GTNH)
 > * Cleanup dependencies by @miozune in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/104 (1.2.14-GTNH)
 >
 
-# Updated GoodGenerator (0.7.16@Side.BOTH --> 0.7.17@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/GoodGenerator/compare/0.7.15...0.7.17
+# Updated GoodGenerator (0.7.16@Side.BOTH --> 0.8.3-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GoodGenerator/compare/0.7.15...0.8.3-pre
 >## What's Changed
+> * fix simple washer recipe issue about Nq Process by @Nxer in https://github.com/GTNewHorizons/GoodGenerator/pull/229 (0.8.2)
+> * Cleanup isValidMetaTileEntity again by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/227 (0.8.0)
+> * Batch mode for compact fusion MKIV-V by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/223 (0.8.0)
+> * Cleanup isValidMetaTileEntity again by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/227 (0.7.17)
+> * Cleanup isValidMetaTileEntity again by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/227 (0.8.0)
+> * Batch mode for compact fusion MKIV-V by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/223 (0.8.0)
 > * Fix crash with Nq Gen if coolant has just been depleted by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/226 (0.7.16)
 >
+>## New Contributors
+> * @Nxer made their first contribution in https://github.com/GTNewHorizons/GoodGenerator/pull/229 (0.8.2)
+>
 
-# Updated Hodgepodge (2.3.40@Side.BOTH --> 2.3.41@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.3.39...2.3.41
+# Updated Hodgepodge (2.3.40@Side.BOTH --> 2.4.6@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.3.39...2.4.6
 >## What's Changed
+> * Adjustable network nbt and packet size limits by @eigenraven in https://github.com/GTNewHorizons/Hodgepodge/pull/300 (2.4.6)
+> * Fix hopper collision by @UltraHex in https://github.com/GTNewHorizons/Hodgepodge/pull/299 (2.4.5)
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/298 (2.4.4)
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/297 (2.4.3)
+> * Completely hide realms button and make mods button wider to fill the gap by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/296 (2.4.2)
+> * Add Disable Realms Button Mixin by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/294 (2.4.1)
+> * Add Disable Realms Button Mixin by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/294 (2.4.1)
+> * Player Skin Fetching Fix part 2 by @kumquat-ir in https://github.com/GTNewHorizons/Hodgepodge/pull/293 (2.4.0)
+> * Player Skin Fetching Fix part 2 by @kumquat-ir in https://github.com/GTNewHorizons/Hodgepodge/pull/293 (2.4.0)
 > * Switch voxelmap to false by default due to no modid and it being a late mixin... by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/292 (2.3.40)
 >
-
-# Updated KubaTech (0.13.11@Side.BOTH --> 0.13.12@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/KubaTech/compare/0.13.10...0.13.12
->## What's Changed
-> * EEC: Fix infernal spawns not happening with 4 EV hatches by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/110 (0.13.11)
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/299 (2.4.5)
 >
 
-# Updated Mobs-Info (0.1.12-GTNH@Side.BOTH --> 0.1.13-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.1.11-GTNH...0.1.13-GTNH
-
-# Updated NewHorizonsCoreMod (2.2.53@Side.BOTH --> 2.2.55@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.2.52...2.2.55
+# Updated HoloInventory (2.3.2-GTNH@Side.BOTH --> 2.4.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.3.0-GTNH...2.4.0-GTNH
 >## What's Changed
-> * Add advanced radiation proof plate space assembler recipe by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/777 (2.2.54)
+> * Fix stack number always showing '1' when renderMultiple=false by @UltraHex in https://github.com/GTNewHorizons/HoloInventory/pull/38 (2.4.0-GTNH)
+> * Make it work with shaders by @UltraHex in https://github.com/GTNewHorizons/HoloInventory/pull/39 (2.4.0-GTNH)
+> * Move GT compat by @miozune in https://github.com/GTNewHorizons/HoloInventory/pull/37 (2.3.2-GTNH)
+>
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/38 (2.4.0-GTNH)
+>
+
+# Updated KubaTech (0.13.11@Side.BOTH --> 0.14.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/KubaTech/compare/0.13.10...0.14.2
+>## What's Changed
+> * Fix Soldering Iron unable to set redstone output strength for the EEC. by @AbdielKavash in https://github.com/GTNewHorizons/KubaTech/pull/115 (0.14.2)
+> * Allow the EIG and MApiary to use IC2 Distilled Water in place of regular water in the structure. by @AbdielKavash in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+> * Fix queen dupe bug in Mega Apiary by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/114 (0.14.1)
+> * Remove now unneeded IMC for DEFusionCrafter by @miozune in https://github.com/GTNewHorizons/KubaTech/pull/111 (0.14.0)
+> * Allow the EIG and MApiary to use IC2 Distilled Water in place of regular water in the structure. by @AbdielKavash in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+> * Fix queen dupe bug in Mega Apiary by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/114 (0.14.1)
+> * Remove now unneeded IMC for DEFusionCrafter by @miozune in https://github.com/GTNewHorizons/KubaTech/pull/111 (0.14.0)
+> * EEC: Fix infernal spawns not happening with 4 EV hatches by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/110 (0.13.11)
+>
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+>
+
+# Updated MagicBees (2.7.1-GTNH@Side.BOTH --> 2.7.3-GTNH-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.7.0-GTNH...2.7.3-GTNH-pre
+>## What's Changed
+> * fixing the ethereal shard dupe by @Alastors in https://github.com/GTNewHorizons/MagicBees/pull/33 (2.7.1-GTNH)
+>
+
+# Updated Mobs-Info (0.1.12-GTNH@Side.BOTH --> 0.2.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.1.11-GTNH...0.2.1-GTNH
+
+# Updated NewHorizonsCoreMod (2.2.53@Side.BOTH --> 2.3.9-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.2.52...2.3.9-pre
+>## What's Changed
+> * Add more basalt blocks to chisel by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/787 (2.3.9-pre)
+> * Add more basalt blocks to chisel by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/787 (2.3.8)
+> * add recipe for Limited Itemfilter by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/785 (2.3.4)
+> * Add Special Handling for the Infinity Sword by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/784 (2.3.3)
+> * Fix LCR Controller recipe in assembler by @LewisSaber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/783 (2.3.2)
+> * Fix a few broken LP recipes using gt++ items by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/782 (2.3.1)
+> * Add advanced radiation proof plate space assembler recipe by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/777 (2.3.0)
 > * Recipe Conflict + Recipe Fix by @54M44R in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/780 (2.2.53)
 >
 >## New Contributors
 > * @54M44R made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/780 (2.2.53)
 >
 
-# Updated Nuclear-Control (2.5.0@Side.BOTH --> 2.5.1@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.4.19...2.5.1
+# Updated Nuclear-Control (2.5.0@Side.BOTH --> 2.6.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.4.19...2.6.0
 >## What's Changed
+> * Angelica support by @ah-OOG-ah in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
+> * Angelica support by @ah-OOG-ah in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
 > * Replace fatal log with info by @bombcar in https://github.com/GTNewHorizons/Nuclear-Control/pull/17 (2.5.0)
 >
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
+>
 
-# Updated OpenBlocks (1.8.2-GTNH@Side.BOTH --> 1.8.3-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.8.1-GTNH...1.8.3-GTNH
+# Updated OpenBlocks (1.8.2-GTNH@Side.BOTH --> 1.9.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.8.1-GTNH...1.9.0-GTNH
 >## What's Changed
+> * Fix server crash due to trying to access translation resource by @ghostflyby in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
+> * Fix server crash due to trying to access translation resource by @ghostflyby in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
 > * Make BlockGrave use the same logic as TileEntityGrave to determine player name by @unilock in https://github.com/GTNewHorizons/OpenBlocks/pull/19 (1.8.2-GTNH)
 >
 >## New Contributors
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
 > * @unilock made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/19 (1.8.2-GTNH)
 >
 
-# Updated OpenComputers (1.9.19-GTNH@Side.BOTH --> 1.9.21-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.9.17-GTNH...1.9.21-GTNH
+# Updated OpenComputers (1.9.19-GTNH@Side.BOTH --> 1.10.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.9.17-GTNH...1.10.3-GTNH
 >## What's Changed
+> * Fix AE2 Integration by @Pelotrio in https://github.com/GTNewHorizons/OpenComputers/pull/113 (1.10.3-GTNH)
+> * Fix Coremod Version by @glowredman in https://github.com/GTNewHorizons/OpenComputers/pull/112 (1.10.1-GTNH)
+> * Bee convert should not be localized by @ghostflyby in https://github.com/GTNewHorizons/OpenComputers/pull/110 (1.10.1-GTNH)
+> * Fix unhandled side for redstone connection by @OneEyeMaker in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
+> * Fix unhandled side for redstone connection by @OneEyeMaker in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
 > * Fix sof crash by @koiNoCirculation in https://github.com/GTNewHorizons/OpenComputers/pull/109 (1.9.19-GTNH)
 >
+>## New Contributors
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/113 (1.10.3-GTNH)
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/110 (1.10.1-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
+>
 
-# Updated Opis (1.3.8-mapless@Side.BOTH --> 1.3.9-mapless@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Opis/compare/1.3.7-mapless...1.3.9-mapless
+# Updated OpenSecurity (1.0.120-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenSecurity/compare/1.0.119-GTNH...1.1.0-GTNH
 >## What's Changed
+> * Fix Version by @glowredman in https://github.com/GTNewHorizons/OpenSecurity/pull/4 (1.1.0-GTNH)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/OpenSecurity/pull/3 (1.0.120-GTNH)
+>
+
+# Updated Opis (1.3.8-mapless@Side.BOTH --> 1.4.1-mapless@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Opis/compare/1.3.7-mapless...1.4.1-mapless
+>## What's Changed
+> * Fix Tags by @glowredman in https://github.com/GTNewHorizons/Opis/pull/13 (1.4.1-mapless)
+> * Remove system.exit to make FML happy by @bombcar in https://github.com/GTNewHorizons/Opis/pull/12 (1.4.0-mapless)
+> * Remove system.exit to make FML happy by @bombcar in https://github.com/GTNewHorizons/Opis/pull/12 (1.4.0-mapless)
 > * Remove system.exit to make FML happy by @bombcar in https://github.com/GTNewHorizons/Opis/pull/12 (1.3.9-mapless)
 > * Add version token replacement for MobiusCore by @glowredman in https://github.com/GTNewHorizons/Opis/pull/10 (1.3.8-mapless)
 > * Add `@MCVersion` annotation by @glowredman in https://github.com/GTNewHorizons/Opis/pull/11 (1.3.8-mapless)
 >
 
-# Updated ProjectRed (4.8.0-GTNH@Side.BOTH --> 4.8.1-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.7.12-GTNH...4.8.1-GTNH
+# Updated ProjectRed (4.8.0-GTNH@Side.BOTH --> 4.9.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.7.12-GTNH...4.9.1-GTNH
 >## What's Changed
+> * Replace `@VERSION@` usage by @glowredman in https://github.com/GTNewHorizons/ProjectRed/pull/28 (4.9.1-GTNH)
+> * Angelica compat - don't rebind textures by @ah-OOG-ah in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
+> * Angelica compat - don't rebind textures by @ah-OOG-ah in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
 > * Update build script; apply spotless by @bombcar in https://github.com/GTNewHorizons/ProjectRed/pull/26 (4.8.0-GTNH)
 >
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
+>
 
-# Updated Random-Things (2.4.5@Side.BOTH --> 2.4.6@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.4.4...2.4.6
+# Updated Random-Things (2.4.5@Side.BOTH --> 2.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.4.4...2.5.0
 >## What's Changed
+> * Add RandomThings to allow mobsinfo to find it. by @bombcar in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
+> * Add RandomThings to allow mobsinfo to find it. by @bombcar in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
 > * Cyclic Bloodmoon by @DrParadox7 in https://github.com/GTNewHorizons/Random-Things/pull/3 (2.4.5)
 >
 >## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
 > * @DrParadox7 made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/3 (2.4.5)
 >
 
-# Updated Realistic-World-Gen (alpha-1.3.8@Side.BOTH --> alpha-1.3.9-pre@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/Realistic-World-Gen/compare/alpha-1.3.6...alpha-1.3.9-pre
+# Updated Realistic-World-Gen (alpha-1.3.8@Side.BOTH --> alpha-1.4.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Realistic-World-Gen/compare/alpha-1.3.6...alpha-1.4.0
 >## What's Changed
+> * Fix broken terrain gen past -20480 in either X or Z by @Caedis in https://github.com/GTNewHorizons/Realistic-World-Gen/pull/15 (alpha-1.4.0)
 > * use lowercase version to match GTNH config file by @Caedis in https://github.com/GTNewHorizons/Realistic-World-Gen/pull/14 (alpha-1.3.8)
 >
 
-# Updated ThaumicHorizons (1.4.1@Side.BOTH --> 1.4.2@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.4.0...1.4.2
+# New Mod - ServerUtilities (2.0.9@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/commits/2.0.9
 >## What's Changed
+> * Add synced Wiki by @glowredman in https://github.com/GTNewHorizons/ServerUtilities/pull/24 (2.0.9)
+> * Fix crash when EnderIO farming station is operating in claimed chunk by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/22 (2.0.8)
+> * Fix player attack logging crashing when attacking with empty hand by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/20 (2.0.7)
+> * fix url typo by @bombcar in https://github.com/GTNewHorizons/ServerUtilities/pull/15 (2.0.6)
+> * Add config gui to the forge mod menu by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/16 (2.0.6)
+> * Add info on how to load/unload to journeymap tooltip by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/17 (2.0.6)
+> * Add some barebones documentation to readme by @bombcar in https://github.com/GTNewHorizons/ServerUtilities/pull/14 (2.0.5)
+> * Disable command override if a bukkit/forge hybrid is detected. by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/13 (2.0.4)
+> * toLowerCase on import from FTB and on save and load (just in case) by @Caedis in https://github.com/GTNewHorizons/ServerUtilities/pull/11 (2.0.3)
+> * Add Visual Prospecting/Journeymap Integration by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/9 (2.0.2)
+> * Fix nether portals spawning when teleporting to other dims by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/8 (2.0.1)
+> * Backwards Compatible backport and rewrite. by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/7 (2.0.0)
+> * Fix Lang loading, since it was missing ingame by @Ethryan in https://github.com/GTNewHorizons/ServerUtilities/pull/4 (1.0.2)
+> * Removal of Import Wildcards by @Ethryan in https://github.com/GTNewHorizons/ServerUtilities/pull/2 (1.0.1)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/24 (2.0.9)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/14 (2.0.5)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/11 (2.0.3)
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/7 (2.0.0)
+> * @Ethryan made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/2 (1.0.1)
+> *  ftblib.json -> serverutilslib.json (1.0.0)
+> * ftbu/ -> serverutils/ (1.0.0)
+>
+
+# Updated Share-Where-I-am (2.0.2@Side.BOTH --> 2.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Share-Where-I-am/compare/0.2.0...2.1.0
+>## What's Changed
+> * Use proper Tags class by @glowredman in https://github.com/GTNewHorizons/Share-Where-I-am/pull/4 (2.1.0)
+> * fix build by @Glease in https://github.com/GTNewHorizons/Share-Where-I-am/pull/3 (2.0.2)
+> * Move JourneyMap class reference out of code that runs even if it's not installed by @ByThePowerOfScience in https://github.com/GTNewHorizons/Share-Where-I-am/pull/2 (2.0.2)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/4 (2.1.0)
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/3 (2.0.2)
+> * @ByThePowerOfScience made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/2 (2.0.2)
+>
+
+# Updated TCNEIAdditions (1.2.2@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TCNEIAdditions/compare/1.2.0...1.3.0
+>## What's Changed
+> * Fix Version of Thaumcraft NEI Plugin by @glowredman in https://github.com/GTNewHorizons/TCNEIAdditions/pull/22 (1.3.0)
+> * TC Aspects not showing up on bookmarks correctly fix. by @Cardinalstars in https://github.com/GTNewHorizons/TCNEIAdditions/pull/21 (1.2.2)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/22 (1.3.0)
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/21 (1.2.2)
+>
+
+# Updated TecTech (5.3.23@Side.BOTH --> 5.3.24-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TecTech/compare/5.3.22...5.3.24-pre
+>## What's Changed
+> * Change EoH number formatting to standard form by @Connor-Colenso in https://github.com/GTNewHorizons/TecTech/pull/266 (5.3.23)
+>
+
+# Updated ThaumicBoots (1.1.0@Side.BOTH --> 1.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/0.2.1...1.1.1
+>## What's Changed
+> * Fixing the jump glitch by @Alastors in https://github.com/GTNewHorizons/ThaumicBoots/pull/23 (1.1.1)
+> * Seasonal Boots (#20) by @Alastors in https://github.com/GTNewHorizons/ThaumicBoots/pull/21 (1.1.0)
+>
+
+# Updated ThaumicEnergistics (1.5.4-GTNH@Side.BOTH --> 1.6.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.5.3-GTNH...1.6.1-GTNH
+>## What's Changed
+> * Fix new essentia cell crash when shift rightclicking by @Hikari1nVoid in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/58 (1.6.1-GTNH)
+> * Introduce special handling for multi-aspect containers by @OneEyeMaker in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/57 (1.6.0-GTNH)
+> * change cells index by @MCTBL in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/56 (1.5.4-GTNH)
+>
+>## New Contributors
+> * @Hikari1nVoid made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/58 (1.6.1-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/57 (1.6.0-GTNH)
+>
+
+# Updated ThaumicHorizons (1.4.1@Side.BOTH --> 1.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.4.0...1.5.0
+>## What's Changed
+> * Correct name application for Nightmare by @bombcar in https://github.com/GTNewHorizons/ThaumicHorizons/pull/62 (1.5.0)
+> * Correct name application for Nightmare by @bombcar in https://github.com/GTNewHorizons/ThaumicHorizons/pull/62 (1.5.0)
 > * New lens textures by @Ethryan in https://github.com/GTNewHorizons/ThaumicHorizons/pull/61 (1.4.1)
 >
 >## New Contributors
 > * @Ethryan made their first contribution in https://github.com/GTNewHorizons/ThaumicHorizons/pull/61 (1.4.1)
 >
 
-# Updated TinkersConstruct (1.10.12-GTNH@Side.BOTH --> 1.10.13-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.10.11-GTNH...1.10.13-GTNH
+# Updated ThaumicTinkerer (2.8.5@Side.BOTH --> 2.9.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.8.4...2.9.0
 >## What's Changed
+> * Talisman of Remedium no longer wastes durability trying to remove permanent debuffs. It also accepts the Unbreaking enchant. by @AbdielKavash in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/36 (2.9.0)
+> * Added balancing configs for Shadowbeam Focus. by @Purple-Towel in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/35 (2.8.5)
+>
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/36 (2.9.0)
+> * @Purple-Towel made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/35 (2.8.5)
+>
+
+# Updated TinkersConstruct (1.10.12-GTNH@Side.BOTH --> 1.11.4-GTNH-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.10.11-GTNH...1.11.4-GTNH-pre
+>## What's Changed
+> * Obsidian harvestlevel fix by @chochem in https://github.com/GTNewHorizons/TinkersConstruct/pull/105 (1.11.3-GTNH)
+> * add name for crystal entity (which seems to be a creeper? by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/103 (1.11.1-GTNH)
+> * TConstruct Gadgets localization by @bessonowjaroslaw in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
+> * Added forbidden dimension config by @Ugachaga in https://github.com/GTNewHorizons/TinkersConstruct/pull/2 (1.11.0)
+> * SoulBound support for additional TC slots by @Ugachaga in https://github.com/GTNewHorizons/TinkersConstruct/pull/3 (1.11.0)
+> * Probable solution by @Technus in https://github.com/GTNewHorizons/TinkersConstruct/pull/4 (1.11.0)
+> * Backport lumberaxe tree chop task from master by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/8 (1.11.0)
+> * Whoops, left this out. by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/9 (1.11.0)
+> * Changed Dependencies to prevent missing "tile.unlitTorch_Stone" errors. by @bartimaeusnek in https://github.com/GTNewHorizons/TinkersConstruct/pull/10 (1.11.0)
+> * Add a null check in case there is no current equipped item by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/11 (1.11.0)
+> * Tinkers bows in Battlegear slots by @Kortako in https://github.com/GTNewHorizons/TinkersConstruct/pull/12 (1.11.0)
+> * Fixed issue with crossbow not being able to attack an enemy the playe… by @Kortako in https://github.com/GTNewHorizons/TinkersConstruct/pull/13 (1.11.0)
+> * Add a null check to avoid what looks like a battlesign related crash by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/14 (1.11.0)
+> * Maybe fix lumber axe error by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/15 (1.11.0)
+> * Totally compatible now by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/16 (1.11.0)
+> * Show progress by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/17 (1.11.0)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/TinkersConstruct/pull/18 (1.11.0)
+> * Add support for swapping belt toolbars in inventory GUIs. by @dvdmandt in https://github.com/GTNewHorizons/TinkersConstruct/pull/19 (1.11.0)
+> * Fix possible packet hacking [REDACTED] by @Sirse in https://github.com/GTNewHorizons/TinkersConstruct/pull/20 (1.11.0)
+> * Fixed a lot of NPE's and few duplication glitches by @Sirse in https://github.com/GTNewHorizons/TinkersConstruct/pull/21 (1.11.0)
+> * Revert to slowly killing mobs in smelteries, so regen enders are once… by @dvdmandt in https://github.com/GTNewHorizons/TinkersConstruct/pull/22 (1.11.0)
+> * Update `hideItemPanelSlot` to account for the bookmark panel on NEI-GTNH by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/23 (1.11.0)
+> * Add fluid localization entry by @Kiwi233 in https://github.com/GTNewHorizons/TinkersConstruct/pull/24 (1.11.0)
+> * Fix Tool Station and Tool Forge button not respect the resource domain setting by @chavalitp in https://github.com/GTNewHorizons/TinkersConstruct/pull/25 (1.11.0)
+> * Fix NEI mouse position calculation by @D-Cysteine in https://github.com/GTNewHorizons/TinkersConstruct/pull/26 (1.11.0)
+> * Add a fall back if we try to look up a missing material by @D-Cysteine in https://github.com/GTNewHorizons/TinkersConstruct/pull/27 (1.11.0)
+> * Update ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/TinkersConstruct/pull/28 (1.11.0)
+> * Make green slime blocks harvestable by axe by @Glease in https://github.com/GTNewHorizons/TinkersConstruct/pull/29 (1.11.0)
+> * attempt to fix incorrect smeltry display for molten metals in German and Russian by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/30 (1.11.0)
+> * Update ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/TinkersConstruct/pull/31 (1.11.0)
+> * Unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/TinkersConstruct/pull/32 (1.11.0)
+> * Update build script and CI by @SinTh0r4s in https://github.com/GTNewHorizons/TinkersConstruct/pull/33 (1.11.0)
+> * Update License by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/34 (1.11.0)
+> * Stencil Table and NEI overlap by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/36 (1.11.0)
+> * CraftingStation side chest now work with any IInventory with a configurable blacklist. by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/35 (1.11.0)
+> * Fix clicking on inventory slots by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/37 (1.11.0)
+> * Fix Mantle Version Requirement by @glowredman in https://github.com/GTNewHorizons/TinkersConstruct/pull/38 (1.11.0)
+> * Yay boolean logic errors by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/39 (1.11.0)
+> * update buildscipt to fix mantle transitive dep by @Glease in https://github.com/GTNewHorizons/TinkersConstruct/pull/41 (1.11.0)
+> * LGPL-3.0 by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/42 (1.11.0)
+> * Add a way to ignore NBT in casting recipes by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/43 (1.11.0)
+> * Fix Tinkers Crafting Tables Height by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/45 (1.11.0)
+> * Added Slime Boots & Slimesling. by @draknyte1 in https://github.com/GTNewHorizons/TinkersConstruct/pull/44 (1.11.0)
+> * Implement IFluidContainerItem for LavaTankItemBlock by @MuXiu1997 in https://github.com/GTNewHorizons/TinkersConstruct/pull/46 (1.11.0)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/TinkersConstruct/pull/47 (1.11.0)
+> * Make crafting stations slots use ISidedInventory/IInventory validation logic by @eigenraven in https://github.com/GTNewHorizons/TinkersConstruct/pull/48 (1.11.0)
+> * Fix broken scrolling of large inventories in the crafting station by @eigenraven in https://github.com/GTNewHorizons/TinkersConstruct/pull/49 (1.11.0)
+> * Add null check by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/50 (1.11.0)
+> * fix bug where it triggers key actions when you have keybinds set to none by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/51 (1.11.0)
+> * stop toggling the traveller's belt hotbar swap in the NEI GUI by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/52 (1.11.0)
+> * Balance Additions by @DrParadox7 in https://github.com/GTNewHorizons/TinkersConstruct/pull/53 (1.11.0)
+> * Fix JABBA-related issues with crafting station slots by @eigenraven in https://github.com/GTNewHorizons/TinkersConstruct/pull/54 (1.11.0)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/TinkersConstruct/pull/55 (1.11.0)
+> * Improve smeltry GUI tooltip by @Glease in https://github.com/GTNewHorizons/TinkersConstruct/pull/56 (1.11.0)
+> * actively update drain comparator output  by @Glease in https://github.com/GTNewHorizons/TinkersConstruct/pull/57 (1.11.0)
+> * Fix Tinker Addons by @DrParadox7 in https://github.com/GTNewHorizons/TinkersConstruct/pull/58 (1.11.0)
+> * Fix amount of molten quartz for Block of Quartz by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/59 (1.11.0)
+> * Mod Friendly Piercing (Rapier, Arrow & Bolts) by @DrParadox7 in https://github.com/GTNewHorizons/TinkersConstruct/pull/60 (1.11.0)
+> * Misc Additions by @DrParadox7 in https://github.com/GTNewHorizons/TinkersConstruct/pull/62 (1.11.0)
+> * Fix slimeboots & slimesling by @mitchej123 in https://github.com/GTNewHorizons/TinkersConstruct/pull/63 (1.11.0)
+> * Backport: Only break one block when sneaking by @NexusNull in https://github.com/GTNewHorizons/TinkersConstruct/pull/65 (1.11.0)
+> * keybinds by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/67 (1.11.0)
+> * code fixes by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/66 (1.11.0)
+> * Backported the Reinforcement Modifier item from 1.12.2 by @Ethryan in https://github.com/GTNewHorizons/TinkersConstruct/pull/68 (1.11.0)
+> * Fix faucets not working, this logic was removed in Alexdoru's refactor by @eigenraven in https://github.com/GTNewHorizons/TinkersConstruct/pull/70 (1.11.0)
+> * Readd recipe for reinforcement by @Ethryan in https://github.com/GTNewHorizons/TinkersConstruct/pull/71 (1.11.0)
+> * cache some Loader.isModLoaded calls by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/72 (1.11.0)
+> * adding the config options from the tinkered constructor fork by @unix-supremacist in https://github.com/GTNewHorizons/TinkersConstruct/pull/73 (1.11.0)
+> * Revert signature changes of public methods that caused crashes by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/74 (1.11.0)
+> * Update BS and Dep of Mantle by @BlueWeabo in https://github.com/GTNewHorizons/TinkersConstruct/pull/75 (1.11.0)
+> * Fix texture for alumite axe handle by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/76 (1.11.0)
+> * Fix: Adding Tooltips to Modifier Items by @Ethryan in https://github.com/GTNewHorizons/TinkersConstruct/pull/77 (1.11.0)
+> * Replace some hard-coded tooltips with translatable text by @StrangeMan1580 in https://github.com/GTNewHorizons/TinkersConstruct/pull/79 (1.11.0)
+> * bump dep to have working fmp by @chochem in https://github.com/GTNewHorizons/TinkersConstruct/pull/81 (1.11.0)
+> * fix smeltery tps lag by clearing drain array before structure check by @Denostrov in https://github.com/GTNewHorizons/TinkersConstruct/pull/82 (1.11.0)
+> * Readme: remove the workspace step by @chill-was-taken in https://github.com/GTNewHorizons/TinkersConstruct/pull/83 (1.11.0)
+> * Use compileOnlyApi for CoFH by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/84 (1.11.0)
+> * fix smeltery acceleration and comparator output by @Denostrov in https://github.com/GTNewHorizons/TinkersConstruct/pull/86 (1.11.0)
+> * fix crash when opening stencil table with cast by @Denostrov in https://github.com/GTNewHorizons/TinkersConstruct/pull/87 (1.11.0)
+> * Remove smeltery tracks melting recipe by @DotJason in https://github.com/GTNewHorizons/TinkersConstruct/pull/88 (1.11.0)
+> * Fix tracks properly by @chochem in https://github.com/GTNewHorizons/TinkersConstruct/pull/90 (1.11.0)
+> * Fix lumberaxe chain break not validating held item by @miozune in https://github.com/GTNewHorizons/TinkersConstruct/pull/89 (1.11.0)
+> * Fixes broken TiC Armor not being repairable by @DrParadox7 in https://github.com/GTNewHorizons/TinkersConstruct/pull/91 (1.11.0)
+> * tinker's + ofanix by @Quetz4l in https://github.com/GTNewHorizons/TinkersConstruct/pull/92 (1.11.0)
+> * slimeBoots and slimeSling by @Quetz4l in https://github.com/GTNewHorizons/TinkersConstruct/pull/93 (1.11.0)
+> * fix slime boots by @Quetz4l in https://github.com/GTNewHorizons/TinkersConstruct/pull/95 (1.11.0)
+> * fix health bar shaking like crazy when the player has regeneration by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/96 (1.11.0)
+> * Fix health bar renderer by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/97 (1.11.0)
+> * fix health bar not being shifted up by DualHotbar by @charagarlnad in https://github.com/GTNewHorizons/TinkersConstruct/pull/98 (1.11.0)
+> * use updated battlegear2 api by @Alexdoru in https://github.com/GTNewHorizons/TinkersConstruct/pull/99 (1.11.0)
+> * feat: add ukrainian localization by @Oleksey-Korolenko in https://github.com/GTNewHorizons/TinkersConstruct/pull/94 (1.11.0)
+> * NEI bookmark pulling by @Nilau1998 in https://github.com/GTNewHorizons/TinkersConstruct/pull/100 (1.11.0)
+> * Patch for Angelica by @ah-OOG-ah in https://github.com/GTNewHorizons/TinkersConstruct/pull/101 (1.11.0)
+> * TConstruct Gadgets localization by @bessonowjaroslaw in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0)
+> * add name for crystal entity (which seems to be a creeper? by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/103 (1.11.1-GTNH)
+> * TConstruct Gadgets localization by @bessonowjaroslaw in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
 > * Patch for Angelica by @ah-OOG-ah in https://github.com/GTNewHorizons/TinkersConstruct/pull/101 (1.10.12-GTNH)
 >
 >## New Contributors
+> * @bessonowjaroslaw made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
+> * @Ugachaga made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/2 (1.11.0)
+> * @Technus made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/4 (1.11.0)
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/8 (1.11.0)
+> * @bartimaeusnek made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/10 (1.11.0)
+> * @Kortako made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/12 (1.11.0)
+> * @Kiwi233 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/18 (1.11.0)
+> * @dvdmandt made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/19 (1.11.0)
+> * @Sirse made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/20 (1.11.0)
+> * @chavalitp made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/25 (1.11.0)
+> * @D-Cysteine made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/26 (1.11.0)
+> * @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/28 (1.11.0)
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/29 (1.11.0)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/30 (1.11.0)
+> * @SinTh0r4s made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/32 (1.11.0)
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/36 (1.11.0)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/38 (1.11.0)
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/43 (1.11.0)
+> * @draknyte1 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/44 (1.11.0)
+> * @MuXiu1997 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/46 (1.11.0)
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/48 (1.11.0)
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/51 (1.11.0)
+> * @DrParadox7 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/53 (1.11.0)
+> * @NexusNull made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/65 (1.11.0)
+> * @Ethryan made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/68 (1.11.0)
+> * @unix-supremacist made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/73 (1.11.0)
+> * @BlueWeabo made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/75 (1.11.0)
+> * @StrangeMan1580 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/79 (1.11.0)
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/81 (1.11.0)
+> * @Denostrov made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/82 (1.11.0)
+> * @chill-was-taken made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/83 (1.11.0)
+> * @DotJason made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/88 (1.11.0)
+> * @Quetz4l made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/92 (1.11.0)
+> * @charagarlnad made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/98 (1.11.0)
+> * @Oleksey-Korolenko made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/94 (1.11.0)
+> * @Nilau1998 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/100 (1.11.0)
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/101 (1.11.0)
+> * @bessonowjaroslaw made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0)
+> * @bessonowjaroslaw made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
 > * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/101 (1.10.12-GTNH)
 >
 
-# Updated WarpTheory (1.2.16-GTNH@Side.BOTH --> 1.2.17-GTNH@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/WarpTheory/compare/1.2.14-GTNH...1.2.17-GTNH
+# Updated Translocators (1.1.2.21@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Translocators/compare/1.1.2.20...1.2.0
 >## What's Changed
+> * Update for latest CCC/L to be threadsafe by @bombcar in https://github.com/GTNewHorizons/Translocators/pull/7 (1.2.0)
+> * don't register keybind if the crafting grid feature is disabled by th… by @Alexdoru in https://github.com/GTNewHorizons/Translocators/pull/6 (1.1.2.21)
+>
+>## New Contributors
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Translocators/pull/6 (1.1.2.21)
+>
+
+# Updated VisualProspecting (1.2.1@Side.BOTH --> 1.2.2-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.2.0...1.2.2-pre
+>## What's Changed
+> * Networking Refactor by @Rune580 in https://github.com/GTNewHorizons/VisualProspecting/pull/40 (1.2.1)
+>
+>## New Contributors
+> * @Rune580 made their first contribution in https://github.com/GTNewHorizons/VisualProspecting/pull/40 (1.2.1)
+>
+
+# Updated WarpTheory (1.2.16-GTNH@Side.BOTH --> 1.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WarpTheory/compare/1.2.14-GTNH...1.3.0-GTNH
+>## What's Changed
+> * Add names for warptheory entities for mobinfo by @bombcar in https://github.com/GTNewHorizons/WarpTheory/pull/31 (1.3.0-GTNH)
+> * Add names for warptheory entities for mobinfo by @bombcar in https://github.com/GTNewHorizons/WarpTheory/pull/31 (1.3.0-GTNH)
 > * Fix spawned doppelgänger by @D-Cysteine in https://github.com/GTNewHorizons/WarpTheory/pull/30 (1.2.16-GTNH)
 >
 
-# Updated bartworks (0.8.22@Side.BOTH --> 0.8.23@Side.BOTH)
-**Full Changelog**: https://github.com/GTNewHorizons/bartworks/compare/0.8.21...0.8.23
+# Updated bartworks (0.8.22@Side.BOTH --> 0.9.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/bartworks/compare/0.8.21...0.9.3
 >## What's Changed
+> * Fix industry frame and galaxyspace plat block recyling by @chochem in https://github.com/GTNewHorizons/bartworks/pull/385 (0.9.3)
+> * Fix painted low power laser converter explosion by @antropod in https://github.com/GTNewHorizons/bartworks/pull/383 (0.9.2)
+> * Fix muffler hatch numbers for mega by @chochem in https://github.com/GTNewHorizons/bartworks/pull/384 (0.9.2)
+> * Fix CAL Locking itself by @LewisSaber in https://github.com/GTNewHorizons/bartworks/pull/381 (0.9.1)
+> * Allow Mega Oil Cracker to use an input bus for programmed circuit automation. by @AbdielKavash in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
+> * Fix CAL Locking itself by @LewisSaber in https://github.com/GTNewHorizons/bartworks/pull/381 (0.9.1)
+> * Allow Mega Oil Cracker to use an input bus for programmed circuit automation. by @AbdielKavash in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
 > * Fix length calculation for CAL by @LewisSaber in https://github.com/GTNewHorizons/bartworks/pull/379 (0.8.22)
+>
+>## New Contributors
+> * @antropod made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/383 (0.9.2)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
+>
+
+# Updated lwjgl3ify (1.5.7@Side.BOTH_JAVA9 --> 1.5.9@Side.BOTH_JAVA9)
+**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/1.5.6...1.5.9
+>## What's Changed
+> * Publish `version.gradle` by @glowredman in https://github.com/GTNewHorizons/lwjgl3ify/pull/104 (1.5.8)
+> * Disable STB stitching if FC 1.23 is present even with OF by @makamys in https://github.com/GTNewHorizons/lwjgl3ify/pull/97 (1.5.7)
+> * Add `version.json` for use in e.g. Technic Launcher by @glowredman in https://github.com/GTNewHorizons/lwjgl3ify/pull/98 (1.5.7)
+>
+>## New Contributors
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/97 (1.5.7)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/98 (1.5.7)
+>
+
+# Updated neiaddons (1.13.0@Side.BOTH --> 1.14.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/neiaddons/compare/1.12.22...1.14.0
+>## What's Changed
+> * Fix Version by @glowredman in https://github.com/GTNewHorizons/neiaddons/pull/8 (1.14.0)
+> * Fix Crash for Ex Nihilo addon by @Cleptomania in https://github.com/GTNewHorizons/neiaddons/pull/7 (1.13.0)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/neiaddons/pull/8 (1.14.0)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/neiaddons/pull/7 (1.13.0)
+>
+
+# Updated twilightforest (2.5.1@Side.BOTH --> 2.5.2-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.5.0...2.5.2-pre
+>## What's Changed
+> * Fix server crash with magic beans by @miozune in https://github.com/GTNewHorizons/twilightforest/pull/32 (2.5.1)
+>
+>## New Contributors
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/32 (2.5.1)
 >
 

--- a/releases/changelogs/changelog from 2.5.1 to nightly.md
+++ b/releases/changelogs/changelog from 2.5.1 to nightly.md
@@ -1,0 +1,2913 @@
+# New Mods:
+> * Angelica
+> * Archaicfix
+> * CoreTweaks
+> * ServerUtilities
+> * Tinkers-Defense
+# Mods Removed:
+> * FastCraft
+> * MalisisCore
+> * Tinkers' Defense
+# Updated AE2FluidCraft-Rework (1.1.74-gtnh@Side.BOTH --> 1.2.19-gtnh@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.1.73-gtnh...1.2.19-gtnh
+>## What's Changed
+> * FIX: Use correct priority increment amounts by @michaeldoylecs in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/192 (1.2.19-gtnh)
+> * Fix Dynamic Font Size by @slprime in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/193 (1.2.18-gtnh)
+> * Use GT and ae2f fluids in ME inputs/outputs and storag by @slprime in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/191 (1.2.17-gtnh)
+> * Use GT and ae2f fluids in ME inputs/outputs and storag by @slprime in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/191 (1.2.16-gtnh-pre)
+> * Adding fluids to sticky card by @Cardinalstars in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/190 (1.2.14-gtnh-pre)
+> * Adding fluids to sticky card by @Cardinalstars in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/190 (1.2.13-gtnh)
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/188 (1.2.9-gtnh-pre)
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/188 (1.2.8-gtnh)
+> * Level Maintainer fulfills requests in a round robin pattern. by @AbdielKavash in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/187 (1.2.7-gtnh)
+> * Add null check to level terminal middle click by @Caedis in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/186 (1.2.6-gtnh)
+> * Fix ability to configure `TileLevelMaintainer` using OC by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/184 (1.2.5-gtnh)
+> * Correct split client-server code by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/183 (1.2.4-gtnh)
+> * Implement Interface Locking for Dual Interfaces by @TechnicianLP in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/182 (1.2.3-gtnh)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` (1.2.2-gtnh)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/179 (1.2.1-gtnh)
+> * Correct `stackSize` z order by @Laiff in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/178 (1.2.0-gtnh)
+>
+>## New Contributors
+> * @michaeldoylecs made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/192 (1.2.19-gtnh)
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/191 (1.2.17-gtnh)
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/191 (1.2.16-gtnh-pre)
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/190 (1.2.14-gtnh-pre)
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/190 (1.2.13-gtnh)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/187 (1.2.7-gtnh)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/186 (1.2.6-gtnh)
+>
+
+# Updated AFSU (1.2.6-GTNH@Side.BOTH --> 1.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AFSU/compare/1.2.5-GTNH...1.3.0-GTNH
+>## What's Changed
+> * [bs] update spotless, clean repos by @bombcar in https://github.com/GTNewHorizons/AFSU/pull/6 (1.3.0-GTNH)
+> * update build by @bombcar in https://github.com/GTNewHorizons/AFSU/pull/4 (1.2.6-GTNH)
+>
+
+# Updated AdventureBackpack2 (1.0.17-GTNH@Side.BOTH --> 1.1.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.0.16-GTNH...1.1.1-GTNH
+>## What's Changed
+> * Add name for rideableSpider by @bombcar in https://github.com/GTNewHorizons/AdventureBackpack2/pull/17 (1.1.0-GTNH)
+>
+
+# Updated AlchemyGrate (1.0.3-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AlchemyGrate/compare/1.0.2-GTNH...1.1.0-GTNH
+>## What's Changed
+> * Spotless apply for branch fixing-research for #3 by @github-actions in https://github.com/GTNewHorizons/AlchemyGrate/pull/4 (1.0.3-GTNH)
+> * actually fixing the researches by @Alastors in https://github.com/GTNewHorizons/AlchemyGrate/pull/3 (1.0.3-GTNH)
+>
+>## New Contributors
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/AlchemyGrate/pull/4 (1.0.3-GTNH)
+> * @Alastors made their first contribution in https://github.com/GTNewHorizons/AlchemyGrate/pull/3 (1.0.3-GTNH)
+>
+
+# Updated Amazing-Trophies (1.1.4@Side.BOTH --> 1.2.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.1.3...1.2.1
+>## What's Changed
+> * VBO (Significant performance boost with Angelica) by @mitchej123 in https://github.com/GTNewHorizons/Amazing-Trophies/pull/6 (1.2.0)
+> * Force Fancy Graphics when rendering a Trophy displaying an Item by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/5 (1.1.4)
+> * Force Fancy Graphics when rendering a Trophy displaying an Item by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/5 (1.1.4)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Amazing-Trophies/pull/6 (1.2.0)
+>
+
+# New Mod - Angelica (1.0.0-alpha31@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/Angelica/commits/1.0.0-alpha31
+>## What's Changed
+> * Ignore the iris/mcpf configs, hardcode angelica-modules.cfg filename by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/333 (1.0.0-alpha31)
+> * Replace config with gtnhlib's config by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/337 (1.0.0-alpha31)
+> * Up required gtnhlib version to 0.2.9 by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/340 (1.0.0-alpha31)
+> * Apparently some mods rely on ForgeHooksClient.getWorldRenderPass() by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/347 (1.0.0-alpha31)
+> * Switch up the signature to take ints instead of a blockpos and stop allocating one by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/324 (1.0.0-alpha30)
+> * Fix #320 by @mts2200 in https://github.com/GTNewHorizons/Angelica/pull/325 (1.0.0-alpha30)
+> * Use a RFB plugin for GLSM transforms when available by @eigenraven in https://github.com/GTNewHorizons/Angelica/pull/329 (1.0.0-alpha30)
+> * Add Dynamic FOV toggle by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/331 (1.0.0-alpha30)
+> * Gate some advanced/beta features behind java properties by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/332 (1.0.0-alpha30)
+> * Don't crash wit invalid lightquality/particalmode options by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/306 (1.0.0-alpha29)
+> * scheduleRebuildOffThread by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/316 (1.0.0-alpha29)
+> * Switcharoo on detecting ThreadSafeISBRHFactory... by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/318 (1.0.0-alpha29)
+> * Requires GTNHLib 0.2.4+ (1.0.0-alpha28)
+> * Fixes issue with HoloInventory (1.0.0-alpha28)
+> * Partially fix entity shaders by @UltraHex in https://github.com/GTNewHorizons/Angelica/pull/294 (1.0.0-alpha28)
+> * Test Basic Matrix operations by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/295 (1.0.0-alpha28)
+> * Sync with NotFine by @jss2a98aj in https://github.com/GTNewHorizons/Angelica/pull/296 (1.0.0-alpha28)
+> * Move JOML dependency to GTNHLib 0.2.4 by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/301 (1.0.0-alpha28)
+> * Fix glLoadMatrix and add a test for it by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/305 (1.0.0-alpha28)
+> * Make getBlockType and getBlockMetadata atomic by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/288 (1.0.0-alpha27)
+> * Exclude AMD in testPushPopEnableBit by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/289 (1.0.0-alpha27)
+> * GLSM Tests & AMD Driver Workaround by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/290 (1.0.0-alpha27)
+> * Blacklist bartworks from the worker thread by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/286 (1.0.0-alpha27)
+> * Update Chinese translation by @Ginsway in https://github.com/GTNewHorizons/Angelica/pull/261 (1.0.0-alpha26)
+> * Log more information in the no-result task exception by @eigenraven in https://github.com/GTNewHorizons/Angelica/pull/283 (1.0.0-alpha26)
+> * Do not return null results in translucency sort task if not cancelled by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/284 (1.0.0-alpha26)
+> * Glsm tests by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/275 (1.0.0-alpha25)
+> * Fix typo in issue template by @ah-OOG-ah in https://github.com/GTNewHorizons/Angelica/pull/280 (1.0.0-alpha25)
+> * A few buildscript and test tweaks by @eigenraven in https://github.com/GTNewHorizons/Angelica/pull/281 (1.0.0-alpha25)
+> * More GLSM Tests by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/282 (1.0.0-alpha25)
+> * Bump GTNH gradle plugin version by @ah-OOG-ah in https://github.com/GTNewHorizons/Angelica/pull/268 (1.0.0-alpha24)
+> * Don't put excessive buffer size by @Asek3 in https://github.com/GTNewHorizons/Angelica/pull/267 (1.0.0-alpha24)
+> * Compat with NotEnoughIDs 16-bit Metadata by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/271 (1.0.0-alpha24)
+> * GLSM Improvements by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/272 (1.0.0-alpha24)
+> * Initial QuadProvider API by @ah-OOG-ah in https://github.com/GTNewHorizons/Angelica/pull/256 (1.0.0-alpha24)
+> * Minor cleanup by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/264 (1.0.0-alpha23)
+> * OpenGL State Debugging by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/262 (1.0.0-alpha23)
+> * Fix some missing state for push/pop attrib by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/260 (1.0.0-alpha22)
+> * Add a Vector3dStack - Fix nested translations being stored by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/258 (1.0.0-alpha21)
+> * Bypass cache longer by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/259 (1.0.0-alpha21)
+> * null check by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/255 (1.0.0-alpha20)
+> * This wasn't supposed to be private :facepalm: by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/246 (1.0.0-alpha19)
+> * Fix leaf rendering issue by @jss2a98aj in https://github.com/GTNewHorizons/Angelica/pull/247 (1.0.0-alpha19)
+> * Only return null if job is explicitly cancelled by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/251 (1.0.0-alpha19)
+> * Fix PBR by @UltraHex in https://github.com/GTNewHorizons/Angelica/pull/252 (1.0.0-alpha19)
+> * Make RedirectorTransformer handle block subclasses correctly (fixes TFC+) by @makamys in https://github.com/GTNewHorizons/Angelica/pull/249 (1.0.0-alpha19)
+> * Add dependency hints by @makamys in https://github.com/GTNewHorizons/Angelica/pull/253 (1.0.0-alpha19)
+> * Opt in thread saftey by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/254 (1.0.0-alpha19)
+> * More aggressive caching by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/239 (1.0.0-alpha18)
+> * Fix texture state leak in BatchedFontRenderer by @Pistonight in https://github.com/GTNewHorizons/Angelica/pull/240 (1.0.0-alpha18)
+> * More Caching by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/242 (1.0.0-alpha18)
+> * Fewer Allocations by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/243 (1.0.0-alpha18)
+> * VBO related Tweaks by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/227 (1.0.0-alpha17)
+> * Fix hud caching alpha handling and boss health by @Pistonight in https://github.com/GTNewHorizons/Angelica/pull/232 (1.0.0-alpha17)
+> * OpenGL Debugging by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/233 (1.0.0-alpha17)
+> * Handle depth buffer properly in HUD Caching by @Pistonight in https://github.com/GTNewHorizons/Angelica/pull/235 (1.0.0-alpha17)
+> * fix runclient17 by @bombcar in https://github.com/GTNewHorizons/Angelica/pull/211 (1.0.0-alpha16)
+> * Fix hud caching vignette and crosshair color issues by @Pistonight in https://github.com/GTNewHorizons/Angelica/pull/212 (1.0.0-alpha16)
+> * Redirect negative display list calls to VBOs globally (fixes Smart Moving) by @makamys in https://github.com/GTNewHorizons/Angelica/pull/217 (1.0.0-alpha16)
+> * ArchaicFix compat by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/220 (1.0.0-alpha16)
+> * Make NotFine's sky toggle more granular by @makamys in https://github.com/GTNewHorizons/Angelica/pull/222 (1.0.0-alpha16)
+> * Fix campfire backport animations by @makamys in https://github.com/GTNewHorizons/Angelica/pull/224 (1.0.0-alpha16)
+> * Config updates by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/225 (1.0.0-alpha16)
+> * Add Reese's Sodium Options by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/219 (1.0.0-alpha16)
+> * fix some iris problems by @Cyl18 in https://github.com/GTNewHorizons/Angelica/pull/183 (1.0.0-alpha15)
+> * Replace fastutil dependency with GTNHLib by @tth05 in https://github.com/GTNewHorizons/Angelica/pull/187 (1.0.0-alpha15)
+> * Don't activate item textures if there is no client world by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/189 (1.0.0-alpha15)
+> * Render all Wavefront objects as VBO by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/192 (1.0.0-alpha15)
+> * Enable NotFine leaf modes when enableNotFineFeatures is true by @jss2a98aj in https://github.com/GTNewHorizons/Angelica/pull/194 (1.0.0-alpha15)
+> * disable sodium weather quality redirect if dynamic surroundings is pr… by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/200 (1.0.0-alpha15)
+> * Remove silly early initial implementation and fix star VBO by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/206 (1.0.0-alpha15)
+> * Reset the offset on cleanup/clearQuads instead of after every draw/reset call by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/159 (1.0.0-alpha14)
+> * Update BS by @makamys in https://github.com/GTNewHorizons/Angelica/pull/165 (1.0.0-alpha14)
+> * Clear event phase before reusing object by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/170 (1.0.0-alpha14)
+> * Handle state changes for display lists correctly in GLSM by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/168 (1.0.0-alpha14)
+> * Only use BatchedFontRenderer when not in a display list compilation by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/174 (1.0.0-alpha14)
+> * Respect animation speedup config by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/180 (1.0.0-alpha14)
+> * Off thread safe blocks by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/177 (1.0.0-alpha14)
+> * Quad cleanup by @makamys in https://github.com/GTNewHorizons/Angelica/pull/124 (1.0.0-alpha13)
+> * Remove tessellator to buffer by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/123 (1.0.0-alpha13)
+> * meh - fix silly by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/126 (1.0.0-alpha13)
+> * Fix chunk update stutter by unparking main thread when a chunk render job completes by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/127 (1.0.0-alpha13)
+> * Performance & allocation rate optimizations by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/128 (1.0.0-alpha13)
+> * DisplayList -> VBO for stars, skies, and ModelRenderer by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/129 (1.0.0-alpha13)
+> * VBO Manager by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/133 (1.0.0-alpha13)
+> * Fix `drawString` returning wrong value by @ZakBerkelaar in https://github.com/GTNewHorizons/Angelica/pull/132 (1.0.0-alpha13)
+> * MCPF config/mixins cleanup by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/130 (1.0.0-alpha13)
+> * VBO Clouds by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/135 (1.0.0-alpha13)
+> * Add archaicfix version requirement, if present by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/136 (1.0.0-alpha13)
+> * Fix Camera#blockPos rounding and apply third person offset by @makamys in https://github.com/GTNewHorizons/Angelica/pull/137 (1.0.0-alpha13)
+> * Use ConcurrentHashMap to store tile entity renderers by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/138 (1.0.0-alpha13)
+> * Set the hasXXX flags so quads get generated properly by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/139 (1.0.0-alpha13)
+> * Make sure the correct discard/reset is being called by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/144 (1.0.0-alpha13)
+> * So binding a texture in a display list compile won't change it, but it'll capture the change..... by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/146 (1.0.0-alpha13)
+> * Integrate Sodium animation system with Angelica's by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/147 (1.0.0-alpha13)
+> * Store state changes generated while creating a display list, and apply them after calling the display list by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/150 (1.0.0-alpha13)
+> * Backport relevant changes from Embeddium versions since the fork by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/149 (1.0.0-alpha13)
+> * Fix for GUI lighting states by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/148 (1.0.0-alpha13)
+> * Fix VBO crash by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/151 (1.0.0-alpha13)
+> * Don't remap, and throw early by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/153 (1.0.0-alpha13)
+> * turn sortAndRender redirect into WrapOperation by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/158 (1.0.0-alpha13)
+> * Only enable threaded block transformations when sodium is enabled by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/107 (1.0.0-alpha12)
+> * Normalize Rotation vector by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/109 (1.0.0-alpha12)
+> * Re-enable lighting after rendering Thaumcraft aspects by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/111 (1.0.0-alpha12)
+> * Defer chunk updates by default by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/112 (1.0.0-alpha12)
+> * fix sodium fluid renderer not using biome colors by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/122 (1.0.0-alpha12)
+> * VBO support by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/120 (1.0.0-alpha12)
+> * Handle bad matrix modes by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/93 (1.0.0-alpha11)
+> * Add debug logging option by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/97 (1.0.0-alpha11)
+> * Preliminary ChunkAPI/EndlessIDs compatibility by @FalsePattern in https://github.com/GTNewHorizons/Angelica/pull/94 (1.0.0-alpha11)
+> * replace lotr blockrendering hashmap with concurrent version by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/98 (1.0.0-alpha11)
+> * Move mod checks to their own static class by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/103 (1.0.0-alpha11)
+> * Texture coordinate precision issues by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/105 (1.0.0-alpha11)
+> * Update the tesselator checks to allow for non main instance tesselators while still on the main thread by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/106 (1.0.0-alpha11)
+> * Fix constant pool parser early-exiting instead of checking all strings by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/90 (1.0.0-alpha10)
+> * Do not include transformed mods in runtime classpath by default by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/91 (1.0.0-alpha10)
+> * Fix Block bounds fields redirects not applying to subclasses by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/79 (1.0.0-alpha9)
+> * Add missed IC2 mixin by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/85 (1.0.0-alpha9)
+> * Fully track GL State changes by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/83 (1.0.0-alpha9)
+> * Catch the specific error, rather than generic Exception (which the error doesn't seem to subclass anyway) by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/88 (1.0.0-alpha9)
+> * Dynamic cstPoolParser by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/89 (1.0.0-alpha9)
+> * Handle GL_COMPILE separately from GL_COMPILE_AND_EXECUTE by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/68 (1.0.0-alpha7)
+> * Use client world for main thread renders by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/62 (1.0.0-alpha6)
+> * Opt in debug by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/67 (1.0.0-alpha6)
+> * Make glPushAttrib match native behavior if bypassing state manager cache by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/55 (1.0.0-alpha5)
+> * Track the model view and projection matrix by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/56 (1.0.0-alpha5)
+> * Avoid restoring GL buffers we didn't modify by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/60 (1.0.0-alpha5)
+> * Because of course someone uses DoubleBuffer by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/61 (1.0.0-alpha5)
+> * Switch up how we're grabbing the projection & model view matrix to avoid needing to call glGetFloat() again by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/53 (1.0.0-alpha3)
+> * mcpf merge 2.0 by @mist475 in https://github.com/GTNewHorizons/Angelica/pull/45 (1.0.0-alpha2)
+> * [Add some more guards around GL capabilities](https://github.com/GTNewHorizons/Angelica/commit/7ae4e14a3e284a59fac1895d6fe0fefa501c1acf) (1.0.0-alpha2)
+> * ThreadedTessellator -> RenderBlocks instance Tessellator (1.0.0-alpha1)
+> * Plus a CME workaround until I can figure out why it's happening (1.0.0-alpha1)
+> * One inject with multiple methods instead of two injects (1.0.0-alpha1)
+> * Add AF's Tessellator#reset mixin Fixes screen flashing when chunks are being built (1.0.0-alpha1)
+> * Thread Saftey (1.0.0-alpha1)
+> * Make each tesselator use its own ByteBuffer (1.0.0-alpha1)
+> * Don't make RecyclingList a static variable (1.0.0-alpha1)
+> * Add some additions via ITessellatorInstance (1.0.0-alpha1)
+> * Stop using builtin updateRenderers (1.0.0-alpha1)
+> * Remove a few unused things in MixinTessellator (1.0.0-alpha1)
+> * Remove useless casting due to implementing the interface (1.0.0-alpha1)
+> * Overwrite some more rendering methods to ensure they're not used (1.0.0-alpha1)
+> * Implement IBlockAccess on WorldSlice (1.0.0-alpha1)
+> * Currently just proxies to the World... need to get it to use the local cache (1.0.0-alpha1)
+> * Make WorldSlice use its copied values instead of using the world (1.0.0-alpha1)
+> * block, meta, and light.  Still need TODO biome (1.0.0-alpha1)
+> * Finish making WorldSlice thread safe (1.0.0-alpha1)
+> * Remove last unsafe this.world accesses (1.0.0-alpha1)
+> * Copy biomeData (1.0.0-alpha1)
+> * Implement getTileEntity(), and getBiomeGenForCoords() (1.0.0-alpha1)
+> * Remove unused 1.16+ classes - Biome, Colorizer, and ColorBlender related (1.0.0-alpha1)
+> * Cache worldHeight instead of asking the provider every time (1.0.0-alpha1)
+> * Debug Screen updates (1.0.0-alpha1)
+> * Disable Culling for now (until it works) (1.0.0-alpha1)
+> * Tessellator Updates (1.0.0-alpha1)
+> * Use one instance on the main thread, and individual instances on every other thread (1.0.0-alpha1)
+> * Prevent draw() and buffer.reset() on non singleton instance (1.0.0-alpha1)
+> * Misc cleanup, maybe better growBuffer? (1.0.0-alpha1)
+> * Fixing splash screen and GUI issues by excluding SplashProgress from GLStateManager transformer (1.0.0-alpha1)
+> * Update docs (1.0.0-alpha1)
+> * Fixing a one line in SodiumWorldRenderer that allows the game setting for the distance at which entities will render. Hope it's not too bad mitch :) (1.0.0-alpha1)
+> * TileEntites now render (1.0.0-alpha1)
+> * Less silly transparency (1.0.0-alpha1)
+> * Removing clamp implementation because I missed the one in mathhelper (1.0.0-alpha1)
+> * Initial sodium entity smooth lighting (1.0.0-alpha1)
+> * Fix entity smooth lighting (1.0.0-alpha1)
+> * Fix lerp uses and use render layers properly (https://github.com/GTNewHorizons/Angelica/pull/17) (1.0.0-alpha1)
+> * Remove some uses of blockstate + patch FluidState (1.0.0-alpha1)
+> * Fix lerp (1.0.0-alpha1)
+> * Enable Sodium fluid rendering (1.0.0-alpha1)
+> * Update FluidRenderer.java (1.0.0-alpha1)
+> * Rewind buffers when copying (1.0.0-alpha1)
+> * Fix multidraw (1.0.0-alpha1)
+> * Force cutout on all non-translucent blocks (1.0.0-alpha1)
+> * Let vanilla handle render pass state (1.0.0-alpha1)
+> * Rewrite render layer check to use Forge 1.7 hook (1.0.0-alpha1)
+> * Fix skylight handling (1.0.0-alpha1)
+> * Fix flickering (1.0.0-alpha1)
+> * Clone TEs correctly (1.0.0-alpha1)
+> * Fixing entityDistMulti (I think) (1.0.0-alpha1)
+> * Fix TEs rendering on the wrong pass (1.0.0-alpha1)
+> * Buff max render distance to 32 Pretty useless since the integrated server stalls instantly, but our renderer supports it (1.0.0-alpha1)
+> * Fix fog (1.0.0-alpha1)
+> * Fix render distance changes being ignored (1.0.0-alpha1)
+> * Implement entity culling (1.0.0-alpha1)
+> * Block face culling (1.0.0-alpha1)
+> * Re-enable occlusion culling (1.0.0-alpha1)
+> * Fix x/z coordinate mixup when indexing biome arrays Partially fixes wrong biome colors, but at chunk edges it's still wrong because neighboring chunks aren't accessed (1.0.0-alpha1)
+> * Make a copy of biome data (1.0.0-alpha1)
+> * Make CompatMemoryUtil#memReallocDirect preserve buffer position (1.0.0-alpha1)
+> * Use biome data of neighboring chunk sections (1.0.0-alpha1)
+> * Re-enable fog culling (1.0.0-alpha1)
+> * Tile entity culling (1.0.0-alpha1)
+> * Remove some unneeded Sodium code (1.0.0-alpha1)
+> * Massive code cleanup (1.0.0-alpha1)
+> * Avoids errors when usin lwjglxdebug (1.0.0-alpha1)
+> * Bump hodgepodge dep (1.0.0-alpha1)
+> * Add AngelicaConfig (1.0.0-alpha1)
+> * Add Mixin to disable MC's builtin checkGLError (1.0.0-alpha1)
+> * Add configs for iris/sodium (1.0.0-alpha1)
+> * Iris work (1.0.0-alpha1)
+> * Move some StateNotifiers to GLStateManager (1.0.0-alpha1)
+> * Remove some redundant mixins based on sodium/angelica work and rendering state captures (1.0.0-alpha1)
+> * Add Iris DebugScreenHandler (1.0.0-alpha1)
+> * rm archaicfix's occlusion renderer and threaded updates (1.0.0-alpha1)
+> * Implemented Sodium's GUI and a couple of setting fixes (https://github.com/GTNewHorizons/Angelica/pull/20) (1.0.0-alpha1)
+> * Ported Sodium's GUI (1.0.0-alpha1)
+> * Correct AO (1.0.0-alpha1)
+> * Fixed Vignette (1.0.0-alpha1)
+> * Re-enable DirectMemoryAccess (1.0.0-alpha1)
+> * Adds some code from lwjgl3 in CompatMemoryUtil.java (1.0.0-alpha1)
+> * Re-add *Unsafe classes (1.0.0-alpha1)
+> * Remove MixinWorldRenderer (1.0.0-alpha1)
+> * Add NEID (mixin pr) support (1.0.0-alpha1)
+> * Only shadow runtime module of antlr4 (1.0.0-alpha1)
+> * Update NotFine (1.0.0-alpha1)
+> * Make LongHashMap actually perform like a hash map (1.0.0-alpha1)
+> * Options GUI Fixes and some option implementations (https://github.com/GTNewHorizons/Angelica/pull/22) (1.0.0-alpha1)
+> * Correct useNoErrorGLContext option (1.0.0-alpha1)
+> * Added translucency sorting option (1.0.0-alpha1)
+> * Implemented Particle Culling gives real fps boost, however, it's not as big as i thought (1.0.0-alpha1)
+> * Begin implementing animateOnlyVisibleTextures (1.0.0-alpha1)
+> * Correct Donation page opening (1.0.0-alpha1)
+> * Fixed Shift + P - Now it uses NotFine's GUI, but it think that NotFine's GUI should be rewrited for using other config options (1.0.0-alpha1)
+> * Correct URL's for Linux (1.0.0-alpha1)
+> * second code cleanup in particle culling (1.0.0-alpha1)
+> * Fix incorrect TE map population (1.0.0-alpha1)
+> * Add optional assertMainThread behind `-Dangelica.assertMainThread=true` (1.0.0-alpha1)
+> * Add back air optimization, but only apply to vanilla air (1.0.0-alpha1)
+> * Implement more options (https://github.com/GTNewHorizons/Angelica/pull/23) (1.0.0-alpha1)
+> * Combine free regions in GlBufferArena (1.0.0-alpha1)
+> * Clear global block entity list when initializing renderer (1.0.0-alpha1)
+> * AF, CompileStubs, and SplashProgress (1.0.0-alpha1)
+> * Move a few mixins over to angelica (1.0.0-alpha1)
+> * Disable if org.lwjgl.util.Debug is set (1.0.0-alpha1)
+> * Only enable Iris/lwjgl debug callbacks if org.lwjgl.util.Debug is set (1.0.0-alpha1)
+> * Rewrite Tessellator hacks - now using a ThreadLocal instead of only patching RenderBlocks (1.0.0-alpha1)
+> * Reenable AF mixins, switch to cached debug var, disable incompatible mixins (1.0.0-alpha1)
+> * Remove AF deps and a late mixin that was missed (1.0.0-alpha1)
+> * Add Iris Sodium Compat impl (1.0.0-alpha1)
+> * Fix Sodium GLProgram to use ResourceLocation instead of Identifier (1.0.0-alpha1)
+> * Start applying Iris -> Sodium Mixins (1.0.0-alpha1)
+> * Make NotFine menu open if holding shift (1.0.0-alpha1)
+> * Fixed Tessellators in production env (1.0.0-alpha1)
+> * Finish Sodium Fluid Renderer (https://github.com/GTNewHorizons/Angelica/pull/24) (1.0.0-alpha1)
+> * Init and pass Sodium LightPipelines (1.0.0-alpha1)
+> * Remove registry lookup and refactor WorldUtil (1.0.0-alpha1)
+> * Hook up lighting pipeline (1.0.0-alpha1)
+> * Patch fluid velocity (1.0.0-alpha1)
+> * It's alive! Sodium Fluid Renderer is alive! (1.0.0-alpha1)
+> * Fix face culling not taking third person camera offset into account (1.0.0-alpha1)
+> * rewrite ACTEntityRenderer to stop transforming ALL the classes (1.0.0-alpha1)
+> * use ClassConstantPoolParser in TessellatorTransformer to speed up search for Tessellator references (1.0.0-alpha1)
+> * use ClassConstantPoolParser in GLStateManagerTransformer to speed up search for class references (1.0.0-alpha1)
+> * rewrite GLStateManagerTransformer and TessellatorTransformer (1.0.0-alpha1)
+> * merge GLStateManagerTransfor and TessellatorTransformer into one Transformer (1.0.0-alpha1)
+> * Fixed smooth lighting rendering (1.0.0-alpha1)
+> * Iris block_id Mixins & BlockStateIdMap initial impl for 1.7.10 (1.0.0-alpha1)
+> * Fix running with lwjgl debug flag & Cleanup old ShadersMod transformers (1.0.0-alpha1)
+> * Initialize GLStateManager via Mixins instead of all in the static block (1.0.0-alpha1)
+> * Clean up chunk load/unload tracking, fix chunks rendering without neighbors sometimes (1.0.0-alpha1)
+> * Fix occlusion culler not re-running after important uploads (1.0.0-alpha1)
+> * Add chunks to queues without going through occlusion culler (1.0.0-alpha1)
+> * Extremely primitive synchronization approach for ISBRH (1.0.0-alpha1)
+> * Use factory for Spdium menu createElement outputs This will allow NotFine to use Sodium menu elements and vice versa in a future commit. (1.0.0-alpha1)
+> * Splash Screen Compat (1.0.0-alpha1)
+> * Separate remaining NamedState enums (1.0.0-alpha1)
+> * NotFine but it loads Sodium pages (1.0.0-alpha1)
+> * Hook up NotFine optimizations (1.0.0-alpha1)
+> * Hook up some NotFine features (1.0.0-alpha1)
+> * copy over hud caching code from hodgepodge (1.0.0-alpha1)
+> * backport glstatemanager mixin (1.0.0-alpha1)
+> * Track thread that currently owns the GL Context in addition to the main thread. (1.0.0-alpha1)
+> * First pass over FontRenderer, 1300->1400 FPS on my GPU when showing F3 (1.0.0-alpha1)
+> * Add JVM flag to bypass GL state caching (1.0.0-alpha1)
+> * Push/Pop Attrib Hacks -- to be evolved later (1.0.0-alpha1)
+> * Fix FontRenderer+SplashScreen combo (1.0.0-alpha1)
+> * HUDCaching tweaks (1.0.0-alpha1)
+> * Add license (1.0.0-alpha1)
+> * Jabba Compat, and reset tesselator state even if the chunk render thread blows up (1.0.0-alpha1)
+> * Initial Xaero's World Map + Minimap Support (1.0.0-alpha1)
+> * Disable Fastcraft & Optifine if present (1.0.0-alpha1)
+> * Iris Progress (1.0.0-alpha1)
+> * Wire up more Iris mixins, informing pipeline stages.  Still not rendering anything visible. (1.0.0-alpha1)
+> * Don't try to transform the server (1.0.0-alpha1)
+> * Avoid running biome generator on client in singleplayer (1.0.0-alpha1)
+> * Call world biome retrieval methods instead of copying array directly (https://github.com/GTNewHorizons/Angelica/pull/25) (1.0.0-alpha1)
+> * Shaders now do something! (1.0.0-alpha1)
+> * Shadow Pass work (1.0.0-alpha1)
+> * First shadow pass renders; however it moves all around when moving the camera... (1.0.0-alpha1)
+> * Second shadow pass not running because it makes everything very very dark instead of just rendering translucents (1.0.0-alpha1)
+> * Actually use the ShadowRenderer Model View when running the shadow pass... (1.0.0-alpha1)
+> * Enable Sodium SmoothLightPipeline & Iris useSeparateAo (1.0.0-alpha1)
+> * Avoid repeatedly copying biome data on each Y level (https://github.com/GTNewHorizons/Angelica/pull/27) (1.0.0-alpha1)
+> * Celestial Rotation fixes (1.0.0-alpha1)
+> * Water progress (1.0.0-alpha1)
+> * Uniforms audit (1.0.0-alpha1)
+> * Lightmap workaround (1.0.0-alpha1)
+> * PBR compiling, stuck on Normal and Specular textures being added in (1.0.0-alpha1)
+> * Shaderpack selection "works"; ShaderOptions TODO (1.0.0-alpha1)
+> * Hud caching angelica (https://github.com/GTNewHorizons/Angelica/pull/28) (1.0.0-alpha1)
+> * Potential hud-caching fix (1.0.0-alpha1)
+> * Shader Options almost working (1.0.0-alpha1)
+> * Entity shadows seem to be working (1.0.0-alpha1)
+> * Move glint fix to Mixin (1.0.0-alpha1)
+> * Rework mouse handling for ShaderPackConfig (1.0.0-alpha1)
+> * Stop centering shader options vertically (1.0.0-alpha1)
+> * Angelica pbr (https://github.com/GTNewHorizons/Angelica/pull/31) (1.0.0-alpha1)
+> * Only use Sodium light pipeline if useSeparateAo is on Sodium pipeline is still very buggy, so isolate it to Iris-only for now (1.0.0-alpha1)
+> * Fix region sorting for translucency (1.0.0-alpha1)
+> * Open Shaderpack now works on Linux (1.0.0-alpha1)
+> * RM Shadersmod (1.0.0-alpha1)
+> * Initial iris scrollbar clicking (1.0.0-alpha1)
+> * Punt unsupported ISBRHs to the main thread (1.0.0-alpha1)
+> * Delete the ISBRH lock, shouldn't be needed anymore (1.0.0-alpha1)
+> * Render GT blocks on main thread (1.0.0-alpha1)
+> * Require CCC 1.2.0+ (1.0.0-alpha1)
+> * Depend on CCC 1.2 (1.0.0-alpha1)
+> * Fix TESRs not being tracked for blocks rendered on main thread (1.0.0-alpha1)
+> * Cut down number of runtime dependencies, enable CoreTweaks in dev by default (1.0.0-alpha1)
+> * Add modern F3 background (1.0.0-alpha1)
+> * Pull over some hodgepodge mixins (1.0.0-alpha1)
+>
+>## New Contributors
+> * @mts2200 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/325 (1.0.0-alpha30)
+> * @Ginsway made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/261 (1.0.0-alpha26)
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/252 (1.0.0-alpha19)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/211 (1.0.0-alpha16)
+> * @Pistonight made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/212 (1.0.0-alpha16)
+> * @Cyl18 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/183 (1.0.0-alpha15)
+> * @tth05 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/187 (1.0.0-alpha15)
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/124 (1.0.0-alpha13)
+> * @ZakBerkelaar made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/132 (1.0.0-alpha13)
+> * @FalsePattern made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/94 (1.0.0-alpha11)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/105 (1.0.0-alpha11)
+> * @embeddedt made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/55 (1.0.0-alpha5)
+>
+
+# Updated AngerMod (0.6.3@Side.BOTH --> 0.7.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AngerMod/compare/0.6.2...0.7.1
+>## What's Changed
+> * [bs] update dependencies and readme by @bombcar in https://github.com/GTNewHorizons/AngerMod/pull/6 (0.7.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/AngerMod/pull/5 (0.7.0)
+> * WTFPL by @bombcar in https://github.com/GTNewHorizons/AngerMod/pull/4 (0.6.3)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/AngerMod/pull/4 (0.6.3)
+>
+
+# Updated AppleCore (3.2.12@Side.BOTH --> 3.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AppleCore/compare/3.2.11...3.3.0
+>## What's Changed
+> * `@Local` / `@Share` / `@ModifyExpressionValue` by @glowredman in https://github.com/GTNewHorizons/AppleCore/pull/28 (3.2.12)
+>
+
+# Updated Applied-Energistics-2-Unofficial (rv3-beta-292-GTNH@Side.BOTH --> rv3-beta-331-GTNH-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-291-GTNH...rv3-beta-331-GTNH-pre
+>## What's Changed
+> * Enable off-thread rendering with Angelica by @Cleptomania in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/478 (rv3-beta-330-GTNH-pre)
+> * Add Dynamic Font Size for Terminals by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/474 (rv3-beta-328-GTNH)
+> * fix overflow during serialization by @Glease in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/477 (rv3-beta-328-GTNH)
+> * Format numbers by @Connor-Colenso in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/475 (rv3-beta-328-GTNH)
+> * Add % share of crafting components extracted from storage by @claimg in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/469 (rv3-beta-327-GTNH)
+> * Fix fluid p2p refusing to push fluids when there are too many outputs by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/473 (rv3-beta-327-GTNH)
+> * Add all missing recipes and rename recipes folder to GTNHRecipe by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/468 (rv3-beta-326-GTNH)
+> * Fix a logical issue with Pattern Terminal buttons. by @wohaopa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/464 (rv3-beta-325-GTNH)
+> * Add sorting options to the crafting plan screen by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/463 (rv3-beta-325-GTNH)
+> * Fix crash from wrong compare by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/465 (rv3-beta-325-GTNH)
+> * Buff interface throughput via transvector by @claimg in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/456 (rv3-beta-324-GTNH)
+> * RecipeLoader: fix & cleanup  by @Pilzinsel64 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/461 (rv3-beta-324-GTNH)
+> * Remove `compareTo` Override in AECommand by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/462 (rv3-beta-322-GTNH)
+> * Show Fluid Pattern Coord in CraftingCPU Gui by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/458 (rv3-beta-319-GTNH)
+> * Fix path for easy mode recipes by @Pilzinsel64 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/460 (rv3-beta-319-GTNH)
+> * Add variable doubling functionality to the Pattern terminal by @wohaopa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/455 (rv3-beta-317-GTNH)
+> * Removing the need for removal of Applied Energistics-2 recipes in NewHorizonsCoreMod by @Cardinalstars in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/453 (rv3-beta-316-GTNH-pre)
+> * Removing the need for removal of Applied Energistics-2 recipes in NewHorizonsCoreMod by @Cardinalstars in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/453 (rv3-beta-315-GTNH)
+> * Add Version Pattern by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/454 (rv3-beta-313-GTNH)
+> * Use simple array list instead of two maps to manage inventories in NetworkInventoryHandler by @tth05 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/451 (rv3-beta-312-GTNH)
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/452 (rv3-beta-311-GTNH-pre)
+> * Fix incompatibility with rv2-api depending jars like IC2C by @eigenraven in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/450 (rv3-beta-311-GTNH-pre)
+> * Fix incompatibility with rv2-api depending jars like IC2C by @eigenraven in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/450 (rv3-beta-310-GTNH)
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/452 (rv3-beta-309-GTNH)
+> * hold the shift to stop sort items by @asdflj in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/449 (rv3-beta-307-GTNH)
+> * ME IO Port Tweaks by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/448 (rv3-beta-306-GTNH)
+> * add tooltips for block container cell,update zh_CN by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/447 (rv3-beta-305-GTNH)
+> * Backport Interface Locking Mode by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * Do not form `CraftingCPU` if storage overflow detected by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/443 (rv3-beta-304-GTNH)
+> * Add Priority Card by @TechnicianLP in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/446 (rv3-beta-304-GTNH)
+> * Respect setting `preserveSearchBar` in `InterfaceTerminal` by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/445 (rv3-beta-304-GTNH)
+> * Support to show p2p outputs in interface terminal by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/441 (rv3-beta-303-GTNH)
+> * Correct stackSize z order by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/440 (rv3-beta-302-GTNH)
+> * Respect interface settings by @Laiff in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/439 (rv3-beta-301-GTNH)
+> * Fix crash when opening disconnected interface terminal by @Caedis in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
+>
+>## New Contributors
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/478 (rv3-beta-330-GTNH-pre)
+> * @claimg made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/456 (rv3-beta-324-GTNH)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/448 (rv3-beta-306-GTNH)
+> * @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/437 (rv3-beta-304-GTNH)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/438 (rv3-beta-300-GTNH)
+>
+
+# Updated ArchitectureCraft (1.8.6@Side.BOTH --> 1.9.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ArchitectureCraft/compare/1.8.5...1.9.4
+>## What's Changed
+> * Pre Angelica Compat - Reorganization by @mitchej123 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/15 (1.9.4)
+> * Thread saftey by @mitchej123 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/16 (1.9.4)
+> * Cleanup by @mitchej123 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/14 (1.9.3)
+> * Add localization for Shapes and ShapePages and add UI color customization by @Flanisch in https://github.com/GTNewHorizons/ArchitectureCraft/pull/13 (1.9.2)
+> * Added a new shape category (glow), and new graphic category registered with item IDs that are different from other shpes and come with light value. This allows for better visual effects by modifying the configuration settings based on the item ID in the presence of shader by @ImgoodWK in https://github.com/GTNewHorizons/ArchitectureCraft/pull/12 (1.9.2)
+> * Add localization for Shapes and ShapePages and add UI color customization by @Flanisch in https://github.com/GTNewHorizons/ArchitectureCraft/pull/13 (1.9.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ArchitectureCraft/pull/11 (1.9.0)
+> * Fixes to Shift Click Behavior in the Sawbench by @Superfrogman98 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/10 (1.8.6)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/14 (1.9.3)
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/13 (1.9.2)
+> * @ImgoodWK made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/12 (1.9.2)
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/13 (1.9.1)
+> * @Superfrogman98 made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/10 (1.8.6)
+>
+
+# Updated AsieLib (0.5.4@Side.BOTH --> 0.5.5@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/AsieLib/compare/0.5.3...0.5.5
+>## What's Changed
+> * Don't use ObjectInputStream by @miozune in https://github.com/GTNewHorizons/AsieLib/pull/3 (0.5.4)
+>
+>## New Contributors
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/AsieLib/pull/3 (0.5.4)
+>
+
+# Updated Avaritia (1.46@Side.BOTH --> 1.49@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.45...1.49
+>## What's Changed
+> * Add alpha channels to masks. by @UltraHex in https://github.com/GTNewHorizons/Avaritia/pull/38 (1.48)
+> * Fix Universium rendering with OptiFine by @UltraHex in https://github.com/GTNewHorizons/Avaritia/pull/37 (1.47)
+> * Workaround for world time error in shader by @catcatcatcaty in https://github.com/GTNewHorizons/Avaritia/pull/36 (1.46)
+>
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/37 (1.47)
+> * @catcatcatcaty made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/36 (1.46)
+>
+
+# Updated Avaritiaddons (1.6.0-GTNH@Side.BOTH --> 1.7.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Avaritiaddons/compare/1.5.5-GTNH...1.7.0-GTNH
+>## What's Changed
+> * NEI Bookmark Pulling feature for compressed chests by @Nilau1998 in https://github.com/GTNewHorizons/Avaritiaddons/pull/10 (1.6.0-GTNH)
+>
+>## New Contributors
+> * @Nilau1998 made their first contribution in https://github.com/GTNewHorizons/Avaritiaddons/pull/10 (1.6.0-GTNH)
+>
+
+# Updated Battlegear2 (1.3.0@Side.BOTH --> 1.3.5@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2/compare/1.2.7...1.3.5
+>## What's Changed
+> * Change to mixin to disable blockpick when in creative and battle mode by @Caedis in https://github.com/GTNewHorizons/Battlegear2/pull/24 (1.3.5)
+> * use MixinClassWriter directly instead of creating a copy of that class by @Alexdoru in https://github.com/GTNewHorizons/Battlegear2/pull/23 (1.3.3)
+> * Small Cleanup by @glowredman in https://github.com/GTNewHorizons/Battlegear2/pull/22 (1.3.0)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Battlegear2/pull/24 (1.3.5)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/Battlegear2/pull/22 (1.3.0)
+>
+
+# Updated Baubles (1.0.3@Side.BOTH --> 1.0.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Baubles/compare/1.0.2...1.0.4
+>## What's Changed
+> * Minor fixes by @Gordon-Frohman in https://github.com/GTNewHorizons/Baubles/pull/6 (1.0.3)
+>
+
+# Updated BeeBetterAtBees-GTNH (0.3.1-GTNH@Side.CLIENT --> 0.4.0-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/BeeBetterAtBees-GTNH/compare/0.3.1-GTNH...0.4.0-GTNH
+>## What's Changed
+> * Create README.md by @Dream-Master in https://github.com/GTNewHorizons/BeeBetterAtBees/pull/1 (0.3.1-GTNH)
+> * Update README.md by @Dream-Master in https://github.com/GTNewHorizons/BeeBetterAtBees/pull/2 (0.3.1-GTNH)
+> * Update Buildscript and fill README by @glowredman in https://github.com/GTNewHorizons/BeeBetterAtBees/pull/3 (0.3.1-GTNH)
+>
+>## New Contributors
+> * @Dream-Master made their first contribution in https://github.com/GTNewHorizons/BeeBetterAtBees/pull/1 (0.3.1-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/BeeBetterAtBees/pull/3 (0.3.1-GTNH)
+>
+
+# Updated BetterAchievements (0.1.3@Side.CLIENT --> 0.2.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterAchievements/compare/0.1.2...0.2.0
+>## What's Changed
+> * Create zh_CN.lang by @Ginsway in https://github.com/GTNewHorizons/BetterAchievements/pull/3 (0.1.3)
+>
+
+# Updated BetterBuildersWands (0.10.1-GTNH@Side.BOTH --> 0.11.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterBuildersWands/compare/0.10.0-GTNH...0.11.0-GTNH
+>## What's Changed
+> * Suppress missing version warning by @bombcar in https://github.com/GTNewHorizons/BetterBuildersWands/pull/10 (0.10.1-GTNH)
+>
+
+# Updated BetterCrashes (1.3.5-GTNH@Side.CLIENT --> 1.4.0-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterCrashes/compare/1.3.4-GTNH...1.4.0-GTNH
+>## What's Changed
+> * Remove spurious MCVersion warning from FML loading logs by @bombcar in https://github.com/GTNewHorizons/BetterCrashes/pull/15 (1.3.5-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/BetterCrashes/pull/15 (1.3.5-GTNH)
+>
+
+# Updated BetterLoadingScreen (1.5.3-GTNH@Side.CLIENT --> 1.6.0-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterLoadingScreen/compare/1.5.2-GTNH...1.6.0-GTNH
+>## What's Changed
+> * Remove a no-longer needed debug Throwable by @bombcar in https://github.com/GTNewHorizons/BetterLoadingScreen/pull/22 (1.5.3-GTNH)
+>
+
+# Updated BetterP2P (1.1.20@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterP2P/compare/1.1.15...1.2.0
+>## What's Changed
+> * [bs] update buildscripts for jankins by @bombcar in https://github.com/GTNewHorizons/BetterP2P/pull/33 (1.2.0)
+> * Rewrite Net code, add dual interface compat by @firenoo in https://github.com/GTNewHorizons/BetterP2P/pull/32 (1.1.20)
+>
+
+# Updated BetterQuesting (3.4.7-GTNH@Side.BOTH --> 3.5.8-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.4.6-GTNH...3.5.8-GTNH
+>## What's Changed
+> * Add Formatting Macros for Quest Descriptions by @Steelux8 in https://github.com/GTNewHorizons/BetterQuesting/pull/122 (3.5.8-GTNH)
+> * NEI text color customization with lang file by @Flanisch in https://github.com/GTNewHorizons/BetterQuesting/pull/131 (3.5.6-GTNH)
+> * unrestrictAdminCommands Config Option by @bertcardinaels in https://github.com/GTNewHorizons/BetterQuesting/pull/128 (3.5.4-GTNH)
+> * Fix quest completion notification causing black screen by @Lyfts in https://github.com/GTNewHorizons/BetterQuesting/pull/126 (3.5.3-GTNH)
+> * [bs] update buildscript by @bombcar in https://github.com/GTNewHorizons/BetterQuesting/pull/129 (3.5.3-GTNH)
+> * fix inserting into empty tag list not setting tag type by @Glease in https://github.com/GTNewHorizons/BetterQuesting/pull/125 (3.5.1-GTNH)
+> * Fix quest notif hud rendering issue by @Alexdoru in https://github.com/GTNewHorizons/BetterQuesting/pull/124 (3.5.0-GTNH)
+>
+>## New Contributors
+> * @Steelux8 made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/122 (3.5.8-GTNH)
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/131 (3.5.6-GTNH)
+> * @bertcardinaels made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/128 (3.5.4-GTNH)
+>
+
+# Updated Binnie (2.2.4@Side.BOTH --> 2.3.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.2.3...2.3.3
+>## What's Changed
+> * No more restriction by player name by @mitchej123 in https://github.com/GTNewHorizons/Binnie/pull/44 (2.3.3)
+> * fix no tooltip in some Gui by @ghostflyby in https://github.com/GTNewHorizons/Binnie/pull/42 (2.3.2)
+> * Fix double layers tooltip with NEI by @ghostflyby in https://github.com/GTNewHorizons/Binnie/pull/41 (2.2.4)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/44 (2.3.3)
+>
+
+# Updated BlockLimiter (0.55@Side.BOTH --> 0.6.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BlockLimiter/commits/0.55@Side.BOTH...0.6.0@Side.BOTH
+
+# Updated BlockRenderer6343 (1.0.6@Side.BOTH --> 1.1.6@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.0.5...1.1.6
+>## What's Changed
+> * Add localization and ability to change UI colors by @Flanisch in https://github.com/GTNewHorizons/BlockRenderer6343/pull/11 (1.1.6)
+> * Add nei overlay button[?] to multiblock preview by @Cyl18 in https://github.com/GTNewHorizons/BlockRenderer6343/pull/13 (1.1.6)
+> * Support mouse middle button in multiblock structure preview by @Cyl18 in https://github.com/GTNewHorizons/BlockRenderer6343/pull/12 (1.1.6)
+> * Remove hard dep on Bartworks by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/10 (1.1.3)
+> * Fix crash when switching tier after projecting a multiblock by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/9 (1.1.1)
+> * Fix preview not showing if multi isn't ISurvivalConstructable by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+>
+>## New Contributors
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/11 (1.1.6)
+> * @Cyl18 made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/13 (1.1.6)
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/8 (1.1.0)
+>
+
+# Updated BloodArsenal (1.2.11@Side.BOTH --> 1.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.2.10...1.3.1
+>## What's Changed
+> * [bs] update buildscripts for jankins by @bombcar in https://github.com/GTNewHorizons/BloodArsenal/pull/22 (1.3.1)
+> * Buff daggers and replace wildcard imports by @Quetz4l in https://github.com/GTNewHorizons/BloodArsenal/pull/20 (1.3.0)
+> * Upload ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/BloodArsenal/pull/21 (1.3.0)
+> * Spotless apply for branch fix-nei-tooltip-crash for #18 by @github-actions in https://github.com/GTNewHorizons/BloodArsenal/pull/19 (1.2.11)
+> * Fix Ritual Stone NEI tooltip crash by @wlhlm in https://github.com/GTNewHorizons/BloodArsenal/pull/18 (1.2.11)
+>
+>## New Contributors
+> * @Quetz4l made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/20 (1.3.0)
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/21 (1.3.0)
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/19 (1.2.11)
+> * @wlhlm made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/18 (1.2.11)
+>
+
+# Updated BloodMagic (1.4.3@Side.BOTH --> 1.5.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.4.2...1.5.1
+>## What's Changed
+> * Ritual of Gaia's Transformation fixes. by @AbdielKavash in https://github.com/GTNewHorizons/BloodMagic/pull/49 (1.5.1)
+> * Fix tooltip for meteor NEI by @miozune in https://github.com/GTNewHorizons/BloodMagic/pull/48 (1.4.3)
+>
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/49 (1.5.1)
+>
+
+# Updated Botania (1.10.3-GTNH@Side.BOTH --> 1.10.10-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.10.2-GTNH...1.10.10-GTNH
+>## What's Changed
+> * Ring of Loki Client/Server fix by @LewisSaber in https://github.com/GTNewHorizons/Botania/pull/45 (1.10.10-GTNH)
+> * The ring of ikoL awakens! by @LewisSaber in https://github.com/GTNewHorizons/Botania/pull/43 (1.10.9-GTNH)
+> * Reduce number of item copies.  by @mitchej123 in https://github.com/GTNewHorizons/Botania/pull/44 (1.10.7-GTNH)
+> * Keep a cache of time uniforms instead of querying them every time by @mitchej123 in https://github.com/GTNewHorizons/Botania/pull/41 (1.10.6-GTNH)
+> * Clarify some misunderstanding by @LewisSaber in https://github.com/GTNewHorizons/Botania/pull/39 (1.10.5-GTNH)
+> * backports VazkiiMods/Botania#2721 by @Glease in https://github.com/GTNewHorizons/Botania/pull/35 (1.10.3-GTNH)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Botania/pull/41 (1.10.6-GTNH)
+>
+
+# Updated Botanic-horizons (1.0.19-GTNH@Side.BOTH --> 1.1.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.0.18-GTNH...1.1.2-GTNH
+>## What's Changed
+> * Fix minor code quality issues in #27 by @combusterf in https://github.com/GTNewHorizons/Botanic-horizons/pull/28 (1.1.1-GTNH)
+> * fix basalt chiselgroup name by @chochem in https://github.com/GTNewHorizons/Botanic-horizons/pull/27 (1.1.0-GTNH)
+>
+
+# Updated BrandonsCore (1.0.0.13-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BrandonsCore/compare/1.0.0.13-GTNH...1.1.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/BrandonsCore/pull/2 (1.1.0-GTNH)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/BrandonsCore/pull/1 (1.0.0.13-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/BrandonsCore/pull/2 (1.1.0-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/BrandonsCore/pull/1 (1.0.0.13-GTNH)
+>
+
+# Updated BugTorch (1.2.12-GTNH@Side.BOTH --> 1.2.13-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BugTorch/compare/1.2.11-GTNH...1.2.13-GTNH
+>## What's Changed
+> * move config load to early enough to hear the Squid by @bombcar in https://github.com/GTNewHorizons/BugTorch/pull/21 (1.2.12-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/BugTorch/pull/21 (1.2.12-GTNH)
+>
+
+# Updated BuildCraft (7.1.38@Side.BOTH --> 7.1.39@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BuildCraft/compare/7.1.37...7.1.39
+>## What's Changed
+> * Fix No Gates Recipes with dreamcraft, really by @ghostflyby in https://github.com/GTNewHorizons/BuildCraft/pull/19 (7.1.38)
+>
+
+# Updated BuildCraftCompat (7.1.16@Side.BOTH --> 7.1.17@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BuildCraftCompat/compare/7.1.15...7.1.17
+>## What's Changed
+> * update bs+deps by @Dream-Master in https://github.com/GTNewHorizons/BuildCraftCompat/pull/11 (7.1.16)
+>
+>## New Contributors
+> * @Dream-Master made their first contribution in https://github.com/GTNewHorizons/BuildCraftCompat/pull/11 (7.1.16)
+>
+
+# Updated BuildCraftOilTweak (1.0.4@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/BuildCraftOilTweak/compare/1.0.4...1.1.0
+>## What's Changed
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/BuildCraftOilTweak/pull/1 (1.0.4)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/BuildCraftOilTweak/pull/1 (1.0.4)
+>
+
+# Updated CarpentersBlocks (3.4.1-GTNH@Side.BOTH --> 3.5.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CarpentersBlocks/compare/3.4.0-GTNH...3.5.1-GTNH
+>## What's Changed
+> * Use IBlockAccess instead of worldObj by @mitchej123 in https://github.com/GTNewHorizons/CarpentersBlocks/pull/4 (3.5.0-GTNH)
+> * Fixes a world memory leak by @Pelotrio in https://github.com/GTNewHorizons/CarpentersBlocks/pull/3 (3.4.1-GTNH)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/CarpentersBlocks/pull/4 (3.5.0-GTNH)
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/CarpentersBlocks/pull/3 (3.4.1-GTNH)
+>
+
+# Updated Catwalks-2 (2.1.4-GTNH@Side.BOTH --> 2.2.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Catwalks-2/compare/2.1.3-GTNH...2.2.1-GTNH
+>## What's Changed
+> * Mostly thread safe by @mitchej123 in https://github.com/GTNewHorizons/Catwalks-2/pull/9 (2.2.1-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Catwalks-2/pull/8 (2.2.0-GTNH)
+> * Clarify Permissions by @glowredman in https://github.com/GTNewHorizons/Catwalks-2/pull/7 (2.1.4-GTNH)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Catwalks-2/pull/9 (2.2.1-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/Catwalks-2/pull/7 (2.1.4-GTNH)
+>
+
+# Updated Chisel (2.12.3-GTNH@Side.BOTH --> 2.14.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.12.2-GTNH...2.14.1-GTNH
+>## What's Changed
+> * Null saftey by @mitchej123 in https://github.com/GTNewHorizons/Chisel/pull/45 (2.14.1-GTNH)
+> * Fixes an NPE thrown with NEI by @mitchej123 in https://github.com/GTNewHorizons/Chisel/pull/46 (2.14.1-GTNH)
+> * Angelica compat by @mitchej123 in https://github.com/GTNewHorizons/Chisel/pull/43 (2.14.0-GTNH)
+> * Update to use CCC/L 1.2.0 for multi-thread compat by @bombcar in https://github.com/GTNewHorizons/Chisel/pull/42 (2.13.4-GTNH)
+> * Another Obsidian harvestlevel fix by @chochem in https://github.com/GTNewHorizons/Chisel/pull/41 (2.13.2-GTNH)
+> * Add vanilla mining levels by @Caedis in https://github.com/GTNewHorizons/Chisel/pull/39 (2.13.1-GTNH)
+> * fix mining levels with iguana by @chochem in https://github.com/GTNewHorizons/Chisel/pull/40 (2.13.1-GTNH)
+> * Don't relocate CTMLib by @makamys in https://github.com/GTNewHorizons/Chisel/pull/37 (2.13.0-GTNH)
+> * Make Forge Multipart dependency optional by @makamys in https://github.com/GTNewHorizons/Chisel/pull/38 (2.13.0-GTNH)
+> * Fix more memory leaks by @Pelotrio in https://github.com/GTNewHorizons/Chisel/pull/36 (2.12.3-GTNH)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/43 (2.14.0-GTNH)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/39 (2.13.1-GTNH)
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/37 (2.13.0-GTNH)
+>
+
+# Updated ChiselTones (1.0.4-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ChiselTones/compare/1.0.4-GTNH...1.1.0-GTNH
+>## What's Changed
+> * [bs] update buildscripts for jankins by @bombcar in https://github.com/GTNewHorizons/ChiselTones/pull/2 (1.1.0-GTNH)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/ChiselTones/pull/1 (1.0.4-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ChiselTones/pull/2 (1.1.0-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/ChiselTones/pull/1 (1.0.4-GTNH)
+>
+
+# Updated CodeChickenCore (1.1.13@Side.BOTH --> 1.2.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenCore/compare/1.1.11...1.2.1
+>## What's Changed
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenCore/pull/12 (1.2.0)
+> * update BS and spotlessApply by @bombcar in https://github.com/GTNewHorizons/CodeChickenCore/pull/11 (1.1.13)
+>
+
+# Updated CodeChickenLib (1.1.10@Side.BOTH --> 1.2.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenLib/compare/1.1.9...1.2.1
+>## What's Changed
+> * Angelica Support - Static -> Instanced by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenLib/pull/14 (1.2.0)
+> * Fix incomplete patch for item id packet by @miozune in https://github.com/GTNewHorizons/CodeChickenLib/pull/13 (1.1.10)
+>
+
+# Updated Computronics (1.7.1-GTNH@Side.BOTH --> 1.7.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Computronics/compare/1.7.0-GTNH...1.7.2-GTNH
+>## What's Changed
+> * Stop OC from executing getInfoData in its worker thread by @MeiTianyou in https://github.com/GTNewHorizons/Computronics/pull/21 (1.7.1-GTNH)
+>
+>## New Contributors
+> * @MeiTianyou made their first contribution in https://github.com/GTNewHorizons/Computronics/pull/21 (1.7.1-GTNH)
+>
+
+# Updated Controlling (2.0.1@Side.CLIENT --> 2.0.2@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/Controlling/compare/2.0.0.0...2.0.2
+
+# Updated CookingForBlockheads (1.2.16-GTNH@Side.BOTH --> 1.3.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.2.15-GTNH...1.3.3-GTNH
+>## What's Changed
+> * Fix handling of container item by @miozune in https://github.com/GTNewHorizons/CookingForBlockheads/pull/42 (1.3.3-GTNH)
+> * update buildscript and dependencies by @bombcar in https://github.com/GTNewHorizons/CookingForBlockheads/pull/41 (1.3.0-GTNH)
+> * Fix: TileEntity migration from old savefiles by @eigenraven in https://github.com/GTNewHorizons/CookingForBlockheads/pull/40 (1.2.16-GTNH)
+>
+>## New Contributors
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/CookingForBlockheads/pull/40 (1.2.16-GTNH)
+>
+
+# Updated CraftTweaker (3.2.13@Side.BOTH --> 3.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CraftTweaker/compare/3.2.12...3.3.1
+>## What's Changed
+> * Fix Implementation of `MCServer$MCCommand.compareTo(Object)` by @glowredman in https://github.com/GTNewHorizons/CraftTweaker/pull/17 (3.3.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/CraftTweaker/pull/16 (3.3.0)
+> * Fix missing ModOnly-IC2 annotations by @eigenraven in https://github.com/GTNewHorizons/CraftTweaker/pull/14 (3.2.13)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/CraftTweaker/pull/17 (3.3.1)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/CraftTweaker/pull/16 (3.3.0)
+>
+
+# Updated CreativeCore (1.3.31-GTNH@Side.BOTH --> 1.4.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CreativeCore/compare/1.3.30-GTNH...1.4.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/CreativeCore/pull/6 (1.4.0-GTNH)
+> * Log what class received by @miozune in https://github.com/GTNewHorizons/CreativeCore/pull/5 (1.3.31-GTNH)
+>
+
+# Updated CropLoadCore (0.1.10@Side.BOTH --> 0.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/CropLoadCore/compare/0.1.9...0.2.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/CropLoadCore/pull/9 (0.2.0)
+> * weeds by @bombcar in https://github.com/GTNewHorizons/CropLoadCore/pull/8 (0.1.10)
+>
+
+# Updated Crops-plus-plus (1.5.12@Side.BOTH --> 1.6.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.5.11...1.6.3
+>## What's Changed
+> * Just textures by @Minepolz320 in https://github.com/GTNewHorizons/Crops-plus-plus/pull/65 (1.6.3)
+> * Fix Potions by @glowredman in https://github.com/GTNewHorizons/Crops-plus-plus/pull/63 (1.6.1)
+> * Fix incorrect cactus drop. by @C0bra5 in https://github.com/GTNewHorizons/Crops-plus-plus/pull/64 (1.6.0)
+> * add back Space Flower uum recipe by @Dream-Master in https://github.com/GTNewHorizons/Crops-plus-plus/pull/62 (1.5.12)
+>
+
+# Updated Custom-Main-Menu (1.10.3@Side.CLIENT --> 1.11.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/Custom-Main-Menu/compare/1.10.2...1.11.0
+>## What's Changed
+> * only build strings when necessary instead of every frame by @charagarlnad in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/4 (1.10.3)
+> * update bs by @Caedis in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/5 (1.10.3)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/5 (1.10.3)
+>
+
+# Updated Default-Configs (1.1.6@Side.CLIENT --> 1.2.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/Default-Configs/compare/1.1.5...1.2.0
+>## What's Changed
+> * don't use SKIP_DEBUG by @Alexdoru in https://github.com/GTNewHorizons/Default-Configs/pull/6 (1.1.6)
+>
+
+# Updated DefaultServerList (1.4.0@Side.CLIENT --> 1.5.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.1.2...1.5.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/DefaultServerList/pull/6 (1.5.0)
+> * Add CF/Modrinth Project Details by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/4 (1.4.0)
+> * Get Changelog as temp file by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/5 (1.4.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/DefaultServerList/pull/6 (1.5.0)
+>
+
+# Updated DefaultWorldGenerator (0.2@Side.CLIENT --> 0.3.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/DefaultWorldGenerator/compare/0.1-b13...0.3.0
+>## What's Changed
+> * [bs] fix Jenkins by @bombcar in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/3 (0.3.0)
+> * Fix bug that resets superflat configuration by @firenoo in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/1 (0.2)
+> * Switch to GTNH ForgeGradle by @miozune in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/2 (0.2)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/3 (0.3.0)
+> * @firenoo made their first contribution in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/1 (0.2)
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/2 (0.2)
+>
+
+# Updated DetravScannerMod (1.7.2@Side.BOTH --> 1.8.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/DetravScannerMod/compare/1.7.1...1.8.0
+
+# Updated Draconic-Evolution (1.2.1-GTNH@Side.BOTH --> 1.3.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.2.0-GTNH...1.3.2-GTNH
+>## What's Changed
+> * Fix wrong encode in manual translation in manual-zh_CN.json by @ghostflyby in https://github.com/GTNewHorizons/Draconic-Evolution/pull/45 (1.3.2-GTNH)
+> * Update manual-ru_RU.json by @kamenskyi in https://github.com/GTNewHorizons/Draconic-Evolution/pull/44 (1.3.1-GTNH)
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Draconic-Evolution/pull/43 (1.2.2-GTNH)
+> * Fix memory leak by @Pelotrio in https://github.com/GTNewHorizons/Draconic-Evolution/pull/42 (1.2.1-GTNH)
+>
+>## New Contributors
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/45 (1.3.2-GTNH)
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/43 (1.2.2-GTNH)
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/42 (1.2.1-GTNH)
+>
+
+# Updated DummyCore (1.17.0@Side.BOTH --> 1.18.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/DummyCore/compare/1.14...1.18.0
+>## What's Changed
+> * Spotless apply for branch hide-menu-switch-btn for #3 by @github-actions in https://github.com/GTNewHorizons/DummyCore/pull/4 (1.17.0)
+> * Hide Menu Switch Button (configurable) by @glowredman in https://github.com/GTNewHorizons/DummyCore/pull/3 (1.17.0)
+>
+>## New Contributors
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/DummyCore/pull/4 (1.17.0)
+>
+
+# Updated DuraDisplay (1.1.7@Side.CLIENT --> 1.2.2@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/DuraDisplay/compare/1.1.5...1.2.2
+>## What's Changed
+> * Convert to foreach over stream by @Caedis in https://github.com/GTNewHorizons/DuraDisplay/pull/16 (1.2.2)
+> * Add WoodenBrickForm to gadgets by @Caedis in https://github.com/GTNewHorizons/DuraDisplay/pull/14 (1.1.7)
+>
+
+# Updated Electro-Magic-Tools (1.3.8@Side.BOTH --> 1.4.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.3.7...1.4.4
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/72 (1.4.4)
+> * Make boots apply speed boost to all directions by @S4mpsa in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/71 (1.4.4)
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/72 (1.4.3-pre)
+> * Convert EMT to RA2 by @chochem in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/70 (1.4.1)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/72 (1.4.4)
+> * @S4mpsa made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/71 (1.4.4)
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/72 (1.4.3-pre)
+>
+
+# Updated EnderCore (0.2.19@Side.BOTH --> 0.4.5@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderCore/compare/0.2.17...0.4.5
+>## What's Changed
+> * Fix NEI optional again by @miozune in https://github.com/GTNewHorizons/EnderCore/pull/23 (0.4.5)
+> * prepare for vertex array usage by @boubou19 in https://github.com/GTNewHorizons/EnderCore/pull/21 (0.4.4)
+> * Fix package name for NEI optional annotation by @miozune in https://github.com/GTNewHorizons/EnderCore/pull/20 (0.4.2)
+> * Thread Safety by @mitchej123 in https://github.com/GTNewHorizons/EnderCore/pull/19 (0.4.1)
+> * Fix for limited item filter by @Tu0rp in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
+> * Get Empty container with drainFluidContainer by @ghostflyby in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.19)
+>
+>## New Contributors
+> * @boubou19 made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/21 (0.4.4)
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/18 (0.3.0)
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/17 (0.2.19)
+>
+
+# Updated EnderIO (2.5.9@Side.BOTH --> 2.7.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.5.8...2.7.1
+>## What's Changed
+> * Actually optional by @mitchej123 in https://github.com/GTNewHorizons/EnderIO/pull/154 (2.7.1)
+> * Angelica compat by @mitchej123 in https://github.com/GTNewHorizons/EnderIO/pull/153 (2.7.0)
+> * Some null checks to avoid outright crashing with Angelica,  by @mitchej123 in https://github.com/GTNewHorizons/EnderIO/pull/150 (2.6.7)
+> * Fix Dark Steel Anvils in WAILA by @connor135246 in https://github.com/GTNewHorizons/EnderIO/pull/152 (2.6.7)
+> * Fix protection mode of travel anchor by @Pilzinsel64 in https://github.com/GTNewHorizons/EnderIO/pull/149 (2.6.6)
+> * Fix Anchor always rendering bug by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/148 (2.6.4)
+> * add required hard dependency on cofhlib by @bombcar in https://github.com/GTNewHorizons/EnderIO/pull/146 (2.6.3)
+> * exchange existing Item filter icon from newer Ender io version by @Dream-Master in https://github.com/GTNewHorizons/EnderIO/pull/145 (2.6.2)
+> * Staff Of Traveling Keybind Feature by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/144 (2.6.1)
+> * Limited Item Filter by @Tu0rp in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * Add Config to allow servers to re-enable support for client-side 'hacks' like Staff Of Traveling Keybind mod. by @TheUnderTaker11 in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
+>
+>## New Contributors
+> * @connor135246 made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/152 (2.6.7)
+> * @Tu0rp made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/143 (2.6.0)
+> * @TheUnderTaker11 made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/142 (2.6.0)
+>
+
+# Updated EnderStorage (1.4.12@Side.BOTH --> 1.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderStorage/compare/1.4.11...1.5.0
+>## What's Changed
+> * Fix for CCC/L 1.2.0 threadsafe rendering by @bombcar in https://github.com/GTNewHorizons/EnderStorage/pull/10 (1.5.0)
+>
+
+# Updated EnderZoo (1.0.23@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnderZoo/compare/1.0.22...1.1.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/EnderZoo/pull/8 (1.1.0)
+> * update for maven by @bombcar in https://github.com/GTNewHorizons/EnderZoo/pull/7 (1.0.23)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/EnderZoo/pull/7 (1.0.23)
+>
+
+# Updated EnhancedLootBags (1.1.0@Side.BOTH --> 1.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.0.8...1.1.1
+>## What's Changed
+> * Add NEI handler by @miozune in https://github.com/GTNewHorizons/EnhancedLootBags/pull/8 (1.1.0)
+>
+
+# Updated Eternal-Singularity (1.1.2@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Eternal-Singularity/compare/1.1.1...1.2.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Eternal-Singularity/pull/9 (1.2.0)
+>
+
+# Updated FindIt (1.1.0@Side.BOTH --> 1.2.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/FindIt/compare/1.0.11...1.2.3
+>## What's Changed
+> * Search Fluids; Changed Block Highlighter by @slprime in https://github.com/GTNewHorizons/FindIt/pull/13 (1.2.3)
+> * [QoF] Adding feature that automatically rotate player view when find a item/tile entity successfully by @gitboy14 in https://github.com/GTNewHorizons/FindIt/pull/12 (1.2.2)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/FindIt/pull/11 (1.2.0)
+> * Remove hard-dependency on GregTech by @glowredman in https://github.com/GTNewHorizons/FindIt/pull/10 (1.1.0)
+>
+>## New Contributors
+> * @gitboy14 made their first contribution in https://github.com/GTNewHorizons/FindIt/pull/12 (1.2.2)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/FindIt/pull/10 (1.1.0)
+>
+
+# Updated FloodLights (1.2.9@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.2.9...1.3.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/FloodLights/pull/2 (1.3.0)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/FloodLights/pull/1 (1.2.9)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/FloodLights/pull/2 (1.3.0)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/FloodLights/pull/1 (1.2.9)
+>
+
+# Updated ForbiddenMagic (0.6.7-GTNH@Side.BOTH --> 0.7.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForbiddenMagic/compare/0.6.6-GTNH...0.7.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ForbiddenMagic/pull/13 (0.7.0-GTNH)
+> * Fixing dependencies by @Cardinalstars in https://github.com/GTNewHorizons/ForbiddenMagic/pull/12 (0.6.7-GTNH)
+>
+>## New Contributors
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/ForbiddenMagic/pull/12 (0.6.7-GTNH)
+>
+
+# Updated ForestryMC (4.7.1@Side.BOTH --> 4.8.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.7.0...4.8.4
+>## What's Changed
+> * Allocation reduction by @mitchej123 in https://github.com/GTNewHorizons/ForestryMC/pull/62 (4.8.4)
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/ForestryMC/pull/61 (4.8.2)
+> * Remove Version Checker by @glowredman in https://github.com/GTNewHorizons/ForestryMC/pull/60 (4.8.1)
+> * Add name for butterflyGE by @bombcar in https://github.com/GTNewHorizons/ForestryMC/pull/59 (4.8.0)
+>
+
+# Updated ForgeMultipart (1.4.1@Side.BOTH --> 1.4.8@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.4.0...1.4.8
+>## What's Changed
+> * Add `version` and `name` Properties to `@Mod` annotations by @glowredman in https://github.com/GTNewHorizons/ForgeMultipart/pull/23 (1.4.8)
+> * Re-add dependencies.info corrected, update BS etc  by @bombcar in https://github.com/GTNewHorizons/ForgeMultipart/pull/22 (1.4.7)
+> * update to support 1.2.0 CCL - needs work to be more performant by @bombcar in https://github.com/GTNewHorizons/ForgeMultipart/pull/21 (1.4.5)
+> * Fix ButtonPart.java crashes, tweaks to allow mods to hook it by @Roadhog360 in https://github.com/GTNewHorizons/ForgeMultipart/pull/20 (1.4.3)
+> * Potential Fix to some FMP stuff relating to Redstone parts not connecting to bottoms of machines. by @Cardinalstars in https://github.com/GTNewHorizons/ForgeMultipart/pull/18 (1.4.1)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/ForgeMultipart/pull/23 (1.4.8)
+> * @Roadhog360 made their first contribution in https://github.com/GTNewHorizons/ForgeMultipart/pull/20 (1.4.3)
+>
+
+# Updated ForgeRelocation (0.0.3@Side.BOTH --> 0.1.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.0.2...0.1.2
+>## What's Changed
+> * Try a thread safe client map, and guard against a null world by @mitchej123 in https://github.com/GTNewHorizons/ForgeRelocation/pull/6 (0.1.2)
+> * Update Version Replacement by @glowredman in https://github.com/GTNewHorizons/ForgeRelocation/pull/5 (0.1.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ForgeRelocation/pull/3 (0.1.0)
+> * Fix Mod not being recognized by @glowredman in https://github.com/GTNewHorizons/ForgeRelocation/pull/2 (0.0.3)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/ForgeRelocation/pull/6 (0.1.2)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ForgeRelocation/pull/3 (0.1.0)
+>
+
+# Updated ForgeRelocationFMP (0.0.4@Side.BOTH --> 0.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocationFMP/compare/0.0.3...0.1.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ForgeRelocationFMP/pull/2 (0.1.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ForgeRelocationFMP/pull/2 (0.1.0)
+>
+
+# Updated Forgelin (1.9.7-GTNH@Side.BOTH --> 1.9.9-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Forgelin/compare/1.9.6-GTNH...1.9.9-GTNH
+>## What's Changed
+> * Add Annotations to Coremod Class by @glowredman in https://github.com/GTNewHorizons/Forgelin/pull/9 (1.9.9-GTNH)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/Forgelin/pull/9 (1.9.9-GTNH)
+>
+
+# Updated GT5-Unofficial (5.09.44.110@Side.BOTH --> 5.09.45.85-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.44.109...5.09.45.85-pre
+>## What's Changed
+> * Add SC steam to turbine tooltip by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2515 (5.09.45.85-pre)
+> * Add cable info to WAILA by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2518 (5.09.45.85-pre)
+> * Add SC steam to turbine tooltip by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2515 (5.09.45.84)
+> * Add cable info to WAILA by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2518 (5.09.45.84)
+> * Self-adaption GUI height for DC by @RealSilverMoon in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2517 (5.09.45.82)
+> * Fix recipe check by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2516 (5.09.45.82)
+> * Add locale code support for lang manager by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2511 (5.09.45.79)
+> * Change error voltage to MAX+ by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2513 (5.09.45.79)
+> * Make some changes to OC Calculator to add functionality to be used by God Forge by @BlueWeabo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2508 (5.09.45.77)
+> * Capitalize TiC recipe categories by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2512 (5.09.45.77)
+> * Hide semi fluid NEI by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2514 (5.09.45.77)
+> * Add recipe categories for TiC integration by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2510 (5.09.45.76)
+> * Update dependencies. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2509 (5.09.45.75)
+> * Add SearchBar for Drone centre by @RealSilverMoon in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2498 (5.09.45.74)
+> * fix LHE preview by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2505 (5.09.45.74)
+> * fix maintenance hatch not showing correct rotation after reload by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2506 (5.09.45.74)
+> * Migrate assline to extended power base by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2503 (5.09.45.73)
+> * Update dependencies. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2497 (5.09.45.72)
+> * Fix Cleanroom logic with an LV energy hatch by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2499 (5.09.45.72)
+> * Adjust mk5 plasmas to account for 1 lost OC by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2504 (5.09.45.72)
+> * Fix water bottle fluid exploit by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2494 (5.09.45.71)
+> * Change over wireless teams to use SP teams by @BlueWeabo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2493 (5.09.45.70)
+> * Allow interacting with machines instantly upon placing by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2496 (5.09.45.69-pre)
+> * Assign force fuel value in GT by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2495 (5.09.45.69-pre)
+> * Allow interacting with machines instantly upon placing by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2496 (5.09.45.68)
+> * Assign force fuel value in GT by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2495 (5.09.45.68)
+> * Wireless Activity Detector; Power On/Off Activity Detector by @slprime in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2490 (5.09.45.64)
+> * Add batch mode to nano forge by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2492 (5.09.45.64)
+> * Add godforge materials by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2491 (5.09.45.63)
+> * Fix MuTE Casings Not Forming Correctly by @Steelux8 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2489 (5.09.45.62)
+> * Fix dimethylbenzene names by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2488 (5.09.45.61)
+> * Refactor Packet Handling for MuTEs by @BlueWeabo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2485 (5.09.45.60)
+> * Fix EBF tooltip by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2487 (5.09.45.59)
+> * fix divide by zero exception by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2486 (5.09.45.58)
+> * Add hatch tier tooltips for several ME hatches by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2482 (5.09.45.57)
+> * fix PCB by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2483 (5.09.45.57)
+> * Fix charcoal igniter tooltip by @RitumsC in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2484 (5.09.45.57)
+> * Add Drone Centre by @RealSilverMoon in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2412 (5.09.45.57)
+> * Add more checking to prevent chaining to different blocks by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2481 (5.09.45.57)
+> * Fix wrench raytrace crash on server by @ghostflyby in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2477 (5.09.45.53)
+> * Change chain spraying to only chain to the same kind of item by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2478 (5.09.45.53)
+> * GT Tool Fixes and ore balance config by @Minepolz320 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2453 (5.09.45.53)
+> * Fix DTPF not consuming energy by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2479 (5.09.45.53)
+> * Fix nano forge nei preview by @Lyfts in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2475 (5.09.45.53)
+> * Fix wrench raytrace crash on server by @ghostflyby in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2477 (5.09.45.52-pre)
+> * Fix large fluid cell Rendering  by @UltraHex in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2476 (5.09.45.50)
+> * Fix oc calculator by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2474 (5.09.45.48-pre)
+> * Fix oc calculator by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2474 (5.09.45.47)
+> * Add Banded Iron EBF processing. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2472 (5.09.45.46-pre)
+> * EBF tooltip by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2471 (5.09.45.46-pre)
+> * Add Banded Iron EBF processing. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2472 (5.09.45.45)
+> * EBF tooltip by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2471 (5.09.45.45)
+> * Remove all usages of GT_ItemStack2 as Set/Map keys by using fastutil by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2465 (5.09.45.43)
+> * Fix PA voltage check by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2470 (5.09.45.43)
+> * Fix massfab by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2468 (5.09.45.41)
+> * Fix void protection of distillation tower with ME output hatches by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2467 (5.09.45.41)
+> * Fix PCB coolant hatch by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2469 (5.09.45.41)
+> * Move the check for item/fluid outputs length in ParallelHelper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2441 (5.09.45.39-pre)
+> * Canola is a better name than Rapeseed (id is staying the same) by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2443 (5.09.45.39-pre)
+> * GT wrench capabilities for AE2 blocks and others by @ghostflyby in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2395 (5.09.45.39-pre)
+> * Rework item renderers by @UltraHex in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2424 (5.09.45.39-pre)
+> * Allow tools to break stuff with a lower harvest level by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2435 (5.09.45.39-pre)
+> * Removed muffler from Vacuum Freezer. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2439 (5.09.45.39-pre)
+> * Fix CRIB ignoring new pattern when it was a replacement in place of a diffrent pattern by @kuba6000 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2442 (5.09.45.39-pre)
+> * Add config to block underground dirt and gravel gen by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2444 (5.09.45.39-pre)
+> * Convert tiny Ash dusts for various EBF recipes to chances by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2445 (5.09.45.39-pre)
+> * Add valid covers bit mask to CoverableTileEntity by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2446 (5.09.45.39-pre)
+> * Reintroduce CRIB name to WAILA by @kstvr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2447 (5.09.45.39-pre)
+> * Make stocking bus/hatch autopull slot refresh timer adjustable by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2448 (5.09.45.39-pre)
+> * Late review of #2446 Optional changes by @leagris in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2449 (5.09.45.39-pre)
+> * PCB coolant hatch supports ME hatch by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2451 (5.09.45.39-pre)
+> * Cleanup a bit the GT_Achievements class by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2450 (5.09.45.39-pre)
+> * Add missing null check in pump cover by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2452 (5.09.45.39-pre)
+> * Fix Fluid Solidifying by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2461 (5.09.45.39-pre)
+> * fix steam turbine NPE by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2457 (5.09.45.39-pre)
+> * Add new properties to parallel helper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2454 (5.09.45.39-pre)
+> * Add back tool mode to wrench by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2462 (5.09.45.39-pre)
+> * Feature/movefluid by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2459 (5.09.45.39-pre)
+> * Fix wire cutter/soldering iron click on gt machines by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2463 (5.09.45.39-pre)
+> * Change Canola back to Rape seed by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2464 (5.09.45.39-pre)
+> * Fix wire cutter/soldering iron click on gt machines by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2463 (5.09.45.38)
+> * Change Canola back to Rape seed by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2464 (5.09.45.38)
+> * Fix Fluid Solidifying by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2461 (5.09.45.36)
+> * fix steam turbine NPE by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2457 (5.09.45.36)
+> * Add new properties to parallel helper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2454 (5.09.45.36)
+> * Add back tool mode to wrench by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2462 (5.09.45.36)
+> * Feature/movefluid by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2459 (5.09.45.36)
+> * Spotless apply for branch feature/movefluid for #2455 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2456 (5.09.45.35-pre)
+> * merge similar code into new utility function moveFluid by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2455 (5.09.45.35-pre)
+> * Spotless apply for branch feature/movefluid for #2459 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2460 (5.09.45.35-pre)
+> * Fix Fluid Solidifying by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2461 (5.09.45.35-pre)
+> * fix steam turbine NPE by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2457 (5.09.45.35-pre)
+> * Spotless apply for branch feature/movefluid for #2455 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2456 (5.09.45.34-pre)
+> * merge similar code into new utility function moveFluid by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2455 (5.09.45.34-pre)
+> * Spotless apply for branch feature/movefluid for #2455 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2458 (5.09.45.34-pre)
+> * Spotless apply for branch feature/movefluid for #2455 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2456 (5.09.45.33-pre)
+> * Add missing null check in pump cover by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2452 (5.09.45.32-pre)
+> * Add missing null check in pump cover by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2452 (5.09.45.31)
+> * Late review of #2446 Optional changes by @leagris in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2449 (5.09.45.29)
+> * PCB coolant hatch supports ME hatch by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2451 (5.09.45.29)
+> * Cleanup a bit the GT_Achievements class by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2450 (5.09.45.29)
+> * GT wrench capabilities for AE2 blocks and others by @ghostflyby in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2395 (5.09.45.27)
+> * Rework item renderers by @UltraHex in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2424 (5.09.45.27)
+> * Allow tools to break stuff with a lower harvest level by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2435 (5.09.45.27)
+> * Removed muffler from Vacuum Freezer. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2439 (5.09.45.27)
+> * Fix CRIB ignoring new pattern when it was a replacement in place of a diffrent pattern by @kuba6000 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2442 (5.09.45.27)
+> * Add config to block underground dirt and gravel gen by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2444 (5.09.45.27)
+> * Convert tiny Ash dusts for various EBF recipes to chances by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2445 (5.09.45.27)
+> * Add valid covers bit mask to CoverableTileEntity by @tth05 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2446 (5.09.45.27)
+> * Reintroduce CRIB name to WAILA by @kstvr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2447 (5.09.45.27)
+> * Make stocking bus/hatch autopull slot refresh timer adjustable by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2448 (5.09.45.27)
+> * Move the check for item/fluid outputs length in ParallelHelper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2441 (5.09.45.26-pre)
+> * Canola is a better name than Rapeseed (id is staying the same) by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2443 (5.09.45.26-pre)
+> * Move the check for item/fluid outputs length in ParallelHelper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2441 (5.09.45.25)
+> * Canola is a better name than Rapeseed (id is staying the same) by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2443 (5.09.45.25)
+> * Merge MuTEMaster into Master by @BlueWeabo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2431 (5.09.45.23)
+> * Update ParallelHelper by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2427 (5.09.45.22)
+> * fix GT oredict log by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2436 (5.09.45.19)
+> * Revert forge hammer recipe for plastic/rubber by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2437 (5.09.45.19)
+> * Let gt ignore more oredicts by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2438 (5.09.45.19)
+> * Improve shader compatibility for tool overlay by @UltraHex in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2425 (5.09.45.15)
+> * Cleanup deprecation by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2416 (5.09.45.14)
+> * Add connect/block to line of fluid pipes by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2407 (5.09.45.13)
+> * Add default impl to getToolTypeName and add a null check by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2430 (5.09.45.12)
+> * Fix muffler hatch numbers by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2433 (5.09.45.12)
+> * Fix RecipeMapBackend not indexing Alternate ItemStacks by @TechnicianLP in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2434 (5.09.45.12)
+> * Prevent loading hook on server by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2428 (5.09.45.11)
+> * Add modes to tools by @LewisSaber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2423 (5.09.45.10)
+> * Change to the overclock logic of Fusion Reactor by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2422 (5.09.45.09)
+> * Restore the ability to use multiple ME hatches for one machine by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2426 (5.09.45.08)
+> * Rework the UI of singleblock pumps. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2420 (5.09.45.07)
+> * Allow a soldering iron to use soldering material from an IC2 Tool Box. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2421 (5.09.45.06)
+> * Fix z ordering for stack size in `Stocking Input` by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2419 (5.09.45.05)
+> * Fix CRIB adding null item inputs by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2415 (5.09.45.04)
+> * update deps by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2414 (5.09.45.04)
+> * Allow Oil Cracker to use an Input Bus for programmed circuit automation. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2413 (5.09.45.03)
+> * fix dep by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2405 (5.09.45.02)
+> * Fix logic with old OC calculation code by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2408 (5.09.45.02)
+> * Don't rotate block if player is sneaking by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2409 (5.09.45.02)
+> * Fix basic machine OC not using amperage by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2410 (5.09.45.02)
+> * update deps by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2411 (5.09.45.02)
+> * Fix: Show CRIB always in interface terminal by @Laiff in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2404 (5.09.45.01)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2403 (5.09.45.00)
+> * make quantum tanks not slow you down for later game players by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2393 (5.09.45.00)
+> * more detailed progress info in waila tooltip for basic machines by @iamblackornot in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2401 (5.09.45.00)
+>
+>## New Contributors
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2490 (5.09.45.64)
+> * @RitumsC made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2484 (5.09.45.57)
+> * @RealSilverMoon made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2412 (5.09.45.57)
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2425 (5.09.45.15)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2413 (5.09.45.03)
+> * @Laiff made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2404 (5.09.45.01)
+>
+
+# Updated GTNEIOrePlugin (1.1.3@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNEIOrePlugin/compare/1.1.1...1.2.0
+>## What's Changed
+> * T9 Planets + new Textures by @glowredman in https://github.com/GTNewHorizons/GTNEIOrePlugin/pull/35 (1.1.3)
+>
+
+# Updated GTNH-Intergalactic (1.2.9@Side.BOTH --> 1.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Intergalactic/compare/1.2.8...1.3.1
+>## What's Changed
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTNH-Intergalactic/pull/56 (1.3.0)
+>
+
+# Updated GTNH-Lanthanides (0.11.9@Side.BOTH --> 0.12.11@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-Lanthanides/compare/0.11.8...0.12.11
+>## What's Changed
+> * Migrate dissolution tank & digester to processingLogic by @GDCloudstrike in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/86 (0.12.11)
+> * Remove muffler from Dissolution Tank. by @AbdielKavash in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/85 (0.12.7)
+> * Clean-up acetylhydrazine and unsymmetricaldimethylhydrazine by @chochem in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/83 (0.12.6)
+> * Fix Digester & Dissolution Tank NEI previews by @Lyfts in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/84 (0.12.6)
+> * fix recipe mistake about RarestEarthResidue by @Nxer in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/82 (0.12.4)
+> * add Digester and DissolutionTank survival construct method by @Nxer in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/81 (0.12.3)
+> * fix simple washer Pure Dust of Cerium and Samarium issue by @Nxer in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/80 (0.12.2)
+> * EuO chem balance fix by @chochem in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/79 (0.12.1)
+> * Remove now unneeded IMC handler by @miozune in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/78 (0.12.0)
+>
+>## New Contributors
+> * @GDCloudstrike made their first contribution in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/86 (0.12.11)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/85 (0.12.7)
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/GTNH-Lanthanides/pull/84 (0.12.6)
+>
+
+# Updated GTNH-TC-Wands (1.3.1@Side.BOTH --> 1.4.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-TC-Wands/compare/1.3.0...1.4.0
+>## What's Changed
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/17 (1.4.0)
+> * Fix missing/broken Staff & Wand recipes by @TechnicianLP in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/16 (1.3.1)
+>
+>## New Contributors
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/17 (1.4.0)
+> * @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/16 (1.3.1)
+>
+
+# Updated GTNHLib (0.0.13@Side.BOTH --> 0.2.10@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.0.12...0.2.10
+>## What's Changed
+> * Add a compare-and-swap reference wrapper and collections by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/36 (0.2.10)
+> * Add a dummy RFB plugin to allow classes to be used earlier in the loading process by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/37 (0.2.10)
+> * Remove required parameter to Config annotation by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/34 (0.2.9)
+> * Add filename and subdirectory overrides to Config class annotation by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/33 (0.2.8)
+> * Localization fix by @AbdielKavash in https://github.com/GTNewHorizons/GTNHLib/pull/32 (0.2.7)
+> * Added MathExpressionParser. by @AbdielKavash in https://github.com/GTNewHorizons/GTNHLib/pull/31 (0.2.6)
+> * Fix lower bound of `@Config.RangeFloat` by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/30 (0.2.5)
+> * Shadow JOML by @Cleptomania in https://github.com/GTNewHorizons/GTNHLib/pull/29 (0.2.4)
+> * Be more accepting; also stop using Tags for modid/name by @mitchej123 in https://github.com/GTNewHorizons/GTNHLib/pull/27 (0.2.3)
+> * Handle multiple config classes by @mitchej123 in https://github.com/GTNewHorizons/GTNHLib/pull/25 (0.2.2)
+> * Add fastutil to dependencies.gradle by @tth05 in https://github.com/GTNewHorizons/GTNHLib/pull/24 (0.2.1)
+> * Port configs from Angelica/ArchaicFix by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/23 (0.2.0)
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/GTNHLib/pull/22 (0.1.0)
+>
+>## New Contributors
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/31 (0.2.6)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/29 (0.2.4)
+> * @tth05 made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/24 (0.2.1)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/23 (0.2.0)
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/22 (0.1.0)
+>
+
+# Updated GTplusplus (1.10.54@Side.BOTH --> 1.11.31@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GTplusplus/compare/1.10.53...1.11.31
+>## What's Changed
+> * Tree Growth Simulator can now harvest leaves and fruits, using appropriate tools. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/839 (1.11.31)
+> * Fix several recipes by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/842 (1.11.31)
+> * Let remainingFlow become 125% of realOptFlow, rather than raw optimal… by @koiNoCirculation in https://github.com/GTNewHorizons/GTplusplus/pull/841 (1.11.29)
+> * add new solidifier hatches for industrial multi machine by @Quetz4l in https://github.com/GTNewHorizons/GTplusplus/pull/810 (1.11.28)
+> * Advanced implosion supports buffer by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/838 (1.11.27)
+> * Add alternate recipes for neptunium and fermium plasma by @GDCloudstrike in https://github.com/GTNewHorizons/GTplusplus/pull/837 (1.11.26)
+> * Force properties should be in GT by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/836 (1.11.25)
+> * fix QFT tooltips by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/835 (1.11.24)
+> * Enable perfect OC on the matter fabrication CPU recycler mode by @GDCloudstrike in https://github.com/GTNewHorizons/GTplusplus/pull/834 (1.11.23)
+> * Fix crop harvester stopping after 1 crop if harvesting is off by @Lyfts in https://github.com/GTNewHorizons/GTplusplus/pull/833 (1.11.23)
+> * GT++ Fish Catcher Water Block Check by @bitonality in https://github.com/GTNewHorizons/GTplusplus/pull/818 (1.11.23)
+> * Fix LFTR by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/832 (1.11.22)
+> * 4/4 overclocks for IsaMill and FlotationCell again by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/831 (1.11.22)
+> * Fix QFT by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/829 (1.11.19)
+> * Fix broken gas in 2 recipes by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/830 (1.11.19)
+> * Fix Multi-Machine Manual Recipe by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/826 (1.11.18)
+> * Fix chemical plant by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/821 (1.11.18)
+> * Fix XL Heat Exchanger description by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/828 (1.11.18)
+> * Fix void protection of dangote by @HoleFish in https://github.com/GTNewHorizons/GTplusplus/pull/827 (1.11.18)
+> * Advanced Muffler Hatch improvements by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/825 (1.11.17)
+> * Enable batch mode on mega ABS by @GDCloudstrike in https://github.com/GTNewHorizons/GTplusplus/pull/824 (1.11.15)
+> * Thermal Boiler rework by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/815 (1.11.14-pre)
+> * Fix Soldering Iron unable to set redstone output strength. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/819 (1.11.14-pre)
+> * Add a tooltip for QFT Fluid mode by @BlueWeabo in https://github.com/GTNewHorizons/GTplusplus/pull/820 (1.11.14-pre)
+> * Fix mutegt dep by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/823 (1.11.14-pre)
+> * Fix mutegt dep by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/823 (1.11.13)
+> * Add a tooltip for QFT Fluid mode by @BlueWeabo in https://github.com/GTNewHorizons/GTplusplus/pull/820 (1.11.11)
+> * Fix Soldering Iron unable to set redstone output strength. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/819 (1.11.10)
+> * Thermal Boiler rework by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/815 (1.11.9)
+> * Fix chisel busses by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/817 (1.11.4)
+> * Add centrifuge recipes for dual and quad depleted fuel rods. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/816 (1.11.3)
+> * Allow emptying of fluid tanks by placing them anywhere in the crafting grid. by @AbdielKavash in https://github.com/GTNewHorizons/GTplusplus/pull/814 (1.11.2)
+> * fix dep problems by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/811 (1.11.1)
+> * Fix superbus UHV recipes and localization by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/812 (1.11.1)
+> * Clarify whether item or fluid output is full by @miozune in https://github.com/GTNewHorizons/GTplusplus/pull/809 (1.11.0)
+> * Fix asymmetry in the qft multiblock by @Pelotrio in https://github.com/GTNewHorizons/GTplusplus/pull/802 (1.11.0)
+> * Fix superbus UHV recipes and localization for stable branch by @chochem in https://github.com/GTNewHorizons/GTplusplus/pull/813 (1.10.55)
+>
+>## New Contributors
+> * @koiNoCirculation made their first contribution in https://github.com/GTNewHorizons/GTplusplus/pull/841 (1.11.29)
+> * @bitonality made their first contribution in https://github.com/GTNewHorizons/GTplusplus/pull/818 (1.11.23)
+> * @HoleFish made their first contribution in https://github.com/GTNewHorizons/GTplusplus/pull/821 (1.11.18)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/GTplusplus/pull/814 (1.11.2)
+>
+
+# Updated Gadomancy (1.2.0@Side.BOTH --> 1.3.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.1.3...1.3.2
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Gadomancy/pull/28 (1.3.1)
+> * Fixed dupe bug with Essentia condenser by @OneEyeMaker in https://github.com/GTNewHorizons/Gadomancy/pull/27 (1.3.0)
+> * Eldrich recipes by @EnderProyects in https://github.com/GTNewHorizons/Gadomancy/pull/25 (1.2.0)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/28 (1.3.1)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/27 (1.3.0)
+> * @EnderProyects made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/25 (1.2.0)
+>
+
+# Updated GalacticGregGT5 (1.0.10@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GalacticGregGT5/compare/1.0.9...1.1.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/GalacticGregGT5/pull/17 (1.1.0)
+> * Fix oregen pattern for space veins by @chochem in https://github.com/GTNewHorizons/GalacticGregGT5/pull/16 (1.0.10)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/GalacticGregGT5/pull/17 (1.1.0)
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/GalacticGregGT5/pull/16 (1.0.10)
+>
+
+# Updated Galacticraft (3.0.75-GTNH@Side.BOTH --> 3.1.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.0.74-GTNH...3.1.3-GTNH
+>## What's Changed
+> * Register planet biomes on preinit by @Caedis in https://github.com/GTNewHorizons/Galacticraft/pull/84 (3.1.3-GTNH)
+> * Update GC lang files to more modern usage for MobInfo by @bombcar in https://github.com/GTNewHorizons/Galacticraft/pull/83 (3.1.1-GTNH)
+> * Fix backwards-compatibility with other Galacticraft addons (e. g. ExtraPlanets) by @PT400C in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/84 (3.1.3-GTNH)
+> * @PT400C made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/82 (3.1.0-GTNH)
+>
+
+# Updated Galaxy-Space-GTNH (1.2.15-GTNH@Side.BOTH --> 1.1.82-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/commits/1.2.15-GTNH@Side.BOTH...1.1.82-GTNH@Side.BOTH
+
+# Updated GigaGramFab (0.3.9@Side.BOTH --> 0.3.14@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GigaGramFab/compare/0.3.8...0.3.14
+>## What's Changed
+> * Add AAL batch mode by @NotAPenguin0 in https://github.com/GTNewHorizons/GigaGramFab/pull/32 (0.3.14)
+> * Fix fluidtank capacity of tool casting machines  by @HoleFish in https://github.com/GTNewHorizons/GigaGramFab/pull/33 (0.3.12)
+> * reset cache more often and sort hatches less often by @Glease in https://github.com/GTNewHorizons/GigaGramFab/pull/31 (0.3.11)
+> * Removed Debug Recipe of Pump by @LewisSaber in https://github.com/GTNewHorizons/GigaGramFab/pull/27 (0.3.9)
+>
+>## New Contributors
+> * @NotAPenguin0 made their first contribution in https://github.com/GTNewHorizons/GigaGramFab/pull/32 (0.3.14)
+> * @HoleFish made their first contribution in https://github.com/GTNewHorizons/GigaGramFab/pull/33 (0.3.12)
+> * @LewisSaber made their first contribution in https://github.com/GTNewHorizons/GigaGramFab/pull/27 (0.3.9)
+>
+
+# Updated GoodGenerator (0.7.17@Side.BOTH --> 0.8.13-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/GoodGenerator/compare/0.7.16...0.8.13-pre
+>## What's Changed
+> * Fix compact fusion tierskip, wrong OC and scanner info by @GDCloudstrike in https://github.com/GTNewHorizons/GoodGenerator/pull/238 (0.8.12)
+> * Fix naq nugget recipe by @chochem in https://github.com/GTNewHorizons/GoodGenerator/pull/237 (0.8.11)
+> * Allow compact fusions to accept any amount of energy from energy hatches by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/235 (0.8.10)
+> * Fix UCFE fuel consumption by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/234 (0.8.10)
+> * Compact fusion structure fixes by @Lyfts in https://github.com/GTNewHorizons/GoodGenerator/pull/236 (0.8.10)
+> * Convert GG to RA2 by @chochem in https://github.com/GTNewHorizons/GoodGenerator/pull/232 (0.8.6)
+> * [bs] update dependencies by @bombcar in https://github.com/GTNewHorizons/GoodGenerator/pull/231 (0.8.4)
+> * Enable batch mode for component assemblyline by @GDCloudstrike in https://github.com/GTNewHorizons/GoodGenerator/pull/233 (0.8.4)
+> * Compact Fusions support buffer by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/230 (0.8.4)
+> * fix simple washer recipe issue about Nq Process by @Nxer in https://github.com/GTNewHorizons/GoodGenerator/pull/229 (0.8.2)
+> * Cleanup isValidMetaTileEntity again by @miozune in https://github.com/GTNewHorizons/GoodGenerator/pull/227 (0.8.0)
+> * Batch mode for compact fusion MKIV-V by @HoleFish in https://github.com/GTNewHorizons/GoodGenerator/pull/223 (0.8.0)
+>
+>## New Contributors
+> * @Nxer made their first contribution in https://github.com/GTNewHorizons/GoodGenerator/pull/229 (0.8.2)
+>
+
+# Updated Gravitation-Suite-Neo (1.0.20@Side.BOTH --> 1.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.0.19...1.1.1
+>## What's Changed
+> * Fix Vajra unintended behaviour by @Lyfts in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/17 (1.1.1)
+> * Fixed breaking unbreakable stuff by @Cardinalstars in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/16 (1.1.1)
+>
+>## New Contributors
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/16 (1.1.1)
+>
+
+# Updated Hardcore-Ender-Expansion (1.9.7-GTNH@Side.BOTH --> 1.10.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.9.5-GTNH...1.10.1-GTNH
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/16 (1.10.1-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/17 (1.10.0-GTNH)
+> * Switch the reflection wrapper to java 17-compatible gtnhlib by @eigenraven in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/15 (1.9.7-GTNH)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/16 (1.10.1-GTNH)
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/15 (1.9.7-GTNH)
+>
+
+# Updated HelpFixer (1.1.0@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/HelpFixer/compare/1.1.0...1.2.0
+>## What's Changed
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/HelpFixer/pull/1 (1.1.0)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/HelpFixer/pull/1 (1.1.0)
+>
+
+# Updated Hodgepodge (2.3.41@Side.BOTH --> 2.4.34@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.3.40...2.4.34
+>## What's Changed
+> * Add lighter water tweak by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/339 (2.4.34)
+> * Add int dimension id to end of login packet by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/341 (2.4.33)
+> * Add color to Fast Block Placing noficiation text by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/338 (2.4.32)
+> * implement a better hashing method for WorldCoordinates by @boubou19 in https://github.com/GTNewHorizons/Hodgepodge/pull/340 (2.4.32)
+> * Apply fasterRemoveAll to Entities too by @wahfl2 in https://github.com/GTNewHorizons/Hodgepodge/pull/337 (2.4.31)
+> * Add config option to manually configure autosave interval by @Pelotrio in https://github.com/GTNewHorizons/Hodgepodge/pull/323 (2.4.30)
+> * Organize Config Fields by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/333 (2.4.29)
+> * Update dependencies. by @AbdielKavash in https://github.com/GTNewHorizons/Hodgepodge/pull/334 (2.4.28)
+> * Spotless apply for branch feat/updateSyncConfig for #330 by @github-actions in https://github.com/GTNewHorizons/Hodgepodge/pull/331 (2.4.27-pre)
+> * Spotless apply for branch autosave-interval for #323 by @github-actions in https://github.com/GTNewHorizons/Hodgepodge/pull/324 (2.4.26-pre)
+> * Update README.md + required gtnhlib by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/328 (2.4.25)
+> * Fix Class Name Typo in Forge by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/326 (2.4.24)
+> * Small Cleanup by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/325 (2.4.24)
+> * Remove 2MB chunk size limit by @eigenraven in https://github.com/GTNewHorizons/Hodgepodge/pull/320 (2.4.23)
+> * Fast Block Placing by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/322 (2.4.23)
+> * Preserve order of layered quads in terrain pass 1 by @UltraHex in https://github.com/GTNewHorizons/Hodgepodge/pull/317 (2.4.23)
+> * Improve mipmap formula by @UltraHex in https://github.com/GTNewHorizons/Hodgepodge/pull/310 (2.4.23)
+> * Use gtnhlib config by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/313 (2.4.19)
+> * Significantly reduce the number of ChunkCoordIntPair allocations by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/312 (2.4.19)
+> * Maybe better retainAll implementation by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/319 (2.4.19)
+> * Use gtnhlib config by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/313 (2.4.16-pre)
+> * Spotless apply for branch reduce-allocations for #312 by @github-actions in https://github.com/GTNewHorizons/Hodgepodge/pull/315 (2.4.16-pre)
+> * Spotless apply for branch reduce-allocations for #312 by @github-actions in https://github.com/GTNewHorizons/Hodgepodge/pull/316 (2.4.16-pre)
+> * update bs+deps by @Dream-Master in https://github.com/GTNewHorizons/Hodgepodge/pull/309 (2.4.12)
+> * Fix some Mipmapping bugs by @UltraHex in https://github.com/GTNewHorizons/Hodgepodge/pull/305 (2.4.12)
+> * Modern Pick Block Behavior by @bearsdotzone in https://github.com/GTNewHorizons/Hodgepodge/pull/307 (2.4.12)
+> * Thermal Dynamics NASE Prevention by @DrParadox7 in https://github.com/GTNewHorizons/Hodgepodge/pull/306 (2.4.10)
+> * Revert "Fix not being able to use an enderpearl in creative mode" by @Connor-Colenso in https://github.com/GTNewHorizons/Hodgepodge/pull/303 (2.4.8)
+> * Fix not being able to use an enderpearl in creative mode by @Connor-Colenso in https://github.com/GTNewHorizons/Hodgepodge/pull/301 (2.4.7)
+> * Adjustable network nbt and packet size limits by @eigenraven in https://github.com/GTNewHorizons/Hodgepodge/pull/300 (2.4.6)
+> * Fix hopper collision by @UltraHex in https://github.com/GTNewHorizons/Hodgepodge/pull/299 (2.4.5)
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/298 (2.4.4)
+> * Angelica Compat by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/297 (2.4.3)
+> * Completely hide realms button and make mods button wider to fill the gap by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/296 (2.4.2)
+> * Add Disable Realms Button Mixin by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/294 (2.4.1)
+> * Player Skin Fetching Fix part 2 by @kumquat-ir in https://github.com/GTNewHorizons/Hodgepodge/pull/293 (2.4.0)
+>
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/339 (2.4.34)
+> * @boubou19 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/340 (2.4.32)
+> * @wahfl2 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/337 (2.4.31)
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/323 (2.4.30)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/334 (2.4.28)
+> * @bearsdotzone made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/307 (2.4.12)
+> * @Connor-Colenso made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/301 (2.4.7)
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/299 (2.4.5)
+>
+
+# Updated HoloInventory (2.3.2-GTNH@Side.BOTH --> 2.4.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.3.0-GTNH...2.4.3-GTNH
+>## What's Changed
+> * Small Cleanup by @glowredman in https://github.com/GTNewHorizons/HoloInventory/pull/41 (2.4.3-GTNH)
+> * Reenable glasses config by @makamys in https://github.com/GTNewHorizons/HoloInventory/pull/40 (2.4.2-GTNH)
+> * Fix stack number always showing '1' when renderMultiple=false by @UltraHex in https://github.com/GTNewHorizons/HoloInventory/pull/38 (2.4.0-GTNH)
+> * Make it work with shaders by @UltraHex in https://github.com/GTNewHorizons/HoloInventory/pull/39 (2.4.0-GTNH)
+> * Move GT compat by @miozune in https://github.com/GTNewHorizons/HoloInventory/pull/37 (2.3.2-GTNH)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/41 (2.4.3-GTNH)
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/40 (2.4.2-GTNH)
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/38 (2.4.0-GTNH)
+>
+
+# Updated HungerOverhaul (1.0.4-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/HungerOverhaul/compare/1.0.3-GTNH...1.1.0-GTNH
+>## What's Changed
+> * arr by @bombcar in https://github.com/GTNewHorizons/HungerOverhaul/pull/3 (1.0.4-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/HungerOverhaul/pull/3 (1.0.4-GTNH)
+>
+
+# Updated HydroEnergy (1.1.1@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.1.0...1.2.0
+>## What's Changed
+> * Cleanup isValidMetaTileEntity by @miozune in https://github.com/GTNewHorizons/HydroEnergy/pull/23 (1.1.1)
+>
+
+# Updated IFU (1.9.6@Side.BOTH --> 1.10.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/IFU/compare/1.9.5...1.10.1
+>## What's Changed
+> * Fix voiding when shift clicking item in wand whilst inventory is full by @Lyfts in https://github.com/GTNewHorizons/IFU/pull/16 (1.10.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/IFU/pull/15 (1.10.0)
+> * Prevent the Ore Finder Wand from imploding by @wlhlm in https://github.com/GTNewHorizons/IFU/pull/13 (1.9.6)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/IFU/pull/16 (1.10.1)
+> * @wlhlm made their first contribution in https://github.com/GTNewHorizons/IFU/pull/13 (1.9.6)
+>
+
+# Updated INpureCore (1.1.5-GTNH@Side.BOTH --> 1.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/INpureCore/compare/1.1.4-GTNH...1.2.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/INpureCore/pull/4 (1.2.0-GTNH)
+> * Fix script loading errors when running under java 8 by @eigenraven in https://github.com/GTNewHorizons/INpureCore/pull/3 (1.1.5-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/INpureCore/pull/4 (1.2.0-GTNH)
+>
+
+# Updated IguanaTweaksTConstruct (2.3.0@Side.BOTH --> 2.4.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/IguanaTweaksTConstruct/compare/2.2.8...2.4.1
+>## What's Changed
+> * fix buildscripts spotless and CCRenderState for jenkins by @bombcar in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/16 (2.4.1)
+> * Fix typos and improve language for tool level-ups by @chochem in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/13 (2.3.0)
+>
+>## New Contributors
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/13 (2.3.0)
+>
+
+# Updated InGame-Info-XML (2.8.5@Side.CLIENT --> 2.8.6@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/InGame-Info-XML/compare/2.8.4...2.8.6
+>## What's Changed
+> * Fix coloring issue with the FPS counter by @crimson-mist in https://github.com/GTNewHorizons/InGame-Info-XML/pull/19 (2.8.5)
+>
+>## New Contributors
+> * @crimson-mist made their first contribution in https://github.com/GTNewHorizons/InGame-Info-XML/pull/19 (2.8.5)
+>
+
+# Updated Infernal-Mobs (1.7.9-GTNH@Side.BOTH --> 1.8.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Infernal-Mobs/compare/1.7.8-GTNH...1.8.1-GTNH
+>## What's Changed
+> * Update zh_CN.lang by @NealDeal34 in https://github.com/GTNewHorizons/Infernal-Mobs/pull/14 (1.8.1-GTNH)
+> * Change access on methods and add variable getters by @kuba6000 in https://github.com/GTNewHorizons/Infernal-Mobs/pull/13 (1.7.9-GTNH)
+>
+>## New Contributors
+> * @NealDeal34 made their first contribution in https://github.com/GTNewHorizons/Infernal-Mobs/pull/14 (1.8.1-GTNH)
+> * @kuba6000 made their first contribution in https://github.com/GTNewHorizons/Infernal-Mobs/pull/13 (1.7.9-GTNH)
+>
+
+# Updated IronChestMinecarts (1.0.8@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/IronChestMinecarts/compare/1.0.7...1.1.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/IronChestMinecarts/pull/7 (1.1.0)
+> * fix deps by @bombcar in https://github.com/GTNewHorizons/IronChestMinecarts/pull/6 (1.0.8)
+>
+
+# Updated Irontanks (1.2.6@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Irontanks/compare/1.2.4...1.3.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Irontanks/pull/13 (1.3.0)
+> * buildscript by @bombcar in https://github.com/GTNewHorizons/Irontanks/pull/12 (1.2.6)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Irontanks/pull/12 (1.2.6)
+>
+
+# Updated Jabba (1.3.1@Side.BOTH --> 1.3.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.3.0...1.3.2
+>## What's Changed
+> * Update buildscript and clean repositories by @bombcar in https://github.com/GTNewHorizons/Jabba/pull/27 (1.3.1)
+>
+
+# Updated KekzTech (0.9.6@Side.BOTH --> 0.10.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/KekzTech/compare/0.9.5...0.10.0
+>## What's Changed
+> * Bs+dep update by @chochem in https://github.com/GTNewHorizons/KekzTech/pull/81 (0.9.6)
+>
+
+# Updated KubaTech (0.13.12@Side.BOTH --> 0.14.5@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/KubaTech/compare/0.13.11...0.14.5
+>## What's Changed
+> * Fix Rolled Tea Leaf recipe by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/118 (0.14.5)
+> * Fix EEC doesn't drop weapon when destroyed by @HoleFish in https://github.com/GTNewHorizons/KubaTech/pull/117 (0.14.4)
+> * Add a mode for EEC to void all enchanted and damaged outputs by @HoleFish in https://github.com/GTNewHorizons/KubaTech/pull/116 (0.14.3)
+> * Fix Soldering Iron unable to set redstone output strength for the EEC. by @AbdielKavash in https://github.com/GTNewHorizons/KubaTech/pull/115 (0.14.2)
+> * Allow the EIG and MApiary to use IC2 Distilled Water in place of regular water in the structure. by @AbdielKavash in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+> * Fix queen dupe bug in Mega Apiary by @kuba6000 in https://github.com/GTNewHorizons/KubaTech/pull/114 (0.14.1)
+> * Remove now unneeded IMC for DEFusionCrafter by @miozune in https://github.com/GTNewHorizons/KubaTech/pull/111 (0.14.0)
+>
+>## New Contributors
+> * @HoleFish made their first contribution in https://github.com/GTNewHorizons/KubaTech/pull/116 (0.14.3)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/KubaTech/pull/113 (0.14.1)
+>
+
+# Updated LittleTiles (1.2.9-GTNH@Side.BOTH --> 1.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.2.7-GTNH...1.3.0-GTNH
+>## What's Changed
+> * Fix item GUI slot blocking by @miozune in https://github.com/GTNewHorizons/LittleTiles/pull/8 (1.2.9-GTNH)
+>
+>## New Contributors
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/LittleTiles/pull/8 (1.2.9-GTNH)
+>
+
+# Updated LogisticsPipes (1.0.8-GTNH@Side.BOTH --> 1.1.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.0.7-GTNH...1.1.3-GTNH
+>## What's Changed
+> * Reenable recipes for non-GTNH environments by @ThePixelbrain in https://github.com/GTNewHorizons/LogisticsPipes/pull/32 (1.1.3-GTNH)
+> * request table gui improvement by @Glease in https://github.com/GTNewHorizons/LogisticsPipes/pull/30 (1.1.2-GTNH)
+> * add quantum chest support by @Glease in https://github.com/GTNewHorizons/LogisticsPipes/pull/29 (1.1.2-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/LogisticsPipes/pull/31 (1.1.1-GTNH-pre)
+> * fix sinking into special tank causing class cast exception by @Glease in https://github.com/GTNewHorizons/LogisticsPipes/pull/27 (1.1.0-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/LogisticsPipes/pull/31 (1.1.0-GTNH)
+> * fix sinking into special tank causing class cast exception by @Glease in https://github.com/GTNewHorizons/LogisticsPipes/pull/27 (1.0.9-GTNH-pre)
+> * Fix Logistic Pipes Storage Drawer Functionality by @krashton1 in https://github.com/GTNewHorizons/LogisticsPipes/pull/26 (1.0.8-GTNH)
+>
+>## New Contributors
+> * @ThePixelbrain made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/32 (1.1.3-GTNH)
+> * @krashton1 made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/26 (1.0.8-GTNH)
+>
+
+# Updated LootGames (2.0.8@Side.BOTH --> 2.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/LootGames/compare/2.0.6...2.1.1
+>## What's Changed
+> * Remove `compareTo` Override in ProfilingCommand by @glowredman in https://github.com/GTNewHorizons/LootGames/pull/14 (2.1.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/LootGames/pull/13 (2.1.0)
+> * Fix java12 crash by @eigenraven in https://github.com/GTNewHorizons/LootGames/pull/12 (2.0.8)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/LootGames/pull/14 (2.1.1)
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/LootGames/pull/12 (2.0.8)
+>
+
+# Updated LunatriusCore (1.1.7-GTNH@Side.BOTH --> 1.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/LunatriusCore/compare/1.1.6-GTNH...1.2.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/LunatriusCore/pull/7 (1.2.0-GTNH)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/LunatriusCore/pull/6 (1.1.7-GTNH)
+>
+>## New Contributors
+> * @Kiwi233 made their first contribution in https://github.com/GTNewHorizons/LunatriusCore/pull/6 (1.1.7-GTNH)
+>
+
+# Updated MX-Random (0.2.0@Side.BOTH --> 0.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/MX-Random/compare/0.1.6...0.3.0
+>## What's Changed
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/MX-Random/pull/7 (0.3.0)
+> * Migrate code to use ForgeDirection instead of byte by @OneEyeMaker in https://github.com/GTNewHorizons/MX-Random/pull/6 (0.2.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/MX-Random/pull/7 (0.3.0)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/MX-Random/pull/6 (0.2.0)
+>
+
+# Updated MagicBees (2.7.1-GTNH@Side.BOTH --> 2.7.14-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.7.0-GTNH...2.7.14-GTNH
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/MagicBees/pull/38 (2.7.14-GTNH)
+> * Fixed Thaumonomicon pages references by @AnrDaemon in https://github.com/GTNewHorizons/MagicBees/pull/39 (2.7.13-GTNH)
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/MagicBees/pull/35 (2.7.11-GTNH)
+> * Add Thaumic Energistics support to the Apimancers drainer by @Quantumlyy in https://github.com/GTNewHorizons/MagicBees/pull/37 (2.7.11-GTNH)
+> * Add Apimancers Drainer by @Quantumlyy in https://github.com/GTNewHorizons/MagicBees/pull/34 (2.7.9-GTNH)
+> * Add GT version checks to avoid crash with GT6 by @kappa-maintainer in https://github.com/GTNewHorizons/MagicBees/pull/36 (2.7.7-GTNH-pre)
+> * fixing the ethereal shard dupe by @Alastors in https://github.com/GTNewHorizons/MagicBees/pull/33 (2.7.1-GTNH)
+>
+>## New Contributors
+> * @AnrDaemon made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/39 (2.7.13-GTNH)
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/35 (2.7.11-GTNH)
+> * @Quantumlyy made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/34 (2.7.9-GTNH)
+> * @kappa-maintainer made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/36 (2.7.7-GTNH-pre)
+>
+
+# Updated MalisisDoors (1.14.0-GTNH@Side.BOTH --> 1.16.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/MalisisDoors/compare/1.13.8-GTNH...1.16.2-GTNH
+>## What's Changed
+> * ASM Cleanup by @Cleptomania in https://github.com/GTNewHorizons/MalisisDoors/pull/10 (1.16.2-GTNH)
+> * Memory Allocation Improvements by @Cleptomania in https://github.com/GTNewHorizons/MalisisDoors/pull/11 (1.16.2-GTNH)
+> * Merge Malisis Core directly into Malisis Doors by @Cleptomania in https://github.com/GTNewHorizons/MalisisDoors/pull/9 (1.16.0-GTNH)
+>
+>## New Contributors
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/MalisisDoors/pull/9 (1.16.0-GTNH)
+>
+
+# Updated Mantle (0.3.7@Side.BOTH --> 0.4.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Mantle/compare/0.3.6...0.4.1
+>## What's Changed
+> * Hide turn page buttons at either ends of books by @YannickMG in https://github.com/GTNewHorizons/Mantle/pull/6 (0.4.1)
+> * Split book text on a newline separator by @YannickMG in https://github.com/GTNewHorizons/Mantle/pull/7 (0.4.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Mantle/pull/5 (0.4.0)
+> * fix smeltery not being able to handle more than 256 items at a time by @Denostrov in https://github.com/GTNewHorizons/Mantle/pull/4 (0.3.7)
+>
+>## New Contributors
+> * @YannickMG made their first contribution in https://github.com/GTNewHorizons/Mantle/pull/6 (0.4.1)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Mantle/pull/5 (0.4.0)
+> * @Denostrov made their first contribution in https://github.com/GTNewHorizons/Mantle/pull/4 (0.3.7)
+>
+
+# Updated Minecraft-Backpack-Mod (2.2.12-GTNH@Side.BOTH --> 2.3.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/compare/2.2.11-GTNH...2.3.0-GTNH
+>## What's Changed
+> * [bs] fix broken repos by @bombcar in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/8 (2.3.0-GTNH)
+> * Add pl_PL.lang by @Radplay in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/7 (2.2.12-GTNH)
+>
+>## New Contributors
+> * @Radplay made their first contribution in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/7 (2.2.12-GTNH)
+>
+
+# Updated Minetweaker-Gregtech-5-Addon (2.0.5@Side.BOTH --> 2.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/compare/2.0.4...2.1.0
+
+# Updated Mobs-Info (0.1.13-GTNH@Side.BOTH --> 0.2.4-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.1.12-GTNH...0.2.4-GTNH
+
+# Updated ModTweaker (0.9.10@Side.BOTH --> 0.10.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ModTweaker/compare/0.9.9...0.10.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ModTweaker/pull/5 (0.10.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ModTweaker/pull/5 (0.10.0)
+>
+
+# Updated ModularUI (1.1.24@Side.BOTH --> 1.1.35@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ModularUI/compare/1.1.23...1.1.35
+>## What's Changed
+> * Added locale-aware formatting of numbers. by @AbdielKavash in https://github.com/GTNewHorizons/ModularUI/pull/67 (1.1.35)
+> * Added test for Chinese locale. by @AbdielKavash in https://github.com/GTNewHorizons/ModularUI/pull/68 (1.1.35)
+> * Added two convenience methods to NumericWidget. by @AbdielKavash in https://github.com/GTNewHorizons/ModularUI/pull/66 (1.1.34)
+> * Support CJKV Unified Ideographs for textField by @RealSilverMoon in https://github.com/GTNewHorizons/ModularUI/pull/65 (1.1.33)
+> * Fix NEI Slot Overlay in Bookmarks Recipe Tooltip by @slprime in https://github.com/GTNewHorizons/ModularUI/pull/64 (1.1.32)
+> * Fix NEI Slot Overlay being slightly off & not showing FindIt overlay by @slprime in https://github.com/GTNewHorizons/ModularUI/pull/63 (1.1.31)
+> * Added a numeric widget. by @AbdielKavash in https://github.com/GTNewHorizons/ModularUI/pull/62 (1.1.30)
+> * Fix build by @miozune in https://github.com/GTNewHorizons/ModularUI/pull/61 (1.1.29)
+> * Add support for scientific notation (2e3 = 2000) and suffixes like k, m, b, ... by @AbdielKavash in https://github.com/GTNewHorizons/ModularUI/pull/58 (1.1.26)
+> * Fix for NEID by @miozune in https://github.com/GTNewHorizons/ModularUI/pull/57 (1.1.24)
+>
+>## New Contributors
+> * @RealSilverMoon made their first contribution in https://github.com/GTNewHorizons/ModularUI/pull/65 (1.1.33)
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/ModularUI/pull/63 (1.1.31)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/ModularUI/pull/58 (1.1.26)
+>
+
+# Updated MouseTweaks (2.4.9-GTNH@Side.CLIENT --> 2.4.17-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/MouseTweaks/compare/2.4.8-GTNH...2.4.17-GTNH
+>## What's Changed
+> * Update gtnhlib and remove unused code by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/11 (2.4.17-GTNH)
+> * Factor in nbt when transfering items by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/10 (2.4.16-GTNH)
+> * Reset mouse wheel delta when new gui is open by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/9 (2.4.15-GTNH)
+> * Fix issues with importing old configs by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/8 (2.4.14-GTNH)
+> * Swap to GTNHLib config by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/5 (2.4.13-GTNH)
+> * Spotless apply for branch newConfig for #5 by @github-actions in https://github.com/GTNewHorizons/MouseTweaks/pull/6 (2.4.12-GTNH-pre)
+> * dev update by @Caedis in https://github.com/GTNewHorizons/MouseTweaks/pull/7 (2.4.12-GTNH-pre)
+> * Backport ScrollItemScaling and WheelScrollDirection config options by @unilock in https://github.com/GTNewHorizons/MouseTweaks/pull/4 (2.4.9-GTNH)
+>
+>## New Contributors
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/MouseTweaks/pull/6 (2.4.12-GTNH-pre)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/MouseTweaks/pull/7 (2.4.12-GTNH-pre)
+> * @unilock made their first contribution in https://github.com/GTNewHorizons/MouseTweaks/pull/4 (2.4.9-GTNH)
+>
+
+# Updated MrTJPCore (1.1.5@Side.BOTH --> 1.1.6@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/MrTJPCore/compare/1.1.4...1.1.6
+>## What's Changed
+> * Use UUIDs as keys instead of player instances in KeyTracking state map by @tth05 in https://github.com/GTNewHorizons/MrTJPCore/pull/4 (1.1.5)
+>
+>## New Contributors
+> * @tth05 made their first contribution in https://github.com/GTNewHorizons/MrTJPCore/pull/4 (1.1.5)
+>
+
+# Updated NEI-Integration (1.3.3@Side.BOTH --> 1.4.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NEI-Integration/compare/1.3.2...1.4.0
+>## What's Changed
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/NEI-Integration/pull/9 (1.4.0)
+> * Revert disabling Pam's HC integration by default by @DotJason in https://github.com/GTNewHorizons/NEI-Integration/pull/8 (1.3.3)
+>
+
+# Updated Natura (2.5.7@Side.BOTH --> 2.6.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.5.6...2.6.0
+>## What's Changed
+> * Fix missing Leaf block names in WAILA by @wlhlm in https://github.com/GTNewHorizons/Natura/pull/17 (2.5.7)
+>
+>## New Contributors
+> * @wlhlm made their first contribution in https://github.com/GTNewHorizons/Natura/pull/17 (2.5.7)
+>
+
+# Updated NaturesCompass (1.3.6-GTNH@Side.BOTH --> 1.4.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NaturesCompass/compare/1.3.5-GTNH...1.4.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/NaturesCompass/pull/6 (1.4.0-GTNH)
+> * fix biome refresh on gui click by @bjin2000 in https://github.com/GTNewHorizons/NaturesCompass/pull/4 (1.3.6-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/NaturesCompass/pull/6 (1.4.0-GTNH)
+>
+
+# Updated NetherPortalFix (1.1.2@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NetherPortalFix/compare/1.1.1...1.2.0
+>## What's Changed
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/NetherPortalFix/pull/1 (1.1.2)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/NetherPortalFix/pull/1 (1.1.2)
+>
+
+# Updated NewHorizonsCoreMod (2.2.55@Side.BOTH --> 2.3.34-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.2.54...2.3.34-pre
+>## What's Changed
+> * Fix moon buggy copy recipe and related fixes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/816 (2.3.33)
+> * Apply TiC recipe category by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/814 (2.3.33)
+> * Cache bg2 inventory field and add backwards compat to older BG2 by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/815 (2.3.33)
+> * Fix battlegear hazard check by @Ableytner in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/813 (2.3.31)
+> * Use oredict for NC Thermometer recipe by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/805 (2.3.28)
+> * Upload ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/807 (2.3.28)
+> * Fix weird looking lang keys by @kuba6000 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/812 (2.3.28)
+> * Remove lead from smeltery by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/800 (2.3.27)
+> * fix glass bottle exploit by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/801 (2.3.27)
+> * Update Tinted Glass assembler recipe by @Ableytner in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/802 (2.3.27)
+> * Add 4 missing recipes for drill head mold/shape by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/803 (2.3.27)
+> * new cuttingboard recipe by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/804 (2.3.27)
+> * Tinker's Construct manuals, Dreamcraft edition by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/797 (2.3.26)
+> * NewHorizonsCoreChanges to reflect recipe checks in Ae2 by @Cardinalstars in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/798 (2.3.26)
+> * Wooden brick form fix by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/799 (2.3.26)
+> * Updated Twilight Forest compatibility by @Gordon-Frohman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/781 (2.3.26)
+> * Add Apiamancer's Drainer recipe by @Quantumlyy in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/786 (2.3.25-pre)
+> * Add Apiamancer's Drainer recipe by @Quantumlyy in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/786 (2.3.24)
+> * Add Non-Vanilla Dye Support to ZTones Blocks within Assembler by @QuantumBlink1337 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/796 (2.3.23-pre)
+> * Add Non-Vanilla Dye Support to ZTones Blocks within Assembler by @QuantumBlink1337 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/796 (2.3.21)
+> * Fix several low-grav recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/795 (2.3.20-pre)
+> * Fix several low-grav recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/795 (2.3.19)
+> * Allow customizing  Tinker's Construct manuals in dreamcraft by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/794 (2.3.15)
+> * Add Horus planet block recipe by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/790 (2.3.13)
+> * Add assembler recipe for fusion coil block by @Pelotrio in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/792 (2.3.13)
+> * reverts 'Roasted without tiny/small dust' by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/791 (2.3.13)
+> * Various recipe fixes and tweaks by @AbdielKavash in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/788 (2.3.13)
+> * Dont make wooden brick form repairable by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/789 (2.3.12-pre)
+> * Dont make wooden brick form repairable by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/789 (2.3.11)
+> * Add more basalt blocks to chisel by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/787 (2.3.9-pre)
+> * Add more basalt blocks to chisel by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/787 (2.3.8)
+> * add recipe for Limited Itemfilter by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/785 (2.3.4)
+> * Add Special Handling for the Infinity Sword by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/784 (2.3.3)
+> * Fix LCR Controller recipe in assembler by @LewisSaber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/783 (2.3.2)
+> * Fix a few broken LP recipes using gt++ items by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/782 (2.3.1)
+> * Add advanced radiation proof plate space assembler recipe by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/777 (2.3.0)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/807 (2.3.28)
+> * @Ableytner made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/802 (2.3.27)
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/798 (2.3.26)
+> * @Gordon-Frohman made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/781 (2.3.26)
+> * @Quantumlyy made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/786 (2.3.25-pre)
+> * @Quantumlyy made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/786 (2.3.24)
+> * @QuantumBlink1337 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/796 (2.3.23-pre)
+> * @QuantumBlink1337 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/796 (2.3.21)
+> * @YannickMG made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/794 (2.3.15)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/788 (2.3.13)
+>
+
+# Updated Nodal-Mechanics (1.1.-6-GTNH@Side.BOTH --> 1.2.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Nodal-Mechanics/compare/Nodal-Mechanics...1.2.1-GTNH
+>## What's Changed
+> * fix dep by @chochem in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/9 (1.2.1-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/8 (1.2.0-GTNH)
+> * Mod rebalance by @OneEyeMaker in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/1 (1.1.-6-GTNH)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/2 (1.1.-6-GTNH)
+> * Change attuned Matrix Recipe to fit thematically by @redmage17 in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/3 (1.1.-6-GTNH)
+> * Fixed error spiked difficulty by @redmage17 in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/4 (1.1.-6-GTNH)
+> * Make nodal matrix unstackable by @repo-alt in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/5 (1.1.-6-GTNH)
+> * Fix fake recipe aspect count by @Glease in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/6 (1.1.-6-GTNH)
+> * Draft for unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/7 (1.1.-6-GTNH)
+>
+>## New Contributors
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/9 (1.2.1-GTNH)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/8 (1.2.0-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/1 (1.1.-6-GTNH)
+> * @Kiwi233 made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/2 (1.1.-6-GTNH)
+> * @redmage17 made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/3 (1.1.-6-GTNH)
+> * @repo-alt made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/5 (1.1.-6-GTNH)
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/6 (1.1.-6-GTNH)
+> * @SinTh0r4s made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/7 (1.1.-6-GTNH)
+>
+
+# Updated NotEnoughEnergistics (1.4.6@Side.BOTH --> 1.5.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughEnergistics/compare/1.4.5...1.5.1
+>## What's Changed
+> * Change read recipeIndex from GuiRecipe by @slprime in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/38 (1.5.1)
+>
+>## New Contributors
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/38 (1.5.1)
+>
+
+# Updated NotEnoughIds (1.5.3@Side.BOTH --> 2.0.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughIds/compare/1.5.2...2.0.3
+>## What's Changed
+> * Change fake NibbleArray to not use empty byte array for Thermos compat by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/10 (2.0.3)
+> * Fixes for Multiplayer by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/9 (2.0.1)
+> * Initial 16-bit Metadata Re-work by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/7 (2.0.0)
+> * Add curseforge and modrinth project IDs by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/8 (1.5.6)
+> * Small code changes by @Alexdoru in https://github.com/GTNewHorizons/NotEnoughIds/pull/5 (1.5.3)
+>
+>## New Contributors
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/NotEnoughIds/pull/5 (1.5.3)
+>
+
+# Updated NotEnoughItems (2.4.13-GTNH@Side.BOTH --> 2.5.23-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.4.12-GTNH...2.5.23-GTNH
+>## What's Changed
+> * Correctly find the recipeId under mouse when using the search by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/465 (2.5.23-GTNH)
+> * Migrate NEI-Utilities by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/461 (2.5.21-GTNH)
+> * DnD big ItemStack; Show green slot highlighting overlay by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/463 (2.5.21-GTNH)
+> * Slot Highlighting Overlay Option by @Caedis in https://github.com/GTNewHorizons/NotEnoughItems/pull/458 (2.5.19-GTNH)
+> * Less StringBuilder allocation nonsense by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/455 (2.5.18-GTNH)
+> * Create Bookmarks Groups; Search Recipe by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/451 (2.5.17-GTNH)
+> * undo dependencies removal, it's loadbearing by @bombcar in https://github.com/GTNewHorizons/NotEnoughItems/pull/449 (2.5.4-GTNH)
+> * Add chat message to chunk overlay key press by @Caedis in https://github.com/GTNewHorizons/NotEnoughItems/pull/450 (2.5.1-GTNH)
+> * Update bs and dependencies by @bombcar in https://github.com/GTNewHorizons/NotEnoughItems/pull/447 (2.5.0-GTNH)
+> * Fixed infinite loop in bookmarks with only one column by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/442 (2.4.13-GTNH)
+>
+
+# Updated Nuclear-Control (2.5.1@Side.BOTH --> 2.6.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.5.0...2.6.1
+>## What's Changed
+> * Angelica support by @ah-OOG-ah in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
+>
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/18 (2.6.0)
+>
+
+# Updated Nutrition (0.0.5@Side.BOTH --> 0.0.9@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.0.4...0.0.9
+>## What's Changed
+> * Add null player check to tooltip event by @Caedis in https://github.com/GTNewHorizons/Nutrition/pull/15 (0.0.9)
+> * Polish translation (pl_PL) by @Mpcs in https://github.com/GTNewHorizons/Nutrition/pull/13 (0.0.8)
+> * Fix some keybind and gui stuff by @Alexdoru in https://github.com/GTNewHorizons/Nutrition/pull/11 (0.0.5)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Nutrition/pull/15 (0.0.9)
+> * @Mpcs made their first contribution in https://github.com/GTNewHorizons/Nutrition/pull/13 (0.0.8)
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Nutrition/pull/11 (0.0.5)
+>
+
+# Updated OCGlasses (1.4.2-GTNH@Side.BOTH --> 1.5.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OCGlasses/compare/1.4.1-GTNH...1.5.0-GTNH
+>## What's Changed
+> * Fixes usages of the player Map by @Pelotrio in https://github.com/GTNewHorizons/OCGlasses/pull/17 (1.4.2-GTNH)
+>
+>## New Contributors
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/OCGlasses/pull/17 (1.4.2-GTNH)
+>
+
+# Updated OpenBlocks (1.8.3-GTNH@Side.BOTH --> 1.9.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.8.2-GTNH...1.9.1-GTNH
+>## What's Changed
+> * Fix server crash due to trying to access translation resource by @ghostflyby in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
+>
+>## New Contributors
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/20 (1.9.0-GTNH)
+>
+
+# Updated OpenComputers (1.9.21-GTNH@Side.BOTH --> 1.10.7-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.9.19-GTNH...1.10.7-GTNH
+>## What's Changed
+> * If we say it's thread safe, that makes it true -- right?  right? by @mitchej123 in https://github.com/GTNewHorizons/OpenComputers/pull/117 (1.10.7-GTNH)
+> * fix extraneous @VERSION@ by @bombcar in https://github.com/GTNewHorizons/OpenComputers/pull/114 (1.10.5-GTNH)
+> * [bs] update dependencies by @bombcar in https://github.com/GTNewHorizons/OpenComputers/pull/115 (1.10.5-GTNH)
+> * Fix AE2 Integration by @Pelotrio in https://github.com/GTNewHorizons/OpenComputers/pull/113 (1.10.3-GTNH)
+> * Fix Coremod Version by @glowredman in https://github.com/GTNewHorizons/OpenComputers/pull/112 (1.10.1-GTNH)
+> * Bee convert should not be localized by @ghostflyby in https://github.com/GTNewHorizons/OpenComputers/pull/110 (1.10.1-GTNH)
+> * Fix unhandled side for redstone connection by @OneEyeMaker in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/117 (1.10.7-GTNH)
+> * @Pelotrio made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/113 (1.10.3-GTNH)
+> * @ghostflyby made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/110 (1.10.1-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/111 (1.10.0-GTNH)
+>
+
+# Updated OpenModsLib (0.10.6@Side.BOTH --> 0.10.9@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenModsLib/compare/0.10.5...0.10.9
+>## What's Changed
+> * Add a version check to prevent 0.11 from happening by @bombcar in https://github.com/GTNewHorizons/OpenModsLib/pull/7 (0.10.9)
+> * Allow `-pre` and `-snapshot` versions by @glowredman in https://github.com/GTNewHorizons/OpenModsLib/pull/8 (0.10.9)
+> * version warning by @bombcar in https://github.com/GTNewHorizons/OpenModsLib/pull/6 (0.10.8)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/OpenModsLib/pull/5 (0.10.7)
+> * correct transient dependency by @Dream-Master in https://github.com/GTNewHorizons/OpenModsLib/pull/4 (0.10.6)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/OpenModsLib/pull/8 (0.10.9)
+> * @Dream-Master made their first contribution in https://github.com/GTNewHorizons/OpenModsLib/pull/4 (0.10.6)
+>
+
+# Updated OpenModularTurrets (2.2.11-247@Side.BOTH --> 2.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.2.11-246...2.3.1
+>## What's Changed
+> * Update Bounding boxes, remove old depdencies by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/4 (2.3.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/OpenModularTurrets/pull/2 (2.3.0)
+> * whoops by @bombcar in https://github.com/GTNewHorizons/OpenModularTurrets/pull/1 (2.2.11-247)
+>
+>## New Contributors
+> * @Keridos made their first contribution in https://github.com/GTNewHorizons/OpenModularTurrets/pull/4 (2.3.1)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/OpenModularTurrets/pull/1 (2.2.11-247)
+>
+
+# Updated OpenPrinter (0.1.3-GTNH@Side.BOTH --> 0.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenPrinter/compare/0.1.2-GTNH...0.2.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/OpenPrinter/pull/5 (0.2.0-GTNH)
+> * Fix Version Replacement by @glowredman in https://github.com/GTNewHorizons/OpenPrinter/pull/4 (0.1.3-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/OpenPrinter/pull/5 (0.2.0-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/OpenPrinter/pull/4 (0.1.3-GTNH)
+>
+
+# Updated OpenSecurity (1.0.120-GTNH@Side.BOTH --> 1.1.1-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/OpenSecurity/compare/1.0.119-GTNH...1.1.1-GTNH
+>## What's Changed
+> * Fix Version by @glowredman in https://github.com/GTNewHorizons/OpenSecurity/pull/4 (1.1.0-GTNH)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/OpenSecurity/pull/3 (1.0.120-GTNH)
+>
+
+# Updated Opis (1.3.9-mapless@Side.BOTH --> 1.4.2-mapless@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Opis/compare/1.3.8-mapless...1.4.2-mapless
+>## What's Changed
+> * Fix Tags by @glowredman in https://github.com/GTNewHorizons/Opis/pull/13 (1.4.1-mapless)
+> * Remove system.exit to make FML happy by @bombcar in https://github.com/GTNewHorizons/Opis/pull/12 (1.4.0-mapless)
+> * Remove system.exit to make FML happy by @bombcar in https://github.com/GTNewHorizons/Opis/pull/12 (1.3.9-mapless)
+>
+
+# Updated OverloadedArmorBar (1.0.3@Side.CLIENT --> 1.1.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/OverloadedArmorBar/compare/1.0.1...1.1.0
+>## What's Changed
+> * Basically rewrite the whole mod by @Alexdoru in https://github.com/GTNewHorizons/OverloadedArmorBar/pull/3 (1.0.3)
+>
+>## New Contributors
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/OverloadedArmorBar/pull/3 (1.0.3)
+>
+
+# Updated PersonalSpace (1.0.28@Side.BOTH --> 1.0.30@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/PersonalSpace/compare/1.0.27...1.0.30
+>## What's Changed
+> * Fix the deprecated nightTime setting not removed at config save time by @eigenraven in https://github.com/GTNewHorizons/PersonalSpace/pull/23 (1.0.29)
+>
+
+# Updated Player-API (1.4.3@Side.BOTH --> 1.4.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Player-API/compare/1.4.2...1.4.4
+>## What's Changed
+> * Update CF link in README by @glowredman in https://github.com/GTNewHorizons/Player-API/pull/2 (1.4.3)
+>
+
+# Updated ProjectBlue (1.1.12-GTNH@Side.BOTH --> 1.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ProjectBlue/compare/1.1.11-GTNH...1.2.0-GTNH
+>## What's Changed
+> * Log what class received by @miozune in https://github.com/GTNewHorizons/ProjectBlue/pull/4 (1.1.12-GTNH)
+>
+
+# Updated ProjectRed (4.8.1-GTNH@Side.BOTH --> 4.9.4-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.8.0-GTNH...4.9.4-GTNH
+>## What's Changed
+> * Lamp Metadata Fix (Compat with NotEnoughIds 2.0+) by @Cleptomania in https://github.com/GTNewHorizons/ProjectRed/pull/32 (4.9.4-GTNH)
+> * Fix missing call to `startDrawing()` by @UltraHex in https://github.com/GTNewHorizons/ProjectRed/pull/30 (4.9.3-GTNH)
+> * update the chickens to have multiple threads by @bombcar in https://github.com/GTNewHorizons/ProjectRed/pull/29 (4.9.2-GTNH)
+> * Replace `@VERSION@` usage by @glowredman in https://github.com/GTNewHorizons/ProjectRed/pull/28 (4.9.1-GTNH)
+> * Angelica compat - don't rebind textures by @ah-OOG-ah in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
+>
+>## New Contributors
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/32 (4.9.4-GTNH)
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/30 (4.9.3-GTNH)
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/27 (4.9.0-GTNH)
+>
+
+# Updated Railcraft (9.15.3@Side.BOTH --> 9.15.6@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.15.2...9.15.6
+>## What's Changed
+> * Seems threadsafe enough by @mitchej123 in https://github.com/GTNewHorizons/Railcraft/pull/56 (9.15.6)
+> * Fix Railcraft tanks showing wrong texture after a resource reload by @UltraHex in https://github.com/GTNewHorizons/Railcraft/pull/55 (9.15.5)
+> * Fluids entering iron tanks use fallback texture when flowing texture is missing by @asoftbird in https://github.com/GTNewHorizons/Railcraft/pull/53 (9.15.3)
+> * do not add color data when not needed by @Glease in https://github.com/GTNewHorizons/Railcraft/pull/54 (9.15.3)
+>
+>## New Contributors
+> * @UltraHex made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/55 (9.15.5)
+> * @asoftbird made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/53 (9.15.3)
+>
+
+# Updated Random-Things (2.4.6@Side.BOTH --> 2.5.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.4.5...2.5.1
+>## What's Changed
+> * Add RandomThings to allow mobsinfo to find it. by @bombcar in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/4 (2.5.0)
+>
+
+# Updated Realistic-World-Gen (alpha-1.3.9-pre@Side.BOTH --> alpha-1.4.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Realistic-World-Gen/compare/alpha-1.3.8...alpha-1.4.1
+>## What's Changed
+> * Fix broken terrain gen past -20480 in either X or Z by @Caedis in https://github.com/GTNewHorizons/Realistic-World-Gen/pull/15 (alpha-1.4.0)
+>
+
+# Updated RemoteIO (2.4.8@Side.BOTH --> 2.5.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/RemoteIO/compare/2.4.7...2.5.2
+>## What's Changed
+> * Reuse instead of allocate and throwaway by @mitchej123 in https://github.com/GTNewHorizons/RemoteIO/pull/12 (2.5.2)
+> * Small Fixes by @glowredman in https://github.com/GTNewHorizons/RemoteIO/pull/11 (2.5.1)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/RemoteIO/pull/10 (2.5.0)
+> * Spotless apply for branch update-buildscript for #8 by @github-actions in https://github.com/GTNewHorizons/RemoteIO/pull/9 (2.4.8)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/RemoteIO/pull/8 (2.4.8)
+>
+>## New Contributors
+> * @mitchej123 made their first contribution in https://github.com/GTNewHorizons/RemoteIO/pull/12 (2.5.2)
+> * @github-actions made their first contribution in https://github.com/GTNewHorizons/RemoteIO/pull/9 (2.4.8)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/RemoteIO/pull/8 (2.4.8)
+>
+
+# Updated Roguelike-Dungeons (1.5.3-GTNH@Side.BOTH --> 1.6.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.5.2-GTNH...1.6.0-GTNH
+>## What's Changed
+> * build on maven by @bombcar in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/2 (1.5.3-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/2 (1.5.3-GTNH)
+>
+
+# Updated SC2 (2.0.2@Side.BOTH --> 2.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.0.1...2.1.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/SC2/pull/4 (2.1.0)
+> * Fix duplicate key by @MuXiu1997 in https://github.com/GTNewHorizons/SC2/pull/3 (2.0.2)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/SC2/pull/4 (2.1.0)
+> * @MuXiu1997 made their first contribution in https://github.com/GTNewHorizons/SC2/pull/3 (2.0.2)
+>
+
+# Updated SGCraft (1.3.13-GTNH@Side.BOTH --> 1.4.3-GTNH-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/SGCraft/compare/1.3.12-GTNH...1.4.3-GTNH-pre
+>## What's Changed
+> * Huge cleanup by @boubou19 in https://github.com/GTNewHorizons/SGCraft/pull/16 (1.4.2-GTNH)
+> * Code cleanup by @boubou19 in https://github.com/GTNewHorizons/SGCraft/pull/15 (1.4.1-GTNH)
+> * make sure SGCraft loads after OpenComputer by @bombcar in https://github.com/GTNewHorizons/SGCraft/pull/13 (1.4.0-GTNH)
+> * trace is default somewhere maybe by @bombcar in https://github.com/GTNewHorizons/SGCraft/pull/10 (1.3.13-GTNH)
+> * Make ring/chevron block available as a beacon base by @MadMan310 in https://github.com/GTNewHorizons/SGCraft/pull/11 (1.3.13-GTNH)
+>
+>## New Contributors
+> * @MadMan310 made their first contribution in https://github.com/GTNewHorizons/SGCraft/pull/11 (1.3.13-GTNH)
+>
+
+# Updated Schematica (1.9.4-GTNH@Side.CLIENT --> 1.11.0-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/Schematica/compare/1.9.3-GTNH...1.11.0-GTNH
+>## What's Changed
+> * Fix server-client sync by @mist475 in https://github.com/GTNewHorizons/Schematica/pull/20 (1.11.0-GTNH)
+> * Fix saving Tile-Entities saving by @mist475 in https://github.com/GTNewHorizons/Schematica/pull/19 (1.11.0-GTNH)
+> * Cleanup by @mist475 in https://github.com/GTNewHorizons/Schematica/pull/18 (1.10.1-GTNH)
+> * Make rotation state save when saving schematic coordinates by @Lyfts in https://github.com/GTNewHorizons/Schematica/pull/17 (1.9.4-GTNH)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/Schematica/pull/17 (1.9.4-GTNH)
+>
+
+# New Mod - ServerUtilities (2.0.27@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/commits/2.0.27
+>## What's Changed
+> * Add config for allowing all block interactions in claimed chunks by @Majora320 in https://github.com/GTNewHorizons/ServerUtilities/pull/47 (2.0.27)
+> * Rename power permission node to priority by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/46 (2.0.26)
+> * Hide sidebar buttons if disabled on server by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/45 (2.0.25)
+> * Fix network exception when chunk claiming is turned off by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/44 (2.0.24)
+> * Fix permissions with values above max getting set to default value by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/43 (2.0.23)
+> * Add ability to claim chunks from JourneyMap by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/41 (2.0.22)
+> * Better fix for disappearing buttons by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/40 (2.0.20)
+> * Convert TP warmup countdown to notification by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/38 (2.0.19)
+> * Fix "/backup start" counting as automatic backup when ran from console by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/34 (2.0.18)
+> * Change leaderboard button icon by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/35 (2.0.16)
+> * Potential fix for disappearing sidebar buttons by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/30 (2.0.14)
+> * Add null check for CommandOverride by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/31 (2.0.12)
+> * Fix for minor command problems by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/26 (2.0.11)
+> * Add config option to have side buttons drawn vertically by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/29 (2.0.11)
+> * Add synced Wiki by @glowredman in https://github.com/GTNewHorizons/ServerUtilities/pull/24 (2.0.9)
+> * Fix crash when EnderIO farming station is operating in claimed chunk by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/22 (2.0.8)
+> * Fix player attack logging crashing when attacking with empty hand by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/20 (2.0.7)
+> * fix url typo by @bombcar in https://github.com/GTNewHorizons/ServerUtilities/pull/15 (2.0.6)
+> * Add config gui to the forge mod menu by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/16 (2.0.6)
+> * Add info on how to load/unload to journeymap tooltip by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/17 (2.0.6)
+> * Add some barebones documentation to readme by @bombcar in https://github.com/GTNewHorizons/ServerUtilities/pull/14 (2.0.5)
+> * Disable command override if a bukkit/forge hybrid is detected. by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/13 (2.0.4)
+> * toLowerCase on import from FTB and on save and load (just in case) by @Caedis in https://github.com/GTNewHorizons/ServerUtilities/pull/11 (2.0.3)
+> * Add Visual Prospecting/Journeymap Integration by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/9 (2.0.2)
+> * Fix nether portals spawning when teleporting to other dims by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/8 (2.0.1)
+> * Backwards Compatible backport and rewrite. by @Lyfts in https://github.com/GTNewHorizons/ServerUtilities/pull/7 (2.0.0)
+> * Fix Lang loading, since it was missing ingame by @Ethryan in https://github.com/GTNewHorizons/ServerUtilities/pull/4 (1.0.2)
+> * Removal of Import Wildcards by @Ethryan in https://github.com/GTNewHorizons/ServerUtilities/pull/2 (1.0.1)
+>
+>## New Contributors
+> * @Majora320 made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/47 (2.0.27)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/24 (2.0.9)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/14 (2.0.5)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/11 (2.0.3)
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/7 (2.0.0)
+> * @Ethryan made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/2 (1.0.1)
+> *  ftblib.json -> serverutilslib.json (1.0.0)
+> * ftbu/ -> serverutils/ (1.0.0)
+>
+
+# Updated Share-Where-I-am (2.0.2@Side.BOTH --> 2.1.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Share-Where-I-am/compare/0.2.0...2.1.1
+>## What's Changed
+> * Use proper Tags class by @glowredman in https://github.com/GTNewHorizons/Share-Where-I-am/pull/4 (2.1.0)
+> * fix build by @Glease in https://github.com/GTNewHorizons/Share-Where-I-am/pull/3 (2.0.2)
+> * Move JourneyMap class reference out of code that runs even if it's not installed by @ByThePowerOfScience in https://github.com/GTNewHorizons/Share-Where-I-am/pull/2 (2.0.2)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/4 (2.1.0)
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/3 (2.0.2)
+> * @ByThePowerOfScience made their first contribution in https://github.com/GTNewHorizons/Share-Where-I-am/pull/2 (2.0.2)
+>
+
+# Updated SleepingBags (0.1.4@Side.BOTH --> 0.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/SleepingBags/compare/0.1.3...0.2.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/SleepingBags/pull/5 (0.2.0)
+> * Create ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/SleepingBags/pull/3 (0.1.4)
+> * spotless+buildscript by @repo-alt in https://github.com/GTNewHorizons/SleepingBags/pull/4 (0.1.4)
+>
+>## New Contributors
+> * @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/SleepingBags/pull/3 (0.1.4)
+> * @repo-alt made their first contribution in https://github.com/GTNewHorizons/SleepingBags/pull/4 (0.1.4)
+>
+
+# Updated SpecialMobs (3.4.3@Side.BOTH --> 3.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/SpecialMobs/compare/3.4.1...3.5.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/SpecialMobs/pull/22 (3.5.0)
+> * Adds Waila tooltips to every mob by @DrParadox7 in https://github.com/GTNewHorizons/SpecialMobs/pull/21 (3.4.3)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/SpecialMobs/pull/22 (3.5.0)
+>
+
+# Updated SpiceOfLife (2.1.1-carrot@Side.BOTH --> 2.1.7-carrot@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/SpiceOfLife/compare/2.1.0-carrot...2.1.7-carrot
+>## What's Changed
+> * Polish translation (pl_PL) by @Mpcs in https://github.com/GTNewHorizons/SpiceOfLife/pull/33 (2.1.7-carrot)
+> * Add a couple more null checks by @Caedis in https://github.com/GTNewHorizons/SpiceOfLife/pull/36 (2.1.6-carrot)
+> * Add null check to food equal check by @Caedis in https://github.com/GTNewHorizons/SpiceOfLife/pull/35 (2.1.4-carrot)
+> * Update buildscript and spotless by @bombcar in https://github.com/GTNewHorizons/SpiceOfLife/pull/31 (2.1.1-carrot)
+>
+>## New Contributors
+> * @Mpcs made their first contribution in https://github.com/GTNewHorizons/SpiceOfLife/pull/33 (2.1.7-carrot)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/SpiceOfLife/pull/35 (2.1.4-carrot)
+>
+
+# Updated Steve-s-Factory-Manager (1.1.7-GTNH@Side.BOTH --> 1.2.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Steve-s-Factory-Manager/compare/1.1.6-GTNH...1.2.3-GTNH
+>## What's Changed
+> * Move Steve's Addons ASM to explicit compat by @ah-OOG-ah in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/14 (1.2.3-GTNH)
+> * [bs] update for Jenkins and apply spotless and remove wildcards by @bombcar in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/13 (1.2.0-GTNH)
+> * don't register certain recipes if dreamcraft loaded instead of using scripts by @Alexdoru in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/12 (1.1.7-GTNH)
+>
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/14 (1.2.3-GTNH)
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/12 (1.1.7-GTNH)
+>
+
+# Updated StevesAddons (0.10.27@Side.BOTH --> 0.12.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StevesAddons/compare/0.10.26...0.12.3
+>## What's Changed
+> * Purge ASM by @ah-OOG-ah in https://github.com/GTNewHorizons/StevesAddons/pull/11 (0.12.3)
+> * [bs] serious bs by @bombcar in https://github.com/GTNewHorizons/StevesAddons/pull/10 (0.12.0)
+>
+>## New Contributors
+> * @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/StevesAddons/pull/11 (0.12.3)
+>
+
+# Updated StorageDrawers (1.12.2-GTNH@Side.BOTH --> 1.13.3-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/1.12.1-GTNH...1.13.3-GTNH
+>## What's Changed
+> * Fix Waila showing default stack limit when downgraded by @Lyfts in https://github.com/GTNewHorizons/StorageDrawers/pull/27 (1.13.3-GTNH)
+> * Allow clearing empty items from locked drawers by @Cleptomania in https://github.com/GTNewHorizons/StorageDrawers/pull/26 (1.13.1-GTNH)
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/StorageDrawers/pull/25 (1.13.0-GTNH)
+> * Fixed dupe bug with breaking of compacting drawer by @OneEyeMaker in https://github.com/GTNewHorizons/StorageDrawers/pull/24 (1.12.2-GTNH)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/StorageDrawers/pull/27 (1.13.3-GTNH)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/StorageDrawers/pull/26 (1.13.1-GTNH)
+>
+
+# Updated StorageDrawers-BiomesOPlenty (1.11.17-GTNH@Side.BOTH --> 1.12.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers-BiomesOPlenty/compare/1.11.11-GTNH...1.12.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/StorageDrawers-BiomesOPlenty/pull/3 (1.12.0-GTNH)
+>
+
+# Updated StorageDrawers-Forestry (1.11.17-GTNH@Side.BOTH --> 1.12.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers-Forestry/compare/1.11.11-GTNH...1.12.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/StorageDrawers-Forestry/pull/3 (1.12.0-GTNH)
+>
+
+# Updated StorageDrawers-Misc (1.11.18-GTNH@Side.BOTH --> 1.12.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers-Misc/compare/1.11.17-GTNH...1.12.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/StorageDrawers-Misc/pull/4 (1.12.0-GTNH)
+> * Set mod as child mod by @glowredman in https://github.com/GTNewHorizons/StorageDrawers-Misc/pull/3 (1.11.18-GTNH)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/StorageDrawers-Misc/pull/3 (1.11.18-GTNH)
+>
+
+# Updated StorageDrawers-Natura (1.11.17-GTNH@Side.BOTH --> 1.12.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers-Natura/compare/1.11.11-GTNH...1.12.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/StorageDrawers-Natura/pull/3 (1.12.0-GTNH)
+>
+
+# Updated StructureCompat (0.4.0@Side.BOTH --> 0.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StructureCompat/compare/0.3.0...0.5.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/StructureCompat/pull/2 (0.5.0)
+> * add structure info for railcraft multis by @Glease in https://github.com/GTNewHorizons/StructureCompat/pull/1 (0.4.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/StructureCompat/pull/2 (0.5.0)
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/StructureCompat/pull/1 (0.4.0)
+>
+
+# Updated StructureLib (1.2.9@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.2.8...1.3.0
+>## What's Changed
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/StructureLib/pull/26 (1.3.0)
+> * revise javadoc publish  by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/27 (1.3.0)
+> * add new api to check for rotation/flip changes by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/24 (1.2.9)
+>
+>## New Contributors
+> * @chochem made their first contribution in https://github.com/GTNewHorizons/StructureLib/pull/26 (1.3.0)
+>
+
+# Updated Super-TiC (1.2.5@Side.BOTH --> 1.3.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Super-TiC/compare/1.2.4...1.3.0
+>## What's Changed
+> * fixed crash without bloodmagic caused by class loading by @Trinsdar in https://github.com/GTNewHorizons/Super-TiC/pull/6 (1.3.0)
+> * Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/Super-TiC/pull/5 (1.2.5)
+>
+>## New Contributors
+> * @Trinsdar made their first contribution in https://github.com/GTNewHorizons/Super-TiC/pull/6 (1.3.0)
+> * @Kiwi233 made their first contribution in https://github.com/GTNewHorizons/Super-TiC/pull/5 (1.2.5)
+>
+
+# Updated TCNEIAdditions (1.2.2@Side.BOTH --> 1.3.4@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TCNEIAdditions/compare/1.2.0...1.3.4
+>## What's Changed
+> * Add color customization via lang file by @Flanisch in https://github.com/GTNewHorizons/TCNEIAdditions/pull/24 (1.3.4)
+> * Move 'open recipes' button by @slprime in https://github.com/GTNewHorizons/TCNEIAdditions/pull/23 (1.3.2)
+> * Fix Version of Thaumcraft NEI Plugin by @glowredman in https://github.com/GTNewHorizons/TCNEIAdditions/pull/22 (1.3.0)
+> * TC Aspects not showing up on bookmarks correctly fix. by @Cardinalstars in https://github.com/GTNewHorizons/TCNEIAdditions/pull/21 (1.2.2)
+>
+>## New Contributors
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/24 (1.3.4)
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/23 (1.3.2)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/22 (1.3.0)
+> * @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/TCNEIAdditions/pull/21 (1.2.2)
+>
+
+# Updated TCNodeTracker (1.1.7@Side.CLIENT --> 1.2.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/TCNodeTracker/compare/1.1.6...1.2.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/TCNodeTracker/pull/8 (1.2.0)
+> * Fix datetime serialization and formatting by @eigenraven in https://github.com/GTNewHorizons/TCNodeTracker/pull/7 (1.1.7)
+>
+>## New Contributors
+> * @eigenraven made their first contribution in https://github.com/GTNewHorizons/TCNodeTracker/pull/7 (1.1.7)
+>
+
+# Updated TX-Loader (1.6.3@Side.CLIENT --> 1.7.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.6.2...1.7.0
+>## What's Changed
+> * don't use SKIP_DEBUG by @Alexdoru in https://github.com/GTNewHorizons/TX-Loader/pull/10 (1.6.3)
+>
+
+# Updated Tainted-Magic (7.6.3-GTNH@Side.BOTH --> 7.6.4-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.2-GTNH...7.6.4-GTNH
+>## What's Changed
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/Tainted-Magic/pull/20 (7.6.4-GTNH)
+> * improve net code by @Glease in https://github.com/GTNewHorizons/Tainted-Magic/pull/19 (7.6.3-GTNH)
+>
+>## New Contributors
+> * @Glease made their first contribution in https://github.com/GTNewHorizons/Tainted-Magic/pull/19 (7.6.3-GTNH)
+>
+
+# Updated TecTech (5.3.23@Side.BOTH --> 5.3.32@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TecTech/compare/5.3.22...5.3.32
+>## What's Changed
+> * Fixing power checks from telsa tower by @Reflex18 in https://github.com/GTNewHorizons/TecTech/pull/271 (5.3.32)
+> * EOH fix by @HoleFish in https://github.com/GTNewHorizons/TecTech/pull/268 (5.3.30)
+> * Add debug uncertainty by @HoleFish in https://github.com/GTNewHorizons/TecTech/pull/267 (5.3.28)
+> * Change EoH number formatting to standard form by @Connor-Colenso in https://github.com/GTNewHorizons/TecTech/pull/266 (5.3.23)
+>
+>## New Contributors
+> * @Reflex18 made their first contribution in https://github.com/GTNewHorizons/TecTech/pull/271 (5.3.32)
+> * @HoleFish made their first contribution in https://github.com/GTNewHorizons/TecTech/pull/267 (5.3.28)
+>
+
+# Updated ThaumcraftMobAspects (1.0.0-GTNH@Side.BOTH --> 1.1.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumcraftMobAspects/compare/1.0.0-GTNH...1.1.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/2 (1.1.0-GTNH)
+> * Migrate to unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/1 (1.0.0-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/2 (1.1.0-GTNH)
+> * @SinTh0r4s made their first contribution in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/1 (1.0.0-GTNH)
+>
+
+# Updated ThaumicBases (1.5.6@Side.BOTH --> 1.6.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.5.5...1.6.1
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/ThaumicBases/pull/27 (1.6.1)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/27 (1.6.1)
+>
+
+# Updated ThaumicBoots (1.1.0@Side.BOTH --> 1.2.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/0.2.1...1.2.1
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/ThaumicBoots/pull/26 (1.2.1)
+> * Slow Boots + Omni Toggle by @Alastors in https://github.com/GTNewHorizons/ThaumicBoots/pull/25 (1.2.0)
+> * Make boots apply speed boost to all directions by @S4mpsa in https://github.com/GTNewHorizons/ThaumicBoots/pull/24 (1.1.3)
+> * Fixing the jump glitch by @Alastors in https://github.com/GTNewHorizons/ThaumicBoots/pull/23 (1.1.1)
+> * Seasonal Boots (#20) by @Alastors in https://github.com/GTNewHorizons/ThaumicBoots/pull/21 (1.1.0)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/26 (1.2.1)
+> * @S4mpsa made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/24 (1.1.3)
+>
+
+# Updated ThaumicEnergistics (1.5.4-GTNH@Side.BOTH --> 1.6.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.5.3-GTNH...1.6.2-GTNH
+>## What's Changed
+> * Fix new essentia cell crash when shift rightclicking by @Hikari1nVoid in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/58 (1.6.1-GTNH)
+> * Introduce special handling for multi-aspect containers by @OneEyeMaker in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/57 (1.6.0-GTNH)
+> * change cells index by @MCTBL in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/56 (1.5.4-GTNH)
+>
+>## New Contributors
+> * @Hikari1nVoid made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/58 (1.6.1-GTNH)
+> * @OneEyeMaker made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/57 (1.6.0-GTNH)
+>
+
+# Updated ThaumicHorizons (1.4.2@Side.BOTH --> 1.5.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.5.0...1.5.1
+>## What's Changed
+> * Correct name application for Nightmare by @bombcar in https://github.com/GTNewHorizons/ThaumicHorizons/pull/62 (1.5.0)
+>
+
+# Updated ThaumicInventoryScanning (1.0.12-GTNH@Side.BOTH --> 1.1.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicInventoryScanning/compare/1.0.12-GTNH...1.1.2-GTNH
+>## What's Changed
+> * Fix inventory scanning always disabled by @Lyfts in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/5 (1.1.2-GTNH)
+> * Fix server mod check by @Cleptomania in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/3 (1.1.1-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/2 (1.1.0-GTNH)
+> * Update Buildscript by @glowredman in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/1 (1.0.12-GTNH)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/5 (1.1.2-GTNH)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/3 (1.1.1-GTNH)
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/2 (1.1.0-GTNH)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/ThaumicInventoryScanning/pull/1 (1.0.12-GTNH)
+>
+
+# Updated ThaumicTinkerer (2.8.5@Side.BOTH --> 2.9.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.8.4...2.9.2
+>## What's Changed
+> * Fix typo in thaumic restorer page by @jurrejelle in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/37 (2.9.2)
+> * Talisman of Remedium no longer wastes durability trying to remove permanent debuffs. It also accepts the Unbreaking enchant. by @AbdielKavash in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/36 (2.9.0)
+> * Added balancing configs for Shadowbeam Focus. by @Purple-Towel in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/35 (2.8.5)
+>
+>## New Contributors
+> * @jurrejelle made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/37 (2.9.2)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/36 (2.9.0)
+> * @Purple-Towel made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/35 (2.8.5)
+>
+
+# Updated Thaumic_Exploration (1.2.0-GTNH@Side.BOTH --> 1.2.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Thaumic_Exploration/compare/1.1.94-GTNH...1.2.2-GTNH
+>## What's Changed
+> * Do essentia transfer on the server only for boundjars by @Caedis in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/32 (1.2.2-GTNH)
+> * Update dependencies.gradle by @Dream-Master in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/33 (1.2.2-GTNH)
+> * fix rare class cast exception by @Glease in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/31 (1.2.0-GTNH)
+>
+>## New Contributors
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/32 (1.2.2-GTNH)
+> * @Dream-Master made their first contribution in https://github.com/GTNewHorizons/Thaumic_Exploration/pull/33 (1.2.2-GTNH)
+>
+
+# Updated TiC-Tooltips (1.3.0@Side.CLIENT --> 1.3.1@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/TiC-Tooltips/compare/1.2.11...1.3.1
+>## What's Changed
+> * feat: add ukrainian localization by @Oleksey-Korolenko in https://github.com/GTNewHorizons/TiC-Tooltips/pull/7 (1.3.0)
+>
+>## New Contributors
+> * @Oleksey-Korolenko made their first contribution in https://github.com/GTNewHorizons/TiC-Tooltips/pull/7 (1.3.0)
+>
+
+# New Mod - Tinkers-Defense (1.2.2@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Tinkers-Defense/commits/1.2.2
+
+# Updated TinkersConstruct (1.10.13-GTNH@Side.BOTH --> 1.11.11-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.10.12-GTNH...1.11.11-GTNH
+>## What's Changed
+> * Delegate manuals to dreamcraft by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/109 (1.11.11-GTNH)
+> * Translate all tool parts by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/108 (1.11.9-GTNH)
+> * Remove unused gui textures by @Flanisch in https://github.com/GTNewHorizons/TinkersConstruct/pull/110 (1.11.9-GTNH)
+> * Function `P` crash if crafting station without chest by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/107 (1.11.8-GTNH)
+> * Seared Tank QOL by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/104 (1.11.7-GTNH)
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/106 (1.11.5-GTNH)
+> * Obsidian harvestlevel fix by @chochem in https://github.com/GTNewHorizons/TinkersConstruct/pull/105 (1.11.3-GTNH)
+> * add name for crystal entity (which seems to be a creeper? by @bombcar in https://github.com/GTNewHorizons/TinkersConstruct/pull/103 (1.11.1-GTNH)
+> * TConstruct Gadgets localization by @bessonowjaroslaw in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
+>
+>## New Contributors
+> * @Flanisch made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/110 (1.11.9-GTNH)
+> * @YannickMG made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/104 (1.11.7-GTNH)
+> * @bessonowjaroslaw made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/102 (1.11.0-GTNH)
+>
+
+# Updated TinkersMechworks (0.3.0@Side.BOTH --> 0.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TinkersMechworks/compare/0.2.17...0.3.1
+>## What's Changed
+> * feat: add ukrainian localization by @Oleksey-Korolenko in https://github.com/GTNewHorizons/TinkersMechworks/pull/5 (0.3.0)
+>
+>## New Contributors
+> * @Oleksey-Korolenko made their first contribution in https://github.com/GTNewHorizons/TinkersMechworks/pull/5 (0.3.0)
+>
+
+# Updated TooMuchLoot (4.1.0-GTNH@Side.BOTH --> 4.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TooMuchLoot/compare/4.1.0-GTNH...4.2.0-GTNH
+>## What's Changed
+> * Migrate to unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/TooMuchLoot/pull/1 (4.1.0-GTNH)
+>
+>## New Contributors
+> * @SinTh0r4s made their first contribution in https://github.com/GTNewHorizons/TooMuchLoot/pull/1 (4.1.0-GTNH)
+>
+
+# Updated ToroHealth (1.0.4@Side.CLIENT --> 1.1.0@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/ToroHealth/compare/1.0.2...1.1.0
+>## What's Changed
+> * fix erronious MCVersion warning from FML by @bombcar in https://github.com/GTNewHorizons/ToroHealth/pull/3 (1.0.4)
+>
+
+# Updated Translocators (1.1.2.21@Side.BOTH --> 1.2.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Translocators/compare/1.1.2.20...1.2.1
+>## What's Changed
+> * Update for latest CCC/L to be threadsafe by @bombcar in https://github.com/GTNewHorizons/Translocators/pull/7 (1.2.0)
+> * don't register keybind if the crafting grid feature is disabled by th… by @Alexdoru in https://github.com/GTNewHorizons/Translocators/pull/6 (1.1.2.21)
+>
+>## New Contributors
+> * @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Translocators/pull/6 (1.1.2.21)
+>
+
+# Updated TravellersGearNeo (1.0@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/TravellersGearNeo/compare/1.0...1.1.0
+
+# Updated Universal-Singularities (8.6.7@Side.BOTH --> 8.7.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Universal-Singularities/compare/8.6.6...8.7.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Universal-Singularities/pull/9 (8.7.0)
+>
+
+# Updated VisualProspecting (1.2.1@Side.BOTH --> 1.2.10@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.2.0...1.2.10
+>## What's Changed
+> * Enable layers to do actions outside rendered drawsteps by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/43 (1.2.10)
+> * Show empty fluid fields on map by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/42 (1.2.8)
+> * Reposition VP buttons on Xaero's Worldmap by @Caedis in https://github.com/GTNewHorizons/VisualProspecting/pull/41 (1.2.6)
+> * Networking Refactor by @Rune580 in https://github.com/GTNewHorizons/VisualProspecting/pull/40 (1.2.1)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/VisualProspecting/pull/42 (1.2.8)
+> * @Caedis made their first contribution in https://github.com/GTNewHorizons/VisualProspecting/pull/41 (1.2.6)
+> * @Rune580 made their first contribution in https://github.com/GTNewHorizons/VisualProspecting/pull/40 (1.2.1)
+>
+
+# Updated WAILAPlugins (0.3.0@Side.BOTH --> 0.4.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WAILAPlugins/compare/0.2.8...0.4.0
+>## What's Changed
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/WAILAPlugins/pull/17 (0.4.0)
+> * Add production modifier to apiary hud, add magic apiary to forestry handler by @hacatu in https://github.com/GTNewHorizons/WAILAPlugins/pull/16 (0.3.0)
+>
+>## New Contributors
+> * @hacatu made their first contribution in https://github.com/GTNewHorizons/WAILAPlugins/pull/16 (0.3.0)
+>
+
+# Updated WAWLA (1.1.3-GTNH@Side.BOTH --> 1.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WAWLA/compare/1.1.2-GTNH...1.2.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/WAWLA/pull/5 (1.2.0-GTNH)
+> * update buildscript for maven by @bombcar in https://github.com/GTNewHorizons/WAWLA/pull/4 (1.1.3-GTNH)
+>
+
+# Updated WailaHarvestability (1.1.10-GTNH@Side.BOTH --> 1.2.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WailaHarvestability/compare/1.1.9-gtnh...1.2.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/WailaHarvestability/pull/4 (1.2.0-GTNH)
+> * maven by @bombcar in https://github.com/GTNewHorizons/WailaHarvestability/pull/3 (1.1.10-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/WailaHarvestability/pull/3 (1.1.10-GTNH)
+>
+
+# Updated WanionLib (1.8.4@Side.BOTH --> 1.9.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WanionLib/compare/1.8.3...1.9.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/WanionLib/pull/2 (1.9.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/WanionLib/pull/2 (1.9.0)
+>
+
+# Updated WarpTheory (1.2.17-GTNH@Side.BOTH --> 1.3.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WarpTheory/compare/1.2.16-GTNH...1.3.2-GTNH
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/WarpTheory/pull/32 (1.3.2-GTNH)
+> * Add names for warptheory entities for mobinfo by @bombcar in https://github.com/GTNewHorizons/WarpTheory/pull/31 (1.3.0-GTNH)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/WarpTheory/pull/32 (1.3.2-GTNH)
+>
+
+# Updated WirelessCraftingTerminal (1.10.1@Side.BOTH --> 1.11.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.10.0...1.11.1
+>## What's Changed
+> * Fix Dynamic Font Size by @slprime in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/32 (1.11.1)
+>
+
+# Updated WirelessRedstone-CBE (1.4.8@Side.BOTH --> 1.5.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WirelessRedstone-CBE/compare/1.4.7...1.5.0
+>## What's Changed
+> * Fix CCRenderState for multithreading by @bombcar in https://github.com/GTNewHorizons/WirelessRedstone-CBE/pull/9 (1.5.0)
+> * remove use of @InterfaceDependancies by @Glease in https://github.com/GTNewHorizons/WirelessRedstone-CBE/pull/8 (1.4.8)
+>
+
+# Updated WitcheryExtras (1.1.14@Side.BOTH --> 1.2.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WitcheryExtras/compare/1.1.13...1.2.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/WitcheryExtras/pull/19 (1.2.0)
+> * Fix NPE with NEI by @miozune in https://github.com/GTNewHorizons/WitcheryExtras/pull/18 (1.1.14)
+>
+
+# Updated WitchingGadgets (1.3.6-GTNH@Side.BOTH --> 1.4.2-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.3.5-GTNH...1.4.2-GTNH
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/WitchingGadgets/pull/49 (1.4.2-GTNH)
+> * Remove lead from smeltery by @chochem in https://github.com/GTNewHorizons/WitchingGadgets/pull/48 (1.4.1-GTNH)
+> * [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/47 (1.4.0-GTNH)
+> * fix mistaken MCVersion warning from FML by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/46 (1.3.6-GTNH)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/49 (1.4.2-GTNH)
+>
+
+# Updated Yamcl (0.5.86@Side.BOTH --> 0.6.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/Yamcl/compare/0.5.85...0.6.0
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/Yamcl/pull/4 (0.6.0)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/Yamcl/pull/4 (0.6.0)
+>
+
+# Updated ae2stuff (0.6.0-GTNH@Side.BOTH --> 0.7.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.5.7-GTNH...0.7.0-GTNH
+>## What's Changed
+> * Use the quartz knife to rename wireless by @firenoo in https://github.com/GTNewHorizons/ae2stuff/pull/16 (0.6.0-GTNH)
+>
+
+# Updated amunra (0.5.0@Side.BOTH --> 0.5.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/amunra/compare/0.4.36...0.5.1
+>## What's Changed
+> * Fix incorrect link by @Lyfts in https://github.com/GTNewHorizons/amunra/pull/29 (0.5.0)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/amunra/pull/29 (0.5.0)
+>
+
+# Updated bartworks (0.8.23@Side.BOTH --> 0.9.13-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/bartworks/compare/0.8.22...0.9.13-pre
+>## What's Changed
+> * Fix Bio Vat internal error & scanner info by @HoleFish in https://github.com/GTNewHorizons/bartworks/pull/394 (0.9.12)
+> * CAL CA mode recipe tier nerf by @LewisSaber in https://github.com/GTNewHorizons/bartworks/pull/392 (0.9.11)
+> * Fix EIC recipe gating by @GDCloudstrike in https://github.com/GTNewHorizons/bartworks/pull/391 (0.9.10)
+> * set back TGregworks to original repo by @Dream-Master in https://github.com/GTNewHorizons/bartworks/pull/390 (0.9.9)
+> * Add EIC recipes for a few Singularities & Infinity Catalyst by @S4mpsa in https://github.com/GTNewHorizons/bartworks/pull/389 (0.9.8)
+> * Fix MBF tooltip by @chochem in https://github.com/GTNewHorizons/bartworks/pull/388 (0.9.7)
+> * Apply the multiplier of the bacterial vat with a new method by @HoleFish in https://github.com/GTNewHorizons/bartworks/pull/387 (0.9.7)
+> * Fix MBF tooltip by @chochem in https://github.com/GTNewHorizons/bartworks/pull/388 (0.9.6-pre)
+> * update dependencies to fix mutemaster inconsistencies by @bombcar in https://github.com/GTNewHorizons/bartworks/pull/386 (0.9.4)
+> * Fix industry frame and galaxyspace plat block recyling by @chochem in https://github.com/GTNewHorizons/bartworks/pull/385 (0.9.3)
+> * Fix painted low power laser converter explosion by @antropod in https://github.com/GTNewHorizons/bartworks/pull/383 (0.9.2)
+> * Fix muffler hatch numbers for mega by @chochem in https://github.com/GTNewHorizons/bartworks/pull/384 (0.9.2)
+> * Fix CAL Locking itself by @LewisSaber in https://github.com/GTNewHorizons/bartworks/pull/381 (0.9.1)
+> * Allow Mega Oil Cracker to use an input bus for programmed circuit automation. by @AbdielKavash in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
+>
+>## New Contributors
+> * @HoleFish made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/387 (0.9.7)
+> * @antropod made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/383 (0.9.2)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/bartworks/pull/382 (0.9.0)
+>
+
+# Updated bdlib (1.9.8-GTNH@Side.BOTH --> 1.10.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/bdlib/compare/1.9.7-GTNH...1.10.0-GTNH
+>## What's Changed
+> * Add byte array to whitelisted classes by @Glease in https://github.com/GTNewHorizons/bdlib/pull/2 (1.9.8-GTNH)
+> * add compacter classes to network filter by @Pa4ok in https://github.com/GTNewHorizons/bdlib/pull/3 (1.9.8-GTNH)
+>
+>## New Contributors
+> * @Pa4ok made their first contribution in https://github.com/GTNewHorizons/bdlib/pull/3 (1.9.8-GTNH)
+>
+
+# Updated gendustry (1.6.5.5-GTNH@Side.BOTH --> 1.7.0-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/gendustry/compare/1.6.5.4-GTNH...1.7.0-GTNH
+>## What's Changed
+> * [bs] spotless apply for jenkins by @bombcar in https://github.com/GTNewHorizons/gendustry/pull/7 (1.7.0-GTNH)
+> * [bs] pointless change to kick jankins by @bombcar in https://github.com/GTNewHorizons/gendustry/pull/8 (1.7.0-GTNH)
+> * Hide moved items from NEI and add info in tooltip by @kuba6000 in https://github.com/GTNewHorizons/gendustry/pull/6 (1.6.5.5-GTNH)
+>
+>## New Contributors
+> * @bombcar made their first contribution in https://github.com/GTNewHorizons/gendustry/pull/7 (1.7.0-GTNH)
+> * @kuba6000 made their first contribution in https://github.com/GTNewHorizons/gendustry/pull/6 (1.6.5.5-GTNH)
+>
+
+# Updated harvestcraft (1.1.4-GTNH@Side.BOTH --> 1.1.10-GTNH@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/harvestcraft/compare/1.1.3-GTNH...1.1.10-GTNH
+>## What's Changed
+> * update german translation by @Pilzinsel64 in https://github.com/GTNewHorizons/harvestcraft/pull/57 (1.1.10-GTNH)
+> * Add Item for BlockPamSink by @Pilzinsel64 in https://github.com/GTNewHorizons/harvestcraft/pull/58 (1.1.10-GTNH)
+> * Add NetherGarden to NEI by @slprime in https://github.com/GTNewHorizons/harvestcraft/pull/56 (1.1.9-GTNH)
+> * Apiary: allow automatic insertion of queenbees by @Pilzinsel64 in https://github.com/GTNewHorizons/harvestcraft/pull/54 (1.1.8-GTNH)
+> * fix `canPlaceBlockOn` for special planting crops by @Pilzinsel64 in https://github.com/GTNewHorizons/harvestcraft/pull/53 (1.1.7-GTNH)
+> * Translated Havestcraft to Polish by @Mpcs by @kuba6000 in https://github.com/GTNewHorizons/harvestcraft/pull/52 (1.1.6-GTNH)
+> * Added extra flag to register Oven Recipes by @DrParadox7 in https://github.com/GTNewHorizons/harvestcraft/pull/51 (1.1.4-GTNH)
+>
+>## New Contributors
+> * @slprime made their first contribution in https://github.com/GTNewHorizons/harvestcraft/pull/56 (1.1.9-GTNH)
+> * @Pilzinsel64 made their first contribution in https://github.com/GTNewHorizons/harvestcraft/pull/53 (1.1.7-GTNH)
+> * @kuba6000 made their first contribution in https://github.com/GTNewHorizons/harvestcraft/pull/52 (1.1.6-GTNH)
+>
+
+# Updated inventory-tweaks (1.6.1@Side.CLIENT --> 1.6.2@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/inventory-tweaks/compare/1.6.0...1.6.2
+>## What's Changed
+> * Improve Inventory Tweaks perf with mods that reuse item ID with different metadata/damage values by @norbby42 in https://github.com/GTNewHorizons/inventory-tweaks/pull/8 (1.6.2)
+> * Remote chat message logging when creating default files by @bombcar in https://github.com/GTNewHorizons/inventory-tweaks/pull/7 (1.6.1)
+>
+>## New Contributors
+> * @norbby42 made their first contribution in https://github.com/GTNewHorizons/inventory-tweaks/pull/8 (1.6.2)
+>
+
+# Updated ironchest (6.0.74@Side.BOTH --> 6.0.76-pre@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.0.73...6.0.76-pre
+>## What's Changed
+> * Bookmark pull feature for iron chests by @Nilau1998 in https://github.com/GTNewHorizons/ironchest/pull/12 (6.0.74)
+>
+>## New Contributors
+> * @Nilau1998 made their first contribution in https://github.com/GTNewHorizons/ironchest/pull/12 (6.0.74)
+>
+
+# Updated lwjgl3ify (1.5.7@Side.BOTH_JAVA9 --> 2.0.0-alpha-9@Side.BOTH_JAVA9)
+**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/1.5.6...2.0.0-alpha-9
+>## What's Changed
+> * Fixes Enum Duplication Issue by @KAMKEEL in https://github.com/GTNewHorizons/lwjgl3ify/pull/118 (2.0.0-alpha-3)
+> * Add Config Toggle to Enable / Disable HRTF Bools in OpenAl by @KAMKEEL in https://github.com/GTNewHorizons/lwjgl3ify/pull/119 (2.0.0-alpha-3)
+> * Add Config Toggle to Enable / Disable HRTF Bools in OpenAl by @KAMKEEL in https://github.com/GTNewHorizons/lwjgl3ify/pull/119 (1.5.16)
+> * Fixes Enum Duplication Issue by @KAMKEEL in https://github.com/GTNewHorizons/lwjgl3ify/pull/118 (1.5.15)
+> * Fix missing key index mappings by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/110 (1.5.13)
+> * Set OpenAL EFX max aux sends to 4 by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/111 (1.5.13)
+> * Fix handling of Ctrl+Alt vs AltGr on Windows by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/107 (1.5.12)
+> * Fix handling of null device/context in ALC bindings by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/108 (1.5.12)
+> * Remove the need for lwjgl package transformer exclusions by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/106 (1.5.11)
+> * Fix key name display on non-QWERTY keyboard layouts by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/105 (1.5.10)
+> * Publish `version.gradle` by @glowredman in https://github.com/GTNewHorizons/lwjgl3ify/pull/104 (1.5.8)
+> * Disable STB stitching if FC 1.23 is present even with OF by @makamys in https://github.com/GTNewHorizons/lwjgl3ify/pull/97 (1.5.7)
+> * Add `version.json` for use in e.g. Technic Launcher by @glowredman in https://github.com/GTNewHorizons/lwjgl3ify/pull/98 (1.5.7)
+>
+>## New Contributors
+> * @KAMKEEL made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/118 (2.0.0-alpha-3)
+> * @KAMKEEL made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/118 (1.5.15)
+> * @makamys made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/97 (1.5.7)
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/98 (1.5.7)
+>
+
+# Updated nei-custom-diagram (1.5.14@Side.BOTH --> 1.5.15@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.5.13...1.5.15
+
+# Updated neiaddons (1.13.0@Side.BOTH --> 1.15.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/neiaddons/compare/1.12.22...1.15.0
+>## What's Changed
+> * Fix Version by @glowredman in https://github.com/GTNewHorizons/neiaddons/pull/8 (1.14.0)
+> * Fix Crash for Ex Nihilo addon by @Cleptomania in https://github.com/GTNewHorizons/neiaddons/pull/7 (1.13.0)
+>
+>## New Contributors
+> * @glowredman made their first contribution in https://github.com/GTNewHorizons/neiaddons/pull/8 (1.14.0)
+> * @Cleptomania made their first contribution in https://github.com/GTNewHorizons/neiaddons/pull/7 (1.13.0)
+>
+
+# Updated oauth (1.06.1-GTNH@Side.CLIENT --> 1.2.2-GTNH@Side.CLIENT)
+**Full Changelog**: https://github.com/GTNewHorizons/oauth/commits/1.06.1-GTNH@Side.CLIENT...1.2.2-GTNH@Side.CLIENT
+
+# Updated supersolarpanels (1.1.2-GT-NH-Mod@Side.BOTH --> 1.1.3@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/supersolarpanels/compare/1.1.2-GT-NH-Mod...1.1.3
+
+# Updated thaumcraft-research-tweaks (1.0.6@Side.BOTH --> 1.1.0@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/thaumcraft-research-tweaks/compare/1.0.5...1.1.0
+>## What's Changed
+> * Enable spotless by @TheElan in https://github.com/GTNewHorizons/thaumcraft-research-tweaks/pull/14 (1.0.6)
+>
+
+# Updated thaumicinsurgence (0.2.7@Side.BOTH --> 0.3.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.2.6...0.3.1
+>## What's Changed
+> * Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/thaumicinsurgence/pull/37 (0.3.1)
+> * Fix broken mod by @chochem in https://github.com/GTNewHorizons/thaumicinsurgence/pull/36 (0.3.0)
+> * Cleanup NEI and remove inappropriate language by @Connor-Colenso in https://github.com/GTNewHorizons/thaumicinsurgence/pull/32 (0.2.7)
+>
+>## New Contributors
+> * @kamenskyi made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/37 (0.3.1)
+> * @Connor-Colenso made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/32 (0.2.7)
+>
+
+# Updated twilightforest (2.5.1@Side.BOTH --> 2.5.17@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.5.0...2.5.17
+>## What's Changed
+> * Twilight materials book fix by @Gordon-Frohman in https://github.com/GTNewHorizons/twilightforest/pull/47 (2.5.17)
+> * Fix crash when shooting something with TC crossbow by @Lyfts in https://github.com/GTNewHorizons/twilightforest/pull/43 (2.5.16)
+> * Tinkers Construct stats tuning by @Gordon-Frohman in https://github.com/GTNewHorizons/twilightforest/pull/40 (2.5.15)
+> * Tinkers Construct Integration by @Gordon-Frohman in https://github.com/GTNewHorizons/twilightforest/pull/39 (2.5.14)
+> * Naga Courtyard backport (and some other stuff) by @Gordon-Frohman in https://github.com/GTNewHorizons/twilightforest/pull/33 (2.5.12)
+> * Fix hardcoded world height. by @AbdielKavash in https://github.com/GTNewHorizons/twilightforest/pull/37 (2.5.3)
+> * Fix server crash with magic beans by @miozune in https://github.com/GTNewHorizons/twilightforest/pull/32 (2.5.1)
+>
+>## New Contributors
+> * @Lyfts made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/43 (2.5.16)
+> * @Gordon-Frohman made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/33 (2.5.12)
+> * @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/37 (2.5.3)
+> * @miozune made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/32 (2.5.1)
+>
+
+# Updated waila (1.6.5@Side.BOTH --> 1.7.1@Side.BOTH)
+**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.6.4...1.7.1
+>## What's Changed
+> * Fix vanilla Anvils, Saplings, and Slabs by @connor135246 in https://github.com/GTNewHorizons/waila/pull/18 (1.7.1)
+> * Convert world unload event handler to public inner class by @tth05 in https://github.com/GTNewHorizons/waila/pull/17 (1.6.5)
+>
+>## New Contributors
+> * @connor135246 made their first contribution in https://github.com/GTNewHorizons/waila/pull/18 (1.7.1)
+>
+

--- a/releases/manifests/nightly.json
+++ b/releases/manifests/nightly.json
@@ -1,848 +1,856 @@
 {
   "version": "nightly",
-  "last_version": "2.5.0",
-  "last_updated": "2023-12-20T23:30:41.420911",
-  "config": "2.5.1",
+  "last_version": "2.5.1",
+  "last_updated": "2024-03-02T10:01:47.451304",
+  "config": "2.6.0-nightly-2024-03-01",
   "github_mods": {
     "AdventureBackpack2": {
-      "version": "1.0.17-GTNH",
+      "version": "1.1.1-GTNH",
       "side": "BOTH"
     },
     "AE2FluidCraft-Rework": {
-      "version": "1.1.74-gtnh",
+      "version": "1.2.19-gtnh",
       "side": "BOTH"
     },
     "ae2stuff": {
-      "version": "0.6.0-GTNH",
+      "version": "0.7.0-GTNH",
       "side": "BOTH"
     },
     "AFSU": {
-      "version": "1.2.6-GTNH",
+      "version": "1.3.0-GTNH",
       "side": "BOTH"
     },
     "AngerMod": {
-      "version": "0.6.3",
+      "version": "0.7.1",
       "side": "BOTH"
     },
     "AppleCore": {
-      "version": "3.2.12",
+      "version": "3.3.0",
       "side": "BOTH"
     },
     "Applied-Energistics-2-Unofficial": {
-      "version": "rv3-beta-292-GTNH",
+      "version": "rv3-beta-331-GTNH-pre",
       "side": "BOTH"
     },
     "ArchitectureCraft": {
-      "version": "1.8.6",
+      "version": "1.9.4",
       "side": "BOTH"
     },
     "AsieLib": {
-      "version": "0.5.4",
+      "version": "0.5.5",
       "side": "BOTH"
     },
     "Avaritia": {
-      "version": "1.46",
+      "version": "1.49",
       "side": "BOTH"
     },
     "Avaritiaddons": {
-      "version": "1.6.0-GTNH",
+      "version": "1.7.0-GTNH",
       "side": "BOTH"
     },
     "bartworks": {
-      "version": "0.8.23",
+      "version": "0.9.13-pre",
       "side": "BOTH"
     },
     "Battlegear2": {
-      "version": "1.3.0",
+      "version": "1.3.5",
       "side": "BOTH"
     },
     "Baubles": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "side": "BOTH"
     },
     "bdlib": {
-      "version": "1.9.8-GTNH",
+      "version": "1.10.0-GTNH",
       "side": "BOTH"
     },
     "BetterBuildersWands": {
-      "version": "0.10.1-GTNH",
+      "version": "0.11.0-GTNH",
       "side": "BOTH"
     },
     "BetterCrashes": {
-      "version": "1.3.5-GTNH",
+      "version": "1.4.0-GTNH",
       "side": "CLIENT"
     },
     "BetterLoadingScreen": {
-      "version": "1.5.3-GTNH",
+      "version": "1.6.0-GTNH",
       "side": "CLIENT"
     },
     "BetterP2P": {
-      "version": "1.1.20",
-      "side": "BOTH"
-    },
-    "BetterQuesting": {
-      "version": "3.4.7-GTNH",
-      "side": "BOTH"
-    },
-    "Binnie": {
-      "version": "2.2.4",
-      "side": "BOTH"
-    },
-    "BlockLimiter": {
-      "version": "0.55",
-      "side": "BOTH"
-    },
-    "BloodArsenal": {
-      "version": "1.2.11",
-      "side": "BOTH"
-    },
-    "BloodMagic": {
-      "version": "1.4.3",
-      "side": "BOTH"
-    },
-    "Botania": {
-      "version": "1.10.3-GTNH",
-      "side": "BOTH"
-    },
-    "Botanic-horizons": {
-      "version": "1.0.19-GTNH",
-      "side": "BOTH"
-    },
-    "BrandonsCore": {
-      "version": "1.0.0.13-GTNH",
-      "side": "BOTH"
-    },
-    "BugTorch": {
-      "version": "1.2.12-GTNH",
-      "side": "BOTH"
-    },
-    "BuildCraft": {
-      "version": "7.1.38",
-      "side": "BOTH"
-    },
-    "BuildCraftCompat": {
-      "version": "7.1.16",
-      "side": "BOTH"
-    },
-    "CarpentersBlocks": {
-      "version": "3.4.1-GTNH",
-      "side": "BOTH"
-    },
-    "Catwalks-2": {
-      "version": "2.1.4-GTNH",
-      "side": "BOTH"
-    },
-    "Chisel": {
-      "version": "2.12.3-GTNH",
-      "side": "BOTH"
-    },
-    "ChiselTones": {
-      "version": "1.0.4-GTNH",
-      "side": "BOTH"
-    },
-    "CodeChickenCore": {
-      "version": "1.1.13",
-      "side": "BOTH"
-    },
-    "Computronics": {
-      "version": "1.7.1-GTNH",
-      "side": "BOTH"
-    },
-    "CookingForBlockheads": {
-      "version": "1.2.16-GTNH",
-      "side": "BOTH"
-    },
-    "CraftTweaker": {
-      "version": "3.2.13",
-      "side": "BOTH"
-    },
-    "CreativeCore": {
-      "version": "1.3.31-GTNH",
-      "side": "BOTH"
-    },
-    "CropLoadCore": {
-      "version": "0.1.10",
-      "side": "BOTH"
-    },
-    "Crops-plus-plus": {
-      "version": "1.5.12",
-      "side": "BOTH"
-    },
-    "DefaultServerList": {
-      "version": "1.4.0",
-      "side": "CLIENT"
-    },
-    "DefaultWorldGenerator": {
-      "version": "0.2",
-      "side": "CLIENT"
-    },
-    "DetravScannerMod": {
-      "version": "1.7.2",
-      "side": "BOTH"
-    },
-    "Draconic-Evolution": {
-      "version": "1.2.1-GTNH",
-      "side": "BOTH"
-    },
-    "Electro-Magic-Tools": {
-      "version": "1.3.8",
-      "side": "BOTH"
-    },
-    "EnderCore": {
-      "version": "0.2.19",
-      "side": "BOTH"
-    },
-    "EnderIO": {
-      "version": "2.5.9",
-      "side": "BOTH"
-    },
-    "EnderStorage": {
-      "version": "1.4.12",
-      "side": "BOTH"
-    },
-    "EnderZoo": {
-      "version": "1.0.23",
-      "side": "BOTH"
-    },
-    "EnhancedLootBags": {
-      "version": "1.1.0",
-      "side": "BOTH"
-    },
-    "Eternal-Singularity": {
-      "version": "1.1.2",
-      "side": "BOTH"
-    },
-    "FindIt": {
-      "version": "1.1.0",
-      "side": "BOTH"
-    },
-    "ForbiddenMagic": {
-      "version": "0.6.7-GTNH",
-      "side": "BOTH"
-    },
-    "ForestryMC": {
-      "version": "4.7.1",
-      "side": "BOTH"
-    },
-    "Forgelin": {
-      "version": "1.9.7-GTNH",
-      "side": "BOTH"
-    },
-    "ForgeMultipart": {
-      "version": "1.4.1",
-      "side": "BOTH"
-    },
-    "Gadomancy": {
       "version": "1.2.0",
       "side": "BOTH"
     },
-    "GalacticGregGT5": {
-      "version": "1.0.10",
+    "BetterQuesting": {
+      "version": "3.5.8-GTNH",
       "side": "BOTH"
     },
-    "Galacticraft": {
-      "version": "3.0.75-GTNH",
+    "Binnie": {
+      "version": "2.3.3",
       "side": "BOTH"
     },
-    "Galaxy-Space-GTNH": {
-      "version": "1.2.15-GTNH",
+    "BlockLimiter": {
+      "version": "0.6.0",
       "side": "BOTH"
     },
-    "gendustry": {
-      "version": "1.6.5.5-GTNH",
-      "side": "BOTH"
-    },
-    "GoodGenerator": {
-      "version": "0.7.17",
-      "side": "BOTH"
-    },
-    "GT5-Unofficial": {
-      "version": "5.09.44.110",
-      "side": "BOTH"
-    },
-    "GTNEIOrePlugin": {
-      "version": "1.1.3",
-      "side": "BOTH"
-    },
-    "GTNH-Lanthanides": {
-      "version": "0.11.9",
-      "side": "BOTH"
-    },
-    "GTNH-TC-Wands": {
+    "BloodArsenal": {
       "version": "1.3.1",
       "side": "BOTH"
     },
-    "GTNHLib": {
-      "version": "0.0.13",
+    "BloodMagic": {
+      "version": "1.5.1",
       "side": "BOTH"
     },
-    "GTplusplus": {
-      "version": "1.10.54",
+    "Botania": {
+      "version": "1.10.10-GTNH",
       "side": "BOTH"
     },
-    "Hardcore-Ender-Expansion": {
-      "version": "1.9.7-GTNH",
+    "Botanic-horizons": {
+      "version": "1.1.2-GTNH",
       "side": "BOTH"
     },
-    "harvestcraft": {
-      "version": "1.1.4-GTNH",
+    "BrandonsCore": {
+      "version": "1.1.0-GTNH",
       "side": "BOTH"
     },
-    "Hodgepodge": {
-      "version": "2.3.41",
+    "BugTorch": {
+      "version": "1.2.13-GTNH",
       "side": "BOTH"
     },
-    "HoloInventory": {
-      "version": "2.3.2-GTNH",
+    "BuildCraft": {
+      "version": "7.1.39",
       "side": "BOTH"
     },
-    "HungerOverhaul": {
-      "version": "1.0.4-GTNH",
+    "BuildCraftCompat": {
+      "version": "7.1.17",
       "side": "BOTH"
     },
-    "HydroEnergy": {
-      "version": "1.1.1",
+    "CarpentersBlocks": {
+      "version": "3.5.1-GTNH",
       "side": "BOTH"
     },
-    "IFU": {
-      "version": "1.9.6",
+    "Catwalks-2": {
+      "version": "2.2.1-GTNH",
       "side": "BOTH"
     },
-    "IguanaTweaksTConstruct": {
-      "version": "2.3.0",
+    "Chisel": {
+      "version": "2.14.1-GTNH",
       "side": "BOTH"
     },
-    "Infernal-Mobs": {
-      "version": "1.7.9-GTNH",
+    "ChiselTones": {
+      "version": "1.1.0-GTNH",
       "side": "BOTH"
     },
-    "InGame-Info-XML": {
-      "version": "2.8.5",
-      "side": "CLIENT"
-    },
-    "INpureCore": {
-      "version": "1.1.5-GTNH",
-      "side": "BOTH"
-    },
-    "inventory-tweaks": {
-      "version": "1.6.1",
-      "side": "CLIENT"
-    },
-    "ironchest": {
-      "version": "6.0.74",
-      "side": "BOTH"
-    },
-    "IronChestMinecarts": {
-      "version": "1.0.8",
-      "side": "BOTH"
-    },
-    "Irontanks": {
-      "version": "1.2.6",
-      "side": "BOTH"
-    },
-    "Jabba": {
-      "version": "1.3.1",
-      "side": "BOTH"
-    },
-    "KekzTech": {
-      "version": "0.9.6",
-      "side": "BOTH"
-    },
-    "KubaTech": {
-      "version": "0.13.12",
-      "side": "BOTH"
-    },
-    "LittleTiles": {
-      "version": "1.2.9-GTNH",
-      "side": "BOTH"
-    },
-    "LogisticsPipes": {
-      "version": "1.0.8-GTNH",
-      "side": "BOTH"
-    },
-    "LootGames": {
-      "version": "2.0.8",
-      "side": "BOTH"
-    },
-    "LunatriusCore": {
-      "version": "1.1.7-GTNH",
-      "side": "BOTH"
-    },
-    "MagicBees": {
-      "version": "2.7.1-GTNH",
-      "side": "BOTH"
-    },
-    "MalisisCore": {
-      "version": "0.14.9",
-      "side": "BOTH"
-    },
-    "MalisisDoors": {
-      "version": "1.14.0-GTNH",
-      "side": "BOTH"
-    },
-    "Mantle": {
-      "version": "0.3.7",
-      "side": "BOTH"
-    },
-    "Minecraft-Backpack-Mod": {
-      "version": "2.2.12-GTNH",
-      "side": "BOTH"
-    },
-    "Minetweaker-Gregtech-5-Addon": {
-      "version": "2.0.5",
-      "side": "BOTH"
-    },
-    "ModTweaker": {
-      "version": "0.9.10",
-      "side": "BOTH"
-    },
-    "MouseTweaks": {
-      "version": "2.4.9-GTNH",
-      "side": "CLIENT"
-    },
-    "MX-Random": {
-      "version": "0.2.0",
-      "side": "BOTH"
-    },
-    "Natura": {
-      "version": "2.5.7",
-      "side": "BOTH"
-    },
-    "NaturesCompass": {
-      "version": "1.3.6-GTNH",
-      "side": "BOTH"
-    },
-    "nei-custom-diagram": {
-      "version": "1.5.14",
-      "side": "BOTH"
-    },
-    "NEI-Integration": {
-      "version": "1.3.3",
-      "side": "BOTH"
-    },
-    "neiaddons": {
-      "version": "1.13.0",
-      "side": "BOTH"
-    },
-    "NetherPortalFix": {
-      "version": "1.1.2",
-      "side": "BOTH"
-    },
-    "NewHorizonsCoreMod": {
-      "version": "2.2.55",
-      "side": "BOTH"
-    },
-    "Nodal-Mechanics": {
-      "version": "1.1.-6-GTNH",
-      "side": "BOTH"
-    },
-    "NotEnoughEnergistics": {
-      "version": "1.4.6",
-      "side": "BOTH"
-    },
-    "NotEnoughItems": {
-      "version": "2.4.13-GTNH",
-      "side": "BOTH"
-    },
-    "Nuclear-Control": {
-      "version": "2.5.1",
-      "side": "BOTH"
-    },
-    "oauth": {
-      "version": "1.06.1-GTNH",
-      "side": "CLIENT"
-    },
-    "OCGlasses": {
-      "version": "1.4.2-GTNH",
-      "side": "BOTH"
-    },
-    "OpenBlocks": {
-      "version": "1.8.3-GTNH",
-      "side": "BOTH"
-    },
-    "OpenComputers": {
-      "version": "1.9.21-GTNH",
-      "side": "BOTH"
-    },
-    "OpenModsLib": {
-      "version": "0.10.6",
-      "side": "BOTH"
-    },
-    "OpenModularTurrets": {
-      "version": "2.2.11-247",
-      "side": "BOTH"
-    },
-    "OpenSecurity": {
-      "version": "1.0.120-GTNH",
-      "side": "BOTH"
-    },
-    "Opis": {
-      "version": "1.3.9-mapless",
-      "side": "BOTH"
-    },
-    "OverloadedArmorBar": {
-      "version": "1.0.3",
-      "side": "CLIENT"
-    },
-    "PersonalSpace": {
-      "version": "1.0.28",
-      "side": "BOTH"
-    },
-    "ProjectBlue": {
-      "version": "1.1.12-GTNH",
-      "side": "BOTH"
-    },
-    "ProjectRed": {
-      "version": "4.8.1-GTNH",
-      "side": "BOTH"
-    },
-    "Railcraft": {
-      "version": "9.15.3",
-      "side": "BOTH"
-    },
-    "Realistic-World-Gen": {
-      "version": "alpha-1.3.9-pre",
-      "side": "BOTH"
-    },
-    "RemoteIO": {
-      "version": "2.4.8",
-      "side": "BOTH"
-    },
-    "Roguelike-Dungeons": {
-      "version": "1.5.3-GTNH",
-      "side": "BOTH"
-    },
-    "SC2": {
-      "version": "2.0.2",
-      "side": "BOTH"
-    },
-    "Schematica": {
-      "version": "1.9.4-GTNH",
-      "side": "CLIENT"
-    },
-    "SGCraft": {
-      "version": "1.3.13-GTNH",
-      "side": "BOTH"
-    },
-    "Share-Where-I-am": {
-      "version": "2.0.2",
-      "side": "BOTH"
-    },
-    "SleepingBags": {
-      "version": "0.1.4",
-      "side": "BOTH"
-    },
-    "SpecialMobs": {
-      "version": "3.4.3",
-      "side": "BOTH"
-    },
-    "SpiceOfLife": {
-      "version": "2.1.1-carrot",
-      "side": "BOTH"
-    },
-    "Steve-s-Factory-Manager": {
-      "version": "1.1.7-GTNH",
-      "side": "BOTH"
-    },
-    "StevesAddons": {
-      "version": "0.10.27",
-      "side": "BOTH"
-    },
-    "StorageDrawers": {
-      "version": "1.12.2-GTNH",
-      "side": "BOTH"
-    },
-    "StorageDrawers-BiomesOPlenty": {
-      "version": "1.11.17-GTNH",
-      "side": "BOTH"
-    },
-    "StorageDrawers-Forestry": {
-      "version": "1.11.17-GTNH",
-      "side": "BOTH"
-    },
-    "StorageDrawers-Misc": {
-      "version": "1.11.18-GTNH",
-      "side": "BOTH"
-    },
-    "StorageDrawers-Natura": {
-      "version": "1.11.17-GTNH",
-      "side": "BOTH"
-    },
-    "StructureCompat": {
-      "version": "0.4.0",
-      "side": "BOTH"
-    },
-    "StructureLib": {
-      "version": "1.2.9",
-      "side": "BOTH"
-    },
-    "Super-TiC": {
-      "version": "1.2.5",
-      "side": "BOTH"
-    },
-    "supersolarpanels": {
-      "version": "1.1.2-GT-NH-Mod",
-      "side": "BOTH"
-    },
-    "TCNEIAdditions": {
-      "version": "1.2.2",
-      "side": "BOTH"
-    },
-    "TCNodeTracker": {
-      "version": "1.1.7",
-      "side": "CLIENT"
-    },
-    "TecTech": {
-      "version": "5.3.23",
-      "side": "BOTH"
-    },
-    "thaumcraft-research-tweaks": {
-      "version": "1.0.6",
-      "side": "BOTH"
-    },
-    "ThaumcraftMobAspects": {
-      "version": "1.0.0-GTNH",
-      "side": "BOTH"
-    },
-    "Thaumic_Exploration": {
-      "version": "1.2.0-GTNH",
-      "side": "BOTH"
-    },
-    "ThaumicBases": {
-      "version": "1.5.6",
-      "side": "BOTH"
-    },
-    "ThaumicEnergistics": {
-      "version": "1.5.4-GTNH",
-      "side": "BOTH"
-    },
-    "ThaumicHorizons": {
-      "version": "1.4.2",
-      "side": "BOTH"
-    },
-    "thaumicinsurgence": {
-      "version": "0.2.7",
-      "side": "BOTH"
-    },
-    "ThaumicInventoryScanning": {
-      "version": "1.0.12-GTNH",
-      "side": "BOTH"
-    },
-    "ThaumicTinkerer": {
-      "version": "2.8.5",
-      "side": "BOTH"
-    },
-    "TiC-Tooltips": {
-      "version": "1.3.0",
-      "side": "CLIENT"
-    },
-    "TinkersConstruct": {
-      "version": "1.10.13-GTNH",
-      "side": "BOTH"
-    },
-    "TinkersMechworks": {
-      "version": "0.3.0",
-      "side": "BOTH"
-    },
-    "TooMuchLoot": {
-      "version": "4.1.0-GTNH",
-      "side": "BOTH"
-    },
-    "ToroHealth": {
-      "version": "1.0.4",
-      "side": "CLIENT"
-    },
-    "Translocators": {
-      "version": "1.1.2.21",
-      "side": "BOTH"
-    },
-    "twilightforest": {
-      "version": "2.5.1",
-      "side": "BOTH"
-    },
-    "Universal-Singularities": {
-      "version": "8.6.7",
-      "side": "BOTH"
-    },
-    "VisualProspecting": {
+    "CodeChickenCore": {
       "version": "1.2.1",
       "side": "BOTH"
     },
-    "waila": {
-      "version": "1.6.5",
+    "Computronics": {
+      "version": "1.7.2-GTNH",
       "side": "BOTH"
     },
-    "WailaHarvestability": {
-      "version": "1.1.10-GTNH",
+    "CookingForBlockheads": {
+      "version": "1.3.3-GTNH",
       "side": "BOTH"
     },
-    "WAILAPlugins": {
+    "CraftTweaker": {
+      "version": "3.3.1",
+      "side": "BOTH"
+    },
+    "CreativeCore": {
+      "version": "1.4.0-GTNH",
+      "side": "BOTH"
+    },
+    "CropLoadCore": {
+      "version": "0.2.0",
+      "side": "BOTH"
+    },
+    "Crops-plus-plus": {
+      "version": "1.6.3",
+      "side": "BOTH"
+    },
+    "DefaultServerList": {
+      "version": "1.5.0",
+      "side": "CLIENT"
+    },
+    "DefaultWorldGenerator": {
       "version": "0.3.0",
+      "side": "CLIENT"
+    },
+    "DetravScannerMod": {
+      "version": "1.8.0",
       "side": "BOTH"
     },
-    "WanionLib": {
-      "version": "1.8.4",
+    "Draconic-Evolution": {
+      "version": "1.3.2-GTNH",
       "side": "BOTH"
     },
-    "WAWLA": {
-      "version": "1.1.3-GTNH",
+    "Electro-Magic-Tools": {
+      "version": "1.4.4",
       "side": "BOTH"
     },
-    "WirelessCraftingTerminal": {
-      "version": "1.10.1",
+    "EnderCore": {
+      "version": "0.4.5",
       "side": "BOTH"
     },
-    "WirelessRedstone-CBE": {
+    "EnderIO": {
+      "version": "2.7.1",
+      "side": "BOTH"
+    },
+    "EnderStorage": {
+      "version": "1.5.0",
+      "side": "BOTH"
+    },
+    "EnderZoo": {
+      "version": "1.1.0",
+      "side": "BOTH"
+    },
+    "EnhancedLootBags": {
+      "version": "1.1.1",
+      "side": "BOTH"
+    },
+    "Eternal-Singularity": {
+      "version": "1.2.0",
+      "side": "BOTH"
+    },
+    "FindIt": {
+      "version": "1.2.3",
+      "side": "BOTH"
+    },
+    "ForbiddenMagic": {
+      "version": "0.7.0-GTNH",
+      "side": "BOTH"
+    },
+    "ForestryMC": {
+      "version": "4.8.4",
+      "side": "BOTH"
+    },
+    "Forgelin": {
+      "version": "1.9.9-GTNH",
+      "side": "BOTH"
+    },
+    "ForgeMultipart": {
       "version": "1.4.8",
       "side": "BOTH"
     },
-    "WitcheryExtras": {
-      "version": "1.1.14",
+    "Gadomancy": {
+      "version": "1.3.2",
       "side": "BOTH"
     },
-    "WitchingGadgets": {
-      "version": "1.3.6-GTNH",
-      "side": "BOTH"
-    },
-    "Yamcl": {
-      "version": "0.5.86",
-      "side": "BOTH"
-    },
-    "OpenPrinter": {
-      "version": "0.1.3-GTNH",
-      "side": "BOTH"
-    },
-    "BlockRenderer6343": {
-      "version": "1.0.6",
-      "side": "BOTH"
-    },
-    "ModularUI": {
-      "version": "1.1.24",
-      "side": "BOTH"
-    },
-    "TX-Loader": {
-      "version": "1.6.3",
-      "side": "CLIENT"
-    },
-    "GigaGramFab": {
-      "version": "0.3.9",
-      "side": "BOTH"
-    },
-    "NotEnoughIds": {
-      "version": "1.5.3",
-      "side": "BOTH"
-    },
-    "FloodLights": {
-      "version": "1.2.9",
-      "side": "BOTH"
-    },
-    "ForgeRelocationFMP": {
-      "version": "0.0.4",
-      "side": "BOTH"
-    },
-    "ForgeRelocation": {
-      "version": "0.0.3",
-      "side": "BOTH"
-    },
-    "HelpFixer": {
+    "GalacticGregGT5": {
       "version": "1.1.0",
       "side": "BOTH"
     },
-    "Player-API": {
-      "version": "1.4.3",
+    "Galacticraft": {
+      "version": "3.1.3-GTNH",
       "side": "BOTH"
     },
-    "BetterAchievements": {
-      "version": "0.1.3",
+    "Galaxy-Space-GTNH": {
+      "version": "1.1.82-GTNH",
+      "side": "BOTH"
+    },
+    "gendustry": {
+      "version": "1.7.0-GTNH",
+      "side": "BOTH"
+    },
+    "GoodGenerator": {
+      "version": "0.8.13-pre",
+      "side": "BOTH"
+    },
+    "GT5-Unofficial": {
+      "version": "5.09.45.85-pre",
+      "side": "BOTH"
+    },
+    "GTNEIOrePlugin": {
+      "version": "1.2.0",
+      "side": "BOTH"
+    },
+    "GTNH-Lanthanides": {
+      "version": "0.12.11",
+      "side": "BOTH"
+    },
+    "GTNH-TC-Wands": {
+      "version": "1.4.0",
+      "side": "BOTH"
+    },
+    "GTNHLib": {
+      "version": "0.2.10",
+      "side": "BOTH"
+    },
+    "GTplusplus": {
+      "version": "1.11.31",
+      "side": "BOTH"
+    },
+    "Hardcore-Ender-Expansion": {
+      "version": "1.10.1-GTNH",
+      "side": "BOTH"
+    },
+    "harvestcraft": {
+      "version": "1.1.10-GTNH",
+      "side": "BOTH"
+    },
+    "Hodgepodge": {
+      "version": "2.4.34",
+      "side": "BOTH"
+    },
+    "HoloInventory": {
+      "version": "2.4.3-GTNH",
+      "side": "BOTH"
+    },
+    "HungerOverhaul": {
+      "version": "1.1.0-GTNH",
+      "side": "BOTH"
+    },
+    "HydroEnergy": {
+      "version": "1.2.0",
+      "side": "BOTH"
+    },
+    "IFU": {
+      "version": "1.10.1",
+      "side": "BOTH"
+    },
+    "IguanaTweaksTConstruct": {
+      "version": "2.4.1",
+      "side": "BOTH"
+    },
+    "Infernal-Mobs": {
+      "version": "1.8.1-GTNH",
+      "side": "BOTH"
+    },
+    "InGame-Info-XML": {
+      "version": "2.8.6",
       "side": "CLIENT"
     },
-    "DummyCore": {
-      "version": "1.17.0",
+    "INpureCore": {
+      "version": "1.2.0-GTNH",
       "side": "BOTH"
     },
-    "Controlling": {
-      "version": "2.0.1",
+    "inventory-tweaks": {
+      "version": "1.6.2",
       "side": "CLIENT"
     },
-    "BuildCraftOilTweak": {
-      "version": "1.0.4",
+    "ironchest": {
+      "version": "6.0.76-pre",
       "side": "BOTH"
     },
-    "Custom-Main-Menu": {
-      "version": "1.10.3",
+    "IronChestMinecarts": {
+      "version": "1.1.0",
+      "side": "BOTH"
+    },
+    "Irontanks": {
+      "version": "1.3.0",
+      "side": "BOTH"
+    },
+    "Jabba": {
+      "version": "1.3.2",
+      "side": "BOTH"
+    },
+    "KekzTech": {
+      "version": "0.10.0",
+      "side": "BOTH"
+    },
+    "KubaTech": {
+      "version": "0.14.5",
+      "side": "BOTH"
+    },
+    "LittleTiles": {
+      "version": "1.3.0-GTNH",
+      "side": "BOTH"
+    },
+    "LogisticsPipes": {
+      "version": "1.1.3-GTNH",
+      "side": "BOTH"
+    },
+    "LootGames": {
+      "version": "2.1.1",
+      "side": "BOTH"
+    },
+    "LunatriusCore": {
+      "version": "1.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "MagicBees": {
+      "version": "2.7.14-GTNH",
+      "side": "BOTH"
+    },
+    "MalisisDoors": {
+      "version": "1.16.2-GTNH",
+      "side": "BOTH"
+    },
+    "Mantle": {
+      "version": "0.4.1",
+      "side": "BOTH"
+    },
+    "Minecraft-Backpack-Mod": {
+      "version": "2.3.0-GTNH",
+      "side": "BOTH"
+    },
+    "Minetweaker-Gregtech-5-Addon": {
+      "version": "2.1.0",
+      "side": "BOTH"
+    },
+    "ModTweaker": {
+      "version": "0.10.0",
+      "side": "BOTH"
+    },
+    "MouseTweaks": {
+      "version": "2.4.17-GTNH",
       "side": "CLIENT"
     },
-    "Gravitation-Suite-Neo": {
-      "version": "1.0.20",
+    "MX-Random": {
+      "version": "0.3.0",
       "side": "BOTH"
     },
-    "MrTJPCore": {
-      "version": "1.1.5",
+    "Natura": {
+      "version": "2.6.0",
       "side": "BOTH"
     },
-    "Random-Things": {
-      "version": "2.4.6",
+    "NaturesCompass": {
+      "version": "1.4.0-GTNH",
       "side": "BOTH"
     },
-    "Tainted-Magic": {
-      "version": "7.6.3-GTNH",
+    "nei-custom-diagram": {
+      "version": "1.5.15",
       "side": "BOTH"
     },
-    "lwjgl3ify": {
-      "version": "1.5.7",
-      "side": "BOTH_JAVA9"
-    },
-    "TravellersGearNeo": {
-      "version": "1.0",
+    "NEI-Integration": {
+      "version": "1.4.0",
       "side": "BOTH"
     },
-    "GTNH-Intergalactic": {
-      "version": "1.2.9",
+    "NetherPortalFix": {
+      "version": "1.2.0",
       "side": "BOTH"
     },
-    "amunra": {
+    "NewHorizonsCoreMod": {
+      "version": "2.3.34-pre",
+      "side": "BOTH"
+    },
+    "Nodal-Mechanics": {
+      "version": "1.2.1-GTNH",
+      "side": "BOTH"
+    },
+    "NotEnoughEnergistics": {
+      "version": "1.5.1",
+      "side": "BOTH"
+    },
+    "NotEnoughItems": {
+      "version": "2.5.23-GTNH",
+      "side": "BOTH"
+    },
+    "Nuclear-Control": {
+      "version": "2.6.1",
+      "side": "BOTH"
+    },
+    "oauth": {
+      "version": "1.2.2-GTNH",
+      "side": "CLIENT"
+    },
+    "OCGlasses": {
+      "version": "1.5.0-GTNH",
+      "side": "BOTH"
+    },
+    "OpenBlocks": {
+      "version": "1.9.1-GTNH",
+      "side": "BOTH"
+    },
+    "OpenComputers": {
+      "version": "1.10.7-GTNH",
+      "side": "BOTH"
+    },
+    "OpenModsLib": {
+      "version": "0.10.9",
+      "side": "BOTH"
+    },
+    "OpenModularTurrets": {
+      "version": "2.3.1",
+      "side": "BOTH"
+    },
+    "OpenSecurity": {
+      "version": "1.1.1-GTNH",
+      "side": "BOTH"
+    },
+    "Opis": {
+      "version": "1.4.2-mapless",
+      "side": "BOTH"
+    },
+    "OverloadedArmorBar": {
+      "version": "1.1.0",
+      "side": "CLIENT"
+    },
+    "PersonalSpace": {
+      "version": "1.0.30",
+      "side": "BOTH"
+    },
+    "ProjectBlue": {
+      "version": "1.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "ProjectRed": {
+      "version": "4.9.4-GTNH",
+      "side": "BOTH"
+    },
+    "Railcraft": {
+      "version": "9.15.6",
+      "side": "BOTH"
+    },
+    "Realistic-World-Gen": {
+      "version": "alpha-1.4.1",
+      "side": "BOTH"
+    },
+    "RemoteIO": {
+      "version": "2.5.2",
+      "side": "BOTH"
+    },
+    "Roguelike-Dungeons": {
+      "version": "1.6.0-GTNH",
+      "side": "BOTH"
+    },
+    "SC2": {
+      "version": "2.1.0",
+      "side": "BOTH"
+    },
+    "Schematica": {
+      "version": "1.11.0-GTNH",
+      "side": "CLIENT"
+    },
+    "SGCraft": {
+      "version": "1.4.3-GTNH-pre",
+      "side": "BOTH"
+    },
+    "Share-Where-I-am": {
+      "version": "2.1.1",
+      "side": "BOTH"
+    },
+    "SleepingBags": {
+      "version": "0.2.0",
+      "side": "BOTH"
+    },
+    "SpecialMobs": {
+      "version": "3.5.0",
+      "side": "BOTH"
+    },
+    "SpiceOfLife": {
+      "version": "2.1.7-carrot",
+      "side": "BOTH"
+    },
+    "Steve-s-Factory-Manager": {
+      "version": "1.2.3-GTNH",
+      "side": "BOTH"
+    },
+    "StevesAddons": {
+      "version": "0.12.3",
+      "side": "BOTH"
+    },
+    "StorageDrawers": {
+      "version": "1.13.3-GTNH",
+      "side": "BOTH"
+    },
+    "StorageDrawers-BiomesOPlenty": {
+      "version": "1.12.0-GTNH",
+      "side": "BOTH"
+    },
+    "StorageDrawers-Forestry": {
+      "version": "1.12.0-GTNH",
+      "side": "BOTH"
+    },
+    "StorageDrawers-Misc": {
+      "version": "1.12.0-GTNH",
+      "side": "BOTH"
+    },
+    "StorageDrawers-Natura": {
+      "version": "1.12.0-GTNH",
+      "side": "BOTH"
+    },
+    "StructureCompat": {
       "version": "0.5.0",
       "side": "BOTH"
     },
-    "DuraDisplay": {
-      "version": "1.1.7",
+    "StructureLib": {
+      "version": "1.3.0",
+      "side": "BOTH"
+    },
+    "Super-TiC": {
+      "version": "1.3.0",
+      "side": "BOTH"
+    },
+    "supersolarpanels": {
+      "version": "1.1.3",
+      "side": "BOTH"
+    },
+    "TCNEIAdditions": {
+      "version": "1.3.4",
+      "side": "BOTH"
+    },
+    "TCNodeTracker": {
+      "version": "1.2.0",
       "side": "CLIENT"
     },
-    "Mobs-Info": {
-      "version": "0.1.13-GTNH",
+    "TecTech": {
+      "version": "5.3.32",
       "side": "BOTH"
     },
-    "BeeBetterAtBees-GTNH": {
-      "version": "0.3.1-GTNH",
-      "side": "CLIENT"
-    },
-    "AlchemyGrate": {
-      "version": "1.0.3-GTNH",
-      "side": "BOTH"
-    },
-    "Nutrition": {
-      "version": "0.0.5",
-      "side": "BOTH"
-    },
-    "Default-Configs": {
-      "version": "1.1.6",
-      "side": "CLIENT"
-    },
-    "CodeChickenLib": {
-      "version": "1.1.10",
-      "side": "BOTH"
-    },
-    "ThaumicBoots": {
+    "thaumcraft-research-tweaks": {
       "version": "1.1.0",
       "side": "BOTH"
     },
-    "Amazing-Trophies": {
-      "version": "1.1.4",
+    "ThaumcraftMobAspects": {
+      "version": "1.1.0-GTNH",
+      "side": "BOTH"
+    },
+    "Thaumic_Exploration": {
+      "version": "1.2.2-GTNH",
+      "side": "BOTH"
+    },
+    "ThaumicBases": {
+      "version": "1.6.1",
+      "side": "BOTH"
+    },
+    "ThaumicEnergistics": {
+      "version": "1.6.2-GTNH",
+      "side": "BOTH"
+    },
+    "ThaumicHorizons": {
+      "version": "1.5.1",
+      "side": "BOTH"
+    },
+    "thaumicinsurgence": {
+      "version": "0.3.1",
+      "side": "BOTH"
+    },
+    "ThaumicInventoryScanning": {
+      "version": "1.1.2-GTNH",
+      "side": "BOTH"
+    },
+    "ThaumicTinkerer": {
+      "version": "2.9.2",
+      "side": "BOTH"
+    },
+    "TiC-Tooltips": {
+      "version": "1.3.1",
+      "side": "CLIENT"
+    },
+    "TinkersConstruct": {
+      "version": "1.11.11-GTNH",
+      "side": "BOTH"
+    },
+    "TinkersMechworks": {
+      "version": "0.3.1",
+      "side": "BOTH"
+    },
+    "TooMuchLoot": {
+      "version": "4.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "ToroHealth": {
+      "version": "1.1.0",
+      "side": "CLIENT"
+    },
+    "Translocators": {
+      "version": "1.2.1",
+      "side": "BOTH"
+    },
+    "twilightforest": {
+      "version": "2.5.17",
+      "side": "BOTH"
+    },
+    "Universal-Singularities": {
+      "version": "8.7.0",
+      "side": "BOTH"
+    },
+    "VisualProspecting": {
+      "version": "1.2.10",
+      "side": "BOTH"
+    },
+    "waila": {
+      "version": "1.7.1",
+      "side": "BOTH"
+    },
+    "WailaHarvestability": {
+      "version": "1.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "WAILAPlugins": {
+      "version": "0.4.0",
+      "side": "BOTH"
+    },
+    "WanionLib": {
+      "version": "1.9.0",
       "side": "BOTH"
     },
     "WarpTheory": {
-      "version": "1.2.17-GTNH",
+      "version": "1.3.2-GTNH",
       "side": "BOTH"
+    },
+    "WAWLA": {
+      "version": "1.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "WirelessCraftingTerminal": {
+      "version": "1.11.1",
+      "side": "BOTH"
+    },
+    "WirelessRedstone-CBE": {
+      "version": "1.5.0",
+      "side": "BOTH"
+    },
+    "WitcheryExtras": {
+      "version": "1.2.0",
+      "side": "BOTH"
+    },
+    "WitchingGadgets": {
+      "version": "1.4.2-GTNH",
+      "side": "BOTH"
+    },
+    "Yamcl": {
+      "version": "0.6.0",
+      "side": "BOTH"
+    },
+    "OpenPrinter": {
+      "version": "0.2.0-GTNH",
+      "side": "BOTH"
+    },
+    "BlockRenderer6343": {
+      "version": "1.1.6",
+      "side": "BOTH"
+    },
+    "ModularUI": {
+      "version": "1.1.35",
+      "side": "BOTH"
+    },
+    "TX-Loader": {
+      "version": "1.7.0",
+      "side": "CLIENT"
+    },
+    "GigaGramFab": {
+      "version": "0.3.14",
+      "side": "BOTH"
+    },
+    "NotEnoughIds": {
+      "version": "2.0.3",
+      "side": "BOTH"
+    },
+    "FloodLights": {
+      "version": "1.3.0",
+      "side": "BOTH"
+    },
+    "ForgeRelocationFMP": {
+      "version": "0.1.0",
+      "side": "BOTH"
+    },
+    "ForgeRelocation": {
+      "version": "0.1.2",
+      "side": "BOTH"
+    },
+    "HelpFixer": {
+      "version": "1.2.0",
+      "side": "BOTH"
+    },
+    "Player-API": {
+      "version": "1.4.4",
+      "side": "BOTH"
+    },
+    "BetterAchievements": {
+      "version": "0.2.0",
+      "side": "CLIENT"
+    },
+    "DummyCore": {
+      "version": "1.18.0",
+      "side": "BOTH"
+    },
+    "Controlling": {
+      "version": "2.0.2",
+      "side": "CLIENT"
+    },
+    "BuildCraftOilTweak": {
+      "version": "1.1.0",
+      "side": "BOTH"
+    },
+    "Custom-Main-Menu": {
+      "version": "1.11.0",
+      "side": "CLIENT"
+    },
+    "Gravitation-Suite-Neo": {
+      "version": "1.1.1",
+      "side": "BOTH"
+    },
+    "MrTJPCore": {
+      "version": "1.1.6",
+      "side": "BOTH"
+    },
+    "Random-Things": {
+      "version": "2.5.1",
+      "side": "BOTH"
+    },
+    "Tainted-Magic": {
+      "version": "7.6.4-GTNH",
+      "side": "BOTH"
+    },
+    "lwjgl3ify": {
+      "version": "2.0.0-alpha-9",
+      "side": "BOTH_JAVA9"
+    },
+    "TravellersGearNeo": {
+      "version": "1.1.0",
+      "side": "BOTH"
+    },
+    "GTNH-Intergalactic": {
+      "version": "1.3.1",
+      "side": "BOTH"
+    },
+    "amunra": {
+      "version": "0.5.1",
+      "side": "BOTH"
+    },
+    "DuraDisplay": {
+      "version": "1.2.2",
+      "side": "CLIENT"
+    },
+    "Mobs-Info": {
+      "version": "0.2.4-GTNH",
+      "side": "BOTH"
+    },
+    "BeeBetterAtBees-GTNH": {
+      "version": "0.4.0-GTNH",
+      "side": "CLIENT"
+    },
+    "AlchemyGrate": {
+      "version": "1.1.0-GTNH",
+      "side": "BOTH"
+    },
+    "Nutrition": {
+      "version": "0.0.9",
+      "side": "BOTH"
+    },
+    "Default-Configs": {
+      "version": "1.2.0",
+      "side": "CLIENT"
+    },
+    "CodeChickenLib": {
+      "version": "1.2.1",
+      "side": "BOTH"
+    },
+    "ThaumicBoots": {
+      "version": "1.2.1",
+      "side": "BOTH"
+    },
+    "Amazing-Trophies": {
+      "version": "1.2.1",
+      "side": "BOTH"
+    },
+    "ServerUtilities": {
+      "version": "2.0.27",
+      "side": "BOTH"
+    },
+    "Tinkers-Defense": {
+      "version": "1.2.2",
+      "side": "BOTH"
+    },
+    "neiaddons": {
+      "version": "1.15.0",
+      "side": "BOTH"
+    },
+    "Angelica": {
+      "version": "1.0.0-alpha31",
+      "side": "CLIENT"
     }
   },
   "external_mods": {
@@ -894,10 +902,6 @@
       "version": "1.7",
       "side": "BOTH"
     },
-    "FastCraft": {
-      "version": "1.25",
-      "side": "CLIENT"
-    },
     "CoFH Core": {
       "version": "3.1.4-329",
       "side": "BOTH"
@@ -920,10 +924,6 @@
     },
     "Thaumic Machina": {
       "version": "0.2.1",
-      "side": "BOTH"
-    },
-    "Tinkers' Defense": {
-      "version": "1.2.1d",
       "side": "BOTH"
     },
     "Travellers Gear": {
@@ -955,7 +955,7 @@
       "side": "BOTH"
     },
     "TC-4-Tweaks": {
-      "version": "1.5.18",
+      "version": "1.5.20",
       "side": "BOTH"
     },
     "Tinkers-Gregworks": {
@@ -967,7 +967,7 @@
       "side": "BOTH"
     },
     "Craft-Presence": {
-      "version": "2.2.5",
+      "version": "2.3.0",
       "side": "CLIENT"
     },
     "Gravitation-Suite-old": {
@@ -975,7 +975,15 @@
       "side": "BOTH"
     },
     "UniMixins": {
-      "version": "0.1.14",
+      "version": "0.1.16",
+      "side": "BOTH"
+    },
+    "CoreTweaks": {
+      "version": "0.3.3.2",
+      "side": "BOTH"
+    },
+    "Archaicfix": {
+      "version": "0.7.1",
       "side": "BOTH"
     }
   }

--- a/releases/readmes/README_nightly.MD
+++ b/releases/readmes/README_nightly.MD
@@ -1,6 +1,6 @@
 # GT New Horizons Mod Pack
 
-Version nightly is out 2023-12-20
+Version nightly is out 2024-03-02
 
 [![Build Status](http://jenkins.usrv.eu:8080/buildStatus/icon?job=GTNewHorizons%20Configs)](http://jenkins.usrv.eu:8080/job/GTNewHorizons%20Configs/)
 
@@ -8,7 +8,7 @@ Version nightly is out 2023-12-20
 
 <p align="justify">
     You are looking at a big progressive kitchensink pack for Minecraft 1.7.10 balanced around the mod GregTech.<BR><BR>
-    Over 8 years of development (and still going) have formed a balance and refinement that only a handful of packs can keep up with. We are talking about thousands of recipe tweaks, a massive questbook with over 3000 quests, unique world generation, custom mods coded for the pack, custom Thaumonomicon pages, and many more.
+    Over 9 years of development (and still going) have formed a balance and refinement that only a handful of packs can keep up with. We are talking about thousands of recipe tweaks, a massive questbook with over 3000 quests, unique world generation, custom mods coded for the pack, custom Thaumonomicon pages, and many more.
     The main intentions of the pack are a long-lasting experience and tying mods together in a progressive fashion, making it feel more like a single game than a compilation of mods thrown together.<BR><BR>
     To reach this goal, GT New Horizons is using the tiers (basically ages of technology) from GregTech and allocates content of other mods to a fitting point within the progression.<BR><BR>
     Starting in the stone age you will barely be able to survive until you get your first steam machines and, eventually, reach electricity. Later on, you will have to visit other planets and dimensions to gather important resources and fight mighty bosses to channel their magical power.<BR><BR>
@@ -147,7 +147,7 @@ Here is our Discord server in case you want to take a look at it:
 ### EU Servers:<BR>
 
 Official EU Server Public (whitelist)<BR>
-http://www.gtnewhorizons.com/ <BR>
+https://www.gtnewhorizons.com/ <BR>
 delta.gtnewhorizons.com<BR>
 epsilon.gtnewhorizons.com<BR>
 eta.gtnewhorizons.com<BR>
@@ -159,9 +159,6 @@ Modded Minecraft Club Falkenstein, Germany (open)<BR>
 https://www.moddedminecraft.club/ <BR>
 gtnh.moddedminecraft.club (Teleport enabled)<BR>
 gtnh-im.moddedminecraft.club (Ironman, no teleport)<BR>
-
-Craftersland
-Craftersland GTNH (EU-DE) gt.craftersland.net<BR>
 
 MineYourMine<BR>
 MineYourMine GTNH (EU) horizons.mineyourmind.net<BR>
@@ -224,8 +221,8 @@ IP: gtnh.114-7.com
 MultiMC Downloads: http://downloads.gtnewhorizons.com/Multi_mc_downloads/ <BR>
 Technic Launcher Link: http://www.technicpack.net/modpack/mcnewhorizons.677387 <BR>
 Curse Link: https://minecraft.curseforge.com/projects/gt-new-horizons <BR>
-Discord Link: https://discord.com/invite/gtnh <BR>
-Forum Link: http://gtnewhorizons.com/ <BR>
+Discord Link: https://discord.gg/EXshrPV <BR>
+Website Link: https://www.gtnewhorizons.com/ <BR>
 WIKI Link: https://gtnh.miraheze.org/wiki/Main_Page
 
 ### Contributing
@@ -245,247 +242,249 @@ Downloads can be found at http://downloads.gtnewhorizons.com - do not try to dow
 | Name | Version |
 | --- | --- |
 | [Advanced Solar Panel For 1.7.10 (Unofficial)](https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels) | 1.7.10 Edition |
-| [AdventureBackpack2](https://github.com/GTNewHorizons/AdventureBackpack2) | 1.0.17-GTNH |
-| [AE2FluidCraft-Rework](https://github.com/GTNewHorizons/AE2FluidCraft-Rework) | 1.1.74-gtnh |
-| [ae2stuff](https://github.com/GTNewHorizons/ae2stuff) | 0.6.0-GTNH |
-| [AFSU](https://github.com/GTNewHorizons/AFSU) | 1.2.6-GTNH |
-| [AlchemyGrate](https://github.com/GTNewHorizons/AlchemyGrate) | 1.0.3-GTNH |
-| [Amazing-Trophies](https://github.com/GTNewHorizons/Amazing-Trophies) | 1.1.4 |
-| [amunra](https://github.com/GTNewHorizons/amunra) | 0.5.0 |
-| [AngerMod](https://github.com/GTNewHorizons/AngerMod) | 0.6.3 |
-| [AppleCore](https://github.com/GTNewHorizons/AppleCore) | 3.2.12 |
-| [Applied-Energistics-2-Unofficial](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial) | rv3-beta-292-GTNH |
-| [ArchitectureCraft](https://github.com/GTNewHorizons/ArchitectureCraft) | 1.8.6 |
+| [AdventureBackpack2](https://github.com/GTNewHorizons/AdventureBackpack2) | 1.1.1-GTNH |
+| [AE2FluidCraft-Rework](https://github.com/GTNewHorizons/AE2FluidCraft-Rework) | 1.2.19-gtnh |
+| [ae2stuff](https://github.com/GTNewHorizons/ae2stuff) | 0.7.0-GTNH |
+| [AFSU](https://github.com/GTNewHorizons/AFSU) | 1.3.0-GTNH |
+| [AlchemyGrate](https://github.com/GTNewHorizons/AlchemyGrate) | 1.1.0-GTNH |
+| [Amazing-Trophies](https://github.com/GTNewHorizons/Amazing-Trophies) | 1.2.1 |
+| [amunra](https://github.com/GTNewHorizons/amunra) | 0.5.1 |
+| [Angelica](https://github.com/GTNewHorizons/Angelica) | 1.0.0-alpha31 |
+| [AngerMod](https://github.com/GTNewHorizons/AngerMod) | 0.7.1 |
+| [AppleCore](https://github.com/GTNewHorizons/AppleCore) | 3.3.0 |
+| [Applied-Energistics-2-Unofficial](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial) | rv3-beta-331-GTNH-pre |
+| [Archaicfix](https://github.com/embeddedt/ArchaicFix) | 0.7.1 |
+| [ArchitectureCraft](https://github.com/GTNewHorizons/ArchitectureCraft) | 1.9.4 |
 | [Aroma1997Core](https://www.curseforge.com/minecraft/mc-mods/aroma1997core) | 1.0.2.16 |
 | [AromaBackup](https://www.curseforge.com/minecraft/mc-mods/aromabackup) | 0.1.0.0 |
-| [AsieLib](https://github.com/GTNewHorizons/AsieLib) | 0.5.4 |
+| [AsieLib](https://github.com/GTNewHorizons/AsieLib) | 0.5.5 |
 | [Automagy](https://www.curseforge.com/minecraft/mc-mods/automagy) | 0.28.2 |
-| [Avaritia](https://github.com/GTNewHorizons/Avaritia) | 1.46 |
-| [Avaritiaddons](https://github.com/GTNewHorizons/Avaritiaddons) | 1.6.0-GTNH |
-| [bartworks](https://github.com/GTNewHorizons/bartworks) | 0.8.23 |
-| [Battlegear2](https://github.com/GTNewHorizons/Battlegear2) | 1.3.0 |
-| [Baubles](https://github.com/GTNewHorizons/Baubles) | 1.0.3 |
-| [bdlib](https://github.com/GTNewHorizons/bdlib) | 1.9.8-GTNH |
-| [BeeBetterAtBees-GTNH](https://github.com/GTNewHorizons/BeeBetterAtBees-GTNH) | 0.3.1-GTNH |
-| [BetterAchievements](https://github.com/GTNewHorizons/BetterAchievements) | 0.1.3 |
-| [BetterBuildersWands](https://github.com/GTNewHorizons/BetterBuildersWands) | 0.10.1-GTNH |
-| [BetterCrashes](https://github.com/GTNewHorizons/BetterCrashes) | 1.3.5-GTNH |
-| [BetterLoadingScreen](https://github.com/GTNewHorizons/BetterLoadingScreen) | 1.5.3-GTNH |
-| [BetterP2P](https://github.com/GTNewHorizons/BetterP2P) | 1.1.20 |
-| [BetterQuesting](https://github.com/GTNewHorizons/BetterQuesting) | 3.4.7-GTNH |
+| [Avaritia](https://github.com/GTNewHorizons/Avaritia) | 1.49 |
+| [Avaritiaddons](https://github.com/GTNewHorizons/Avaritiaddons) | 1.7.0-GTNH |
+| [bartworks](https://github.com/GTNewHorizons/bartworks) | 0.9.13-pre |
+| [Battlegear2](https://github.com/GTNewHorizons/Battlegear2) | 1.3.5 |
+| [Baubles](https://github.com/GTNewHorizons/Baubles) | 1.0.4 |
+| [bdlib](https://github.com/GTNewHorizons/bdlib) | 1.10.0-GTNH |
+| [BeeBetterAtBees-GTNH](https://github.com/GTNewHorizons/BeeBetterAtBees-GTNH) | 0.4.0-GTNH |
+| [BetterAchievements](https://github.com/GTNewHorizons/BetterAchievements) | 0.2.0 |
+| [BetterBuildersWands](https://github.com/GTNewHorizons/BetterBuildersWands) | 0.11.0-GTNH |
+| [BetterCrashes](https://github.com/GTNewHorizons/BetterCrashes) | 1.4.0-GTNH |
+| [BetterLoadingScreen](https://github.com/GTNewHorizons/BetterLoadingScreen) | 1.6.0-GTNH |
+| [BetterP2P](https://github.com/GTNewHorizons/BetterP2P) | 1.2.0 |
+| [BetterQuesting](https://github.com/GTNewHorizons/BetterQuesting) | 3.5.8-GTNH |
 | [BiblioCraft: BiblioWoods Biomes O'Plenty Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-biomes-oplenty-edition) | 1.9 |
 | [BiblioCraft: BiblioWoods Forestry Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-forestry-edition) | 1.7 |
 | [BiblioCraft: BiblioWoods Natura Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-natura-edition) | 1.5 |
 | [BiblioCraft](https://www.curseforge.com/minecraft/mc-mods/bibliocraft) | 1.11.7 |
-| [Binnie](https://github.com/GTNewHorizons/Binnie) | 2.2.4 |
+| [Binnie](https://github.com/GTNewHorizons/Binnie) | 2.3.3 |
 | [Biomes O' Plenty](https://www.curseforge.com/minecraft/mc-mods/biomes-o-plenty) | 2.1.0.2308 |
-| [BlockLimiter](https://github.com/GTNewHorizons/BlockLimiter) | 0.55 |
-| [BlockRenderer6343](https://github.com/GTNewHorizons/BlockRenderer6343) | 1.0.6 |
-| [BloodArsenal](https://github.com/GTNewHorizons/BloodArsenal) | 1.2.11 |
-| [BloodMagic](https://github.com/GTNewHorizons/BloodMagic) | 1.4.3 |
-| [Botania](https://github.com/GTNewHorizons/Botania) | 1.10.3-GTNH |
-| [Botanic-horizons](https://github.com/GTNewHorizons/Botanic-horizons) | 1.0.19-GTNH |
-| [BrandonsCore](https://github.com/GTNewHorizons/BrandonsCore) | 1.0.0.13-GTNH |
-| [BugTorch](https://github.com/GTNewHorizons/BugTorch) | 1.2.12-GTNH |
-| [BuildCraft](https://github.com/GTNewHorizons/BuildCraft) | 7.1.38 |
-| [BuildCraftCompat](https://github.com/GTNewHorizons/BuildCraftCompat) | 7.1.16 |
-| [BuildCraftOilTweak](https://github.com/GTNewHorizons/BuildCraftOilTweak) | 1.0.4 |
-| [CarpentersBlocks](https://github.com/GTNewHorizons/CarpentersBlocks) | 3.4.1-GTNH |
-| [Catwalks-2](https://github.com/GTNewHorizons/Catwalks-2) | 2.1.4-GTNH |
-| [Chisel](https://github.com/GTNewHorizons/Chisel) | 2.12.3-GTNH |
-| [ChiselTones](https://github.com/GTNewHorizons/ChiselTones) | 1.0.4-GTNH |
-| [CodeChickenCore](https://github.com/GTNewHorizons/CodeChickenCore) | 1.1.13 |
-| [CodeChickenLib](https://github.com/GTNewHorizons/CodeChickenLib) | 1.1.10 |
+| [BlockLimiter](https://github.com/GTNewHorizons/BlockLimiter) | 0.6.0 |
+| [BlockRenderer6343](https://github.com/GTNewHorizons/BlockRenderer6343) | 1.1.6 |
+| [BloodArsenal](https://github.com/GTNewHorizons/BloodArsenal) | 1.3.1 |
+| [BloodMagic](https://github.com/GTNewHorizons/BloodMagic) | 1.5.1 |
+| [Botania](https://github.com/GTNewHorizons/Botania) | 1.10.10-GTNH |
+| [Botanic-horizons](https://github.com/GTNewHorizons/Botanic-horizons) | 1.1.2-GTNH |
+| [BrandonsCore](https://github.com/GTNewHorizons/BrandonsCore) | 1.1.0-GTNH |
+| [BugTorch](https://github.com/GTNewHorizons/BugTorch) | 1.2.13-GTNH |
+| [BuildCraft](https://github.com/GTNewHorizons/BuildCraft) | 7.1.39 |
+| [BuildCraftCompat](https://github.com/GTNewHorizons/BuildCraftCompat) | 7.1.17 |
+| [BuildCraftOilTweak](https://github.com/GTNewHorizons/BuildCraftOilTweak) | 1.1.0 |
+| [CarpentersBlocks](https://github.com/GTNewHorizons/CarpentersBlocks) | 3.5.1-GTNH |
+| [Catwalks-2](https://github.com/GTNewHorizons/Catwalks-2) | 2.2.1-GTNH |
+| [Chisel](https://github.com/GTNewHorizons/Chisel) | 2.14.1-GTNH |
+| [ChiselTones](https://github.com/GTNewHorizons/ChiselTones) | 1.1.0-GTNH |
+| [CodeChickenCore](https://github.com/GTNewHorizons/CodeChickenCore) | 1.2.1 |
+| [CodeChickenLib](https://github.com/GTNewHorizons/CodeChickenLib) | 1.2.1 |
 | [CoFH Core](https://www.curseforge.com/minecraft/mc-mods/cofh-core) | 3.1.4-329 |
 | [Compact Kinetic Generators](https://forum.industrial-craft.net/thread/12724-ic2-exp-1-7-10-compact-kinetic-generators/) | 1.0 |
-| [Computronics](https://github.com/GTNewHorizons/Computronics) | 1.7.1-GTNH |
-| [Controlling](https://github.com/GTNewHorizons/Controlling) | 2.0.1 |
-| [CookingForBlockheads](https://github.com/GTNewHorizons/CookingForBlockheads) | 1.2.16-GTNH |
-| [Craft-Presence](https://www.curseforge.com/minecraft/mc-mods/craftpresence/) | 2.2.5 |
-| [CraftTweaker](https://github.com/GTNewHorizons/CraftTweaker) | 3.2.13 |
-| [CreativeCore](https://github.com/GTNewHorizons/CreativeCore) | 1.3.31-GTNH |
-| [CropLoadCore](https://github.com/GTNewHorizons/CropLoadCore) | 0.1.10 |
-| [Crops-plus-plus](https://github.com/GTNewHorizons/Crops-plus-plus) | 1.5.12 |
-| [Custom-Main-Menu](https://github.com/GTNewHorizons/Custom-Main-Menu) | 1.10.3 |
-| [Default-Configs](https://github.com/GTNewHorizons/Default-Configs) | 1.1.6 |
-| [DefaultServerList](https://github.com/GTNewHorizons/DefaultServerList) | 1.4.0 |
-| [DefaultWorldGenerator](https://github.com/GTNewHorizons/DefaultWorldGenerator) | 0.2 |
-| [DetravScannerMod](https://github.com/GTNewHorizons/DetravScannerMod) | 1.7.2 |
-| [Draconic-Evolution](https://github.com/GTNewHorizons/Draconic-Evolution) | 1.2.1-GTNH |
-| [DummyCore](https://github.com/GTNewHorizons/DummyCore) | 1.17.0 |
-| [DuraDisplay](https://github.com/GTNewHorizons/DuraDisplay) | 1.1.7 |
-| [Electro-Magic-Tools](https://github.com/GTNewHorizons/Electro-Magic-Tools) | 1.3.8 |
-| [EnderCore](https://github.com/GTNewHorizons/EnderCore) | 0.2.19 |
-| [EnderIO](https://github.com/GTNewHorizons/EnderIO) | 2.5.9 |
-| [EnderStorage](https://github.com/GTNewHorizons/EnderStorage) | 1.4.12 |
-| [EnderZoo](https://github.com/GTNewHorizons/EnderZoo) | 1.0.23 |
-| [EnhancedLootBags](https://github.com/GTNewHorizons/EnhancedLootBags) | 1.1.0 |
-| [Eternal-Singularity](https://github.com/GTNewHorizons/Eternal-Singularity) | 1.1.2 |
+| [Computronics](https://github.com/GTNewHorizons/Computronics) | 1.7.2-GTNH |
+| [Controlling](https://github.com/GTNewHorizons/Controlling) | 2.0.2 |
+| [CookingForBlockheads](https://github.com/GTNewHorizons/CookingForBlockheads) | 1.3.3-GTNH |
+| [CoreTweaks](https://github.com/makamys/CoreTweaks) | 0.3.3.2 |
+| [Craft-Presence](https://www.curseforge.com/minecraft/mc-mods/craftpresence/) | 2.3.0 |
+| [CraftTweaker](https://github.com/GTNewHorizons/CraftTweaker) | 3.3.1 |
+| [CreativeCore](https://github.com/GTNewHorizons/CreativeCore) | 1.4.0-GTNH |
+| [CropLoadCore](https://github.com/GTNewHorizons/CropLoadCore) | 0.2.0 |
+| [Crops-plus-plus](https://github.com/GTNewHorizons/Crops-plus-plus) | 1.6.3 |
+| [Custom-Main-Menu](https://github.com/GTNewHorizons/Custom-Main-Menu) | 1.11.0 |
+| [Default-Configs](https://github.com/GTNewHorizons/Default-Configs) | 1.2.0 |
+| [DefaultServerList](https://github.com/GTNewHorizons/DefaultServerList) | 1.5.0 |
+| [DefaultWorldGenerator](https://github.com/GTNewHorizons/DefaultWorldGenerator) | 0.3.0 |
+| [DetravScannerMod](https://github.com/GTNewHorizons/DetravScannerMod) | 1.8.0 |
+| [Draconic-Evolution](https://github.com/GTNewHorizons/Draconic-Evolution) | 1.3.2-GTNH |
+| [DummyCore](https://github.com/GTNewHorizons/DummyCore) | 1.18.0 |
+| [DuraDisplay](https://github.com/GTNewHorizons/DuraDisplay) | 1.2.2 |
+| [Electro-Magic-Tools](https://github.com/GTNewHorizons/Electro-Magic-Tools) | 1.4.4 |
+| [EnderCore](https://github.com/GTNewHorizons/EnderCore) | 0.4.5 |
+| [EnderIO](https://github.com/GTNewHorizons/EnderIO) | 2.7.1 |
+| [EnderStorage](https://github.com/GTNewHorizons/EnderStorage) | 1.5.0 |
+| [EnderZoo](https://github.com/GTNewHorizons/EnderZoo) | 1.1.0 |
+| [EnhancedLootBags](https://github.com/GTNewHorizons/EnhancedLootBags) | 1.1.1 |
+| [Eternal-Singularity](https://github.com/GTNewHorizons/Eternal-Singularity) | 1.2.0 |
 | [Extra Utilities](https://www.curseforge.com/minecraft/mc-mods/extra-utilities) | 1.2.13a |
-| [FastCraft](https://www.curseforge.com/minecraft/mc-mods/fastcraft) | 1.25 |
-| [FindIt](https://github.com/GTNewHorizons/FindIt) | 1.1.0 |
-| [FloodLights](https://github.com/GTNewHorizons/FloodLights) | 1.2.9 |
-| [ForbiddenMagic](https://github.com/GTNewHorizons/ForbiddenMagic) | 0.6.7-GTNH |
-| [ForestryMC](https://github.com/GTNewHorizons/ForestryMC) | 4.7.1 |
-| [Forgelin](https://github.com/GTNewHorizons/Forgelin) | 1.9.7-GTNH |
-| [ForgeMultipart](https://github.com/GTNewHorizons/ForgeMultipart) | 1.4.1 |
-| [ForgeRelocation](https://github.com/GTNewHorizons/ForgeRelocation) | 0.0.3 |
-| [ForgeRelocationFMP](https://github.com/GTNewHorizons/ForgeRelocationFMP) | 0.0.4 |
-| [Gadomancy](https://github.com/GTNewHorizons/Gadomancy) | 1.2.0 |
-| [GalacticGregGT5](https://github.com/GTNewHorizons/GalacticGregGT5) | 1.0.10 |
-| [Galacticraft](https://github.com/GTNewHorizons/Galacticraft) | 3.0.75-GTNH |
-| [Galaxy-Space-GTNH](https://github.com/GTNewHorizons/Galaxy-Space-GTNH) | 1.2.15-GTNH |
-| [gendustry](https://github.com/GTNewHorizons/gendustry) | 1.6.5.5-GTNH |
-| [GigaGramFab](https://github.com/GTNewHorizons/GigaGramFab) | 0.3.9 |
-| [GoodGenerator](https://github.com/GTNewHorizons/GoodGenerator) | 0.7.17 |
-| [Gravitation-Suite-Neo](https://github.com/GTNewHorizons/Gravitation-Suite-Neo) | 1.0.20 |
+| [FindIt](https://github.com/GTNewHorizons/FindIt) | 1.2.3 |
+| [FloodLights](https://github.com/GTNewHorizons/FloodLights) | 1.3.0 |
+| [ForbiddenMagic](https://github.com/GTNewHorizons/ForbiddenMagic) | 0.7.0-GTNH |
+| [ForestryMC](https://github.com/GTNewHorizons/ForestryMC) | 4.8.4 |
+| [Forgelin](https://github.com/GTNewHorizons/Forgelin) | 1.9.9-GTNH |
+| [ForgeMultipart](https://github.com/GTNewHorizons/ForgeMultipart) | 1.4.8 |
+| [ForgeRelocation](https://github.com/GTNewHorizons/ForgeRelocation) | 0.1.2 |
+| [ForgeRelocationFMP](https://github.com/GTNewHorizons/ForgeRelocationFMP) | 0.1.0 |
+| [Gadomancy](https://github.com/GTNewHorizons/Gadomancy) | 1.3.2 |
+| [GalacticGregGT5](https://github.com/GTNewHorizons/GalacticGregGT5) | 1.1.0 |
+| [Galacticraft](https://github.com/GTNewHorizons/Galacticraft) | 3.1.3-GTNH |
+| [Galaxy-Space-GTNH](https://github.com/GTNewHorizons/Galaxy-Space-GTNH) | 1.1.82-GTNH |
+| [gendustry](https://github.com/GTNewHorizons/gendustry) | 1.7.0-GTNH |
+| [GigaGramFab](https://github.com/GTNewHorizons/GigaGramFab) | 0.3.14 |
+| [GoodGenerator](https://github.com/GTNewHorizons/GoodGenerator) | 0.8.13-pre |
+| [Gravitation-Suite-Neo](https://github.com/GTNewHorizons/Gravitation-Suite-Neo) | 1.1.1 |
 | [Gravitation-Suite-old](https://forum.industrial-craft.net/thread/6915-ic2-exp-1-7-10-gravitation-suite-v2-0-3/) | 2.0.3 |
-| [GT5-Unofficial](https://github.com/GTNewHorizons/GT5-Unofficial) | 5.09.44.110 |
-| [GTNEIOrePlugin](https://github.com/GTNewHorizons/GTNEIOrePlugin) | 1.1.3 |
-| [GTNH-Intergalactic](https://github.com/GTNewHorizons/GTNH-Intergalactic) | 1.2.9 |
-| [GTNH-Lanthanides](https://github.com/GTNewHorizons/GTNH-Lanthanides) | 0.11.9 |
-| [GTNH-TC-Wands](https://github.com/GTNewHorizons/GTNH-TC-Wands) | 1.3.1 |
-| [GTNHLib](https://github.com/GTNewHorizons/GTNHLib) | 0.0.13 |
-| [GTplusplus](https://github.com/GTNewHorizons/GTplusplus) | 1.10.54 |
+| [GT5-Unofficial](https://github.com/GTNewHorizons/GT5-Unofficial) | 5.09.45.85-pre |
+| [GTNEIOrePlugin](https://github.com/GTNewHorizons/GTNEIOrePlugin) | 1.2.0 |
+| [GTNH-Intergalactic](https://github.com/GTNewHorizons/GTNH-Intergalactic) | 1.3.1 |
+| [GTNH-Lanthanides](https://github.com/GTNewHorizons/GTNH-Lanthanides) | 0.12.11 |
+| [GTNH-TC-Wands](https://github.com/GTNewHorizons/GTNH-TC-Wands) | 1.4.0 |
+| [GTNHLib](https://github.com/GTNewHorizons/GTNHLib) | 0.2.10 |
+| [GTplusplus](https://github.com/GTNewHorizons/GTplusplus) | 1.11.31 |
 | [Hardcore Darkness](https://www.curseforge.com/minecraft/mc-mods/hardcore-darkness) | 1.7 |
-| [Hardcore-Ender-Expansion](https://github.com/GTNewHorizons/Hardcore-Ender-Expansion) | 1.9.7-GTNH |
-| [harvestcraft](https://github.com/GTNewHorizons/harvestcraft) | 1.1.4-GTNH |
+| [Hardcore-Ender-Expansion](https://github.com/GTNewHorizons/Hardcore-Ender-Expansion) | 1.10.1-GTNH |
+| [harvestcraft](https://github.com/GTNewHorizons/harvestcraft) | 1.1.10-GTNH |
 | [Healer](https://www.curseforge.com/minecraft/mc-mods/healer) | 1.2.1 |
-| [HelpFixer](https://github.com/GTNewHorizons/HelpFixer) | 1.1.0 |
-| [Hodgepodge](https://github.com/GTNewHorizons/Hodgepodge) | 2.3.41 |
-| [HoloInventory](https://github.com/GTNewHorizons/HoloInventory) | 2.3.2-GTNH |
-| [HungerOverhaul](https://github.com/GTNewHorizons/HungerOverhaul) | 1.0.4-GTNH |
-| [HydroEnergy](https://github.com/GTNewHorizons/HydroEnergy) | 1.1.1 |
+| [HelpFixer](https://github.com/GTNewHorizons/HelpFixer) | 1.2.0 |
+| [Hodgepodge](https://github.com/GTNewHorizons/Hodgepodge) | 2.4.34 |
+| [HoloInventory](https://github.com/GTNewHorizons/HoloInventory) | 2.4.3-GTNH |
+| [HungerOverhaul](https://github.com/GTNewHorizons/HungerOverhaul) | 1.1.0-GTNH |
+| [HydroEnergy](https://github.com/GTNewHorizons/HydroEnergy) | 1.2.0 |
 | [IC2 Crop-Breeding Plugin](https://www.curseforge.com/minecraft/mc-mods/ic2-nei-crop-plugin) | 1.3.1 |
-| [IFU](https://github.com/GTNewHorizons/IFU) | 1.9.6 |
-| [IguanaTweaksTConstruct](https://github.com/GTNewHorizons/IguanaTweaksTConstruct) | 2.3.0 |
+| [IFU](https://github.com/GTNewHorizons/IFU) | 1.10.1 |
+| [IguanaTweaksTConstruct](https://github.com/GTNewHorizons/IguanaTweaksTConstruct) | 2.4.1 |
 | [Industrial Craft 2](https://www.curseforge.com/minecraft/mc-mods/industrial-craft) | 2.2.82a-experimental |
-| [Infernal-Mobs](https://github.com/GTNewHorizons/Infernal-Mobs) | 1.7.9-GTNH |
-| [InGame-Info-XML](https://github.com/GTNewHorizons/InGame-Info-XML) | 2.8.5 |
-| [INpureCore](https://github.com/GTNewHorizons/INpureCore) | 1.1.5-GTNH |
-| [inventory-tweaks](https://github.com/GTNewHorizons/inventory-tweaks) | 1.6.1 |
-| [ironchest](https://github.com/GTNewHorizons/ironchest) | 6.0.74 |
-| [IronChestMinecarts](https://github.com/GTNewHorizons/IronChestMinecarts) | 1.0.8 |
-| [Irontanks](https://github.com/GTNewHorizons/Irontanks) | 1.2.6 |
-| [Jabba](https://github.com/GTNewHorizons/Jabba) | 1.3.1 |
+| [Infernal-Mobs](https://github.com/GTNewHorizons/Infernal-Mobs) | 1.8.1-GTNH |
+| [InGame-Info-XML](https://github.com/GTNewHorizons/InGame-Info-XML) | 2.8.6 |
+| [INpureCore](https://github.com/GTNewHorizons/INpureCore) | 1.2.0-GTNH |
+| [inventory-tweaks](https://github.com/GTNewHorizons/inventory-tweaks) | 1.6.2 |
+| [ironchest](https://github.com/GTNewHorizons/ironchest) | 6.0.76-pre |
+| [IronChestMinecarts](https://github.com/GTNewHorizons/IronChestMinecarts) | 1.1.0 |
+| [Irontanks](https://github.com/GTNewHorizons/Irontanks) | 1.3.0 |
+| [Jabba](https://github.com/GTNewHorizons/Jabba) | 1.3.2 |
 | [JourneyMap Server](https://www.curseforge.com/minecraft/mc-mods/journeymap-server) | 1.0.5 |
 | [JourneyMap](https://www.curseforge.com/minecraft/mc-mods/journeymap) | 5.1.4p6-fairplay |
-| [KekzTech](https://github.com/GTNewHorizons/KekzTech) | 0.9.6 |
-| [KubaTech](https://github.com/GTNewHorizons/KubaTech) | 0.13.12 |
-| [LittleTiles](https://github.com/GTNewHorizons/LittleTiles) | 1.2.9-GTNH |
-| [LogisticsPipes](https://github.com/GTNewHorizons/LogisticsPipes) | 1.0.8-GTNH |
-| [LootGames](https://github.com/GTNewHorizons/LootGames) | 2.0.8 |
-| [LunatriusCore](https://github.com/GTNewHorizons/LunatriusCore) | 1.1.7-GTNH |
-| [lwjgl3ify](https://github.com/GTNewHorizons/lwjgl3ify) | 1.5.7 |
-| [MagicBees](https://github.com/GTNewHorizons/MagicBees) | 2.7.1-GTNH |
-| [MalisisCore](https://github.com/GTNewHorizons/MalisisCore) | 0.14.9 |
-| [MalisisDoors](https://github.com/GTNewHorizons/MalisisDoors) | 1.14.0-GTNH |
-| [Mantle](https://github.com/GTNewHorizons/Mantle) | 0.3.7 |
-| [Minecraft-Backpack-Mod](https://github.com/GTNewHorizons/Minecraft-Backpack-Mod) | 2.2.12-GTNH |
-| [Minetweaker-Gregtech-5-Addon](https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon) | 2.0.5 |
-| [Mobs-Info](https://github.com/GTNewHorizons/Mobs-Info) | 0.1.13-GTNH |
-| [ModTweaker](https://github.com/GTNewHorizons/ModTweaker) | 0.9.10 |
-| [ModularUI](https://github.com/GTNewHorizons/ModularUI) | 1.1.24 |
+| [KekzTech](https://github.com/GTNewHorizons/KekzTech) | 0.10.0 |
+| [KubaTech](https://github.com/GTNewHorizons/KubaTech) | 0.14.5 |
+| [LittleTiles](https://github.com/GTNewHorizons/LittleTiles) | 1.3.0-GTNH |
+| [LogisticsPipes](https://github.com/GTNewHorizons/LogisticsPipes) | 1.1.3-GTNH |
+| [LootGames](https://github.com/GTNewHorizons/LootGames) | 2.1.1 |
+| [LunatriusCore](https://github.com/GTNewHorizons/LunatriusCore) | 1.2.0-GTNH |
+| [lwjgl3ify](https://github.com/GTNewHorizons/lwjgl3ify) | 2.0.0-alpha-9 |
+| [MagicBees](https://github.com/GTNewHorizons/MagicBees) | 2.7.14-GTNH |
+| [MalisisDoors](https://github.com/GTNewHorizons/MalisisDoors) | 1.16.2-GTNH |
+| [Mantle](https://github.com/GTNewHorizons/Mantle) | 0.4.1 |
+| [Minecraft-Backpack-Mod](https://github.com/GTNewHorizons/Minecraft-Backpack-Mod) | 2.3.0-GTNH |
+| [Minetweaker-Gregtech-5-Addon](https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon) | 2.1.0 |
+| [Mobs-Info](https://github.com/GTNewHorizons/Mobs-Info) | 0.2.4-GTNH |
+| [ModTweaker](https://github.com/GTNewHorizons/ModTweaker) | 0.10.0 |
+| [ModularUI](https://github.com/GTNewHorizons/ModularUI) | 1.1.35 |
 | [Morpheus](https://www.curseforge.com/minecraft/mc-mods/morpheus) | 1.6.21 |
-| [MouseTweaks](https://github.com/GTNewHorizons/MouseTweaks) | 2.4.9-GTNH |
-| [MrTJPCore](https://github.com/GTNewHorizons/MrTJPCore) | 1.1.5 |
-| [MX-Random](https://github.com/GTNewHorizons/MX-Random) | 0.2.0 |
-| [Natura](https://github.com/GTNewHorizons/Natura) | 2.5.7 |
-| [NaturesCompass](https://github.com/GTNewHorizons/NaturesCompass) | 1.3.6-GTNH |
-| [nei-custom-diagram](https://github.com/GTNewHorizons/nei-custom-diagram) | 1.5.14 |
-| [NEI-Integration](https://github.com/GTNewHorizons/NEI-Integration) | 1.3.3 |
-| [neiaddons](https://github.com/GTNewHorizons/neiaddons) | 1.13.0 |
-| [NetherPortalFix](https://github.com/GTNewHorizons/NetherPortalFix) | 1.1.2 |
-| [NewHorizonsCoreMod](https://github.com/GTNewHorizons/NewHorizonsCoreMod) | 2.2.55 |
-| [Nodal-Mechanics](https://github.com/GTNewHorizons/Nodal-Mechanics) | 1.1.-6-GTNH |
-| [NotEnoughEnergistics](https://github.com/GTNewHorizons/NotEnoughEnergistics) | 1.4.6 |
-| [NotEnoughIds](https://github.com/GTNewHorizons/NotEnoughIds) | 1.5.3 |
-| [NotEnoughItems](https://github.com/GTNewHorizons/NotEnoughItems) | 2.4.13-GTNH |
-| [Nuclear-Control](https://github.com/GTNewHorizons/Nuclear-Control) | 2.5.1 |
-| [Nutrition](https://github.com/GTNewHorizons/Nutrition) | 0.0.5 |
-| [oauth](https://github.com/GTNewHorizons/oauth) | 1.06.1-GTNH |
-| [OCGlasses](https://github.com/GTNewHorizons/OCGlasses) | 1.4.2-GTNH |
-| [OpenBlocks](https://github.com/GTNewHorizons/OpenBlocks) | 1.8.3-GTNH |
-| [OpenComputers](https://github.com/GTNewHorizons/OpenComputers) | 1.9.21-GTNH |
-| [OpenModsLib](https://github.com/GTNewHorizons/OpenModsLib) | 0.10.6 |
-| [OpenModularTurrets](https://github.com/GTNewHorizons/OpenModularTurrets) | 2.2.11-247 |
-| [OpenPrinter](https://github.com/GTNewHorizons/OpenPrinter) | 0.1.3-GTNH |
-| [OpenSecurity](https://github.com/GTNewHorizons/OpenSecurity) | 1.0.120-GTNH |
-| [Opis](https://github.com/GTNewHorizons/Opis) | 1.3.9-mapless |
-| [OverloadedArmorBar](https://github.com/GTNewHorizons/OverloadedArmorBar) | 1.0.3 |
+| [MouseTweaks](https://github.com/GTNewHorizons/MouseTweaks) | 2.4.17-GTNH |
+| [MrTJPCore](https://github.com/GTNewHorizons/MrTJPCore) | 1.1.6 |
+| [MX-Random](https://github.com/GTNewHorizons/MX-Random) | 0.3.0 |
+| [Natura](https://github.com/GTNewHorizons/Natura) | 2.6.0 |
+| [NaturesCompass](https://github.com/GTNewHorizons/NaturesCompass) | 1.4.0-GTNH |
+| [nei-custom-diagram](https://github.com/GTNewHorizons/nei-custom-diagram) | 1.5.15 |
+| [NEI-Integration](https://github.com/GTNewHorizons/NEI-Integration) | 1.4.0 |
+| [neiaddons](https://github.com/GTNewHorizons/neiaddons) | 1.15.0 |
+| [NetherPortalFix](https://github.com/GTNewHorizons/NetherPortalFix) | 1.2.0 |
+| [NewHorizonsCoreMod](https://github.com/GTNewHorizons/NewHorizonsCoreMod) | 2.3.34-pre |
+| [Nodal-Mechanics](https://github.com/GTNewHorizons/Nodal-Mechanics) | 1.2.1-GTNH |
+| [NotEnoughEnergistics](https://github.com/GTNewHorizons/NotEnoughEnergistics) | 1.5.1 |
+| [NotEnoughIds](https://github.com/GTNewHorizons/NotEnoughIds) | 2.0.3 |
+| [NotEnoughItems](https://github.com/GTNewHorizons/NotEnoughItems) | 2.5.23-GTNH |
+| [Nuclear-Control](https://github.com/GTNewHorizons/Nuclear-Control) | 2.6.1 |
+| [Nutrition](https://github.com/GTNewHorizons/Nutrition) | 0.0.9 |
+| [oauth](https://github.com/GTNewHorizons/oauth) | 1.2.2-GTNH |
+| [OCGlasses](https://github.com/GTNewHorizons/OCGlasses) | 1.5.0-GTNH |
+| [OpenBlocks](https://github.com/GTNewHorizons/OpenBlocks) | 1.9.1-GTNH |
+| [OpenComputers](https://github.com/GTNewHorizons/OpenComputers) | 1.10.7-GTNH |
+| [OpenModsLib](https://github.com/GTNewHorizons/OpenModsLib) | 0.10.9 |
+| [OpenModularTurrets](https://github.com/GTNewHorizons/OpenModularTurrets) | 2.3.1 |
+| [OpenPrinter](https://github.com/GTNewHorizons/OpenPrinter) | 0.2.0-GTNH |
+| [OpenSecurity](https://github.com/GTNewHorizons/OpenSecurity) | 1.1.1-GTNH |
+| [Opis](https://github.com/GTNewHorizons/Opis) | 1.4.2-mapless |
+| [OverloadedArmorBar](https://github.com/GTNewHorizons/OverloadedArmorBar) | 1.1.0 |
 | [Pam's Harvest the Nether](https://www.curseforge.com/minecraft/mc-mods/pams-harvest-the-nether) | 1.7.10a |
-| [PersonalSpace](https://github.com/GTNewHorizons/PersonalSpace) | 1.0.28 |
-| [Player-API](https://github.com/GTNewHorizons/Player-API) | 1.4.3 |
-| [ProjectBlue](https://github.com/GTNewHorizons/ProjectBlue) | 1.1.12-GTNH |
-| [ProjectRed](https://github.com/GTNewHorizons/ProjectRed) | 4.8.1-GTNH |
-| [Railcraft](https://github.com/GTNewHorizons/Railcraft) | 9.15.3 |
-| [Random-Things](https://github.com/GTNewHorizons/Random-Things) | 2.4.6 |
-| [Realistic-World-Gen](https://github.com/GTNewHorizons/Realistic-World-Gen) | alpha-1.3.9-pre |
-| [RemoteIO](https://github.com/GTNewHorizons/RemoteIO) | 2.4.8 |
-| [Roguelike-Dungeons](https://github.com/GTNewHorizons/Roguelike-Dungeons) | 1.5.3-GTNH |
-| [SC2](https://github.com/GTNewHorizons/SC2) | 2.0.2 |
-| [Schematica](https://github.com/GTNewHorizons/Schematica) | 1.9.4-GTNH |
-| [SGCraft](https://github.com/GTNewHorizons/SGCraft) | 1.3.13-GTNH |
-| [Share-Where-I-am](https://github.com/GTNewHorizons/Share-Where-I-am) | 2.0.2 |
-| [SleepingBags](https://github.com/GTNewHorizons/SleepingBags) | 0.1.4 |
-| [SpecialMobs](https://github.com/GTNewHorizons/SpecialMobs) | 3.4.3 |
-| [SpiceOfLife](https://github.com/GTNewHorizons/SpiceOfLife) | 2.1.1-carrot |
-| [Steve-s-Factory-Manager](https://github.com/GTNewHorizons/Steve-s-Factory-Manager) | 1.1.7-GTNH |
-| [StevesAddons](https://github.com/GTNewHorizons/StevesAddons) | 0.10.27 |
-| [StorageDrawers-BiomesOPlenty](https://github.com/GTNewHorizons/StorageDrawers-BiomesOPlenty) | 1.11.17-GTNH |
-| [StorageDrawers-Forestry](https://github.com/GTNewHorizons/StorageDrawers-Forestry) | 1.11.17-GTNH |
-| [StorageDrawers-Misc](https://github.com/GTNewHorizons/StorageDrawers-Misc) | 1.11.18-GTNH |
-| [StorageDrawers-Natura](https://github.com/GTNewHorizons/StorageDrawers-Natura) | 1.11.17-GTNH |
-| [StorageDrawers](https://github.com/GTNewHorizons/StorageDrawers) | 1.12.2-GTNH |
-| [StructureCompat](https://github.com/GTNewHorizons/StructureCompat) | 0.4.0 |
-| [StructureLib](https://github.com/GTNewHorizons/StructureLib) | 1.2.9 |
-| [Super-TiC](https://github.com/GTNewHorizons/Super-TiC) | 1.2.5 |
-| [supersolarpanels](https://github.com/GTNewHorizons/supersolarpanels) | 1.1.2-GT-NH-Mod |
-| [Tainted-Magic](https://github.com/GTNewHorizons/Tainted-Magic) | 7.6.3-GTNH |
-| [TC-4-Tweaks](https://www.curseforge.com/minecraft/mc-mods/tc4tweaks) | 1.5.18 |
-| [TCNEIAdditions](https://github.com/GTNewHorizons/TCNEIAdditions) | 1.2.2 |
-| [TCNodeTracker](https://github.com/GTNewHorizons/TCNodeTracker) | 1.1.7 |
-| [TecTech](https://github.com/GTNewHorizons/TecTech) | 5.3.23 |
+| [PersonalSpace](https://github.com/GTNewHorizons/PersonalSpace) | 1.0.30 |
+| [Player-API](https://github.com/GTNewHorizons/Player-API) | 1.4.4 |
+| [ProjectBlue](https://github.com/GTNewHorizons/ProjectBlue) | 1.2.0-GTNH |
+| [ProjectRed](https://github.com/GTNewHorizons/ProjectRed) | 4.9.4-GTNH |
+| [Railcraft](https://github.com/GTNewHorizons/Railcraft) | 9.15.6 |
+| [Random-Things](https://github.com/GTNewHorizons/Random-Things) | 2.5.1 |
+| [Realistic-World-Gen](https://github.com/GTNewHorizons/Realistic-World-Gen) | alpha-1.4.1 |
+| [RemoteIO](https://github.com/GTNewHorizons/RemoteIO) | 2.5.2 |
+| [Roguelike-Dungeons](https://github.com/GTNewHorizons/Roguelike-Dungeons) | 1.6.0-GTNH |
+| [SC2](https://github.com/GTNewHorizons/SC2) | 2.1.0 |
+| [Schematica](https://github.com/GTNewHorizons/Schematica) | 1.11.0-GTNH |
+| [ServerUtilities](https://github.com/GTNewHorizons/ServerUtilities) | 2.0.27 |
+| [SGCraft](https://github.com/GTNewHorizons/SGCraft) | 1.4.3-GTNH-pre |
+| [Share-Where-I-am](https://github.com/GTNewHorizons/Share-Where-I-am) | 2.1.1 |
+| [SleepingBags](https://github.com/GTNewHorizons/SleepingBags) | 0.2.0 |
+| [SpecialMobs](https://github.com/GTNewHorizons/SpecialMobs) | 3.5.0 |
+| [SpiceOfLife](https://github.com/GTNewHorizons/SpiceOfLife) | 2.1.7-carrot |
+| [Steve-s-Factory-Manager](https://github.com/GTNewHorizons/Steve-s-Factory-Manager) | 1.2.3-GTNH |
+| [StevesAddons](https://github.com/GTNewHorizons/StevesAddons) | 0.12.3 |
+| [StorageDrawers-BiomesOPlenty](https://github.com/GTNewHorizons/StorageDrawers-BiomesOPlenty) | 1.12.0-GTNH |
+| [StorageDrawers-Forestry](https://github.com/GTNewHorizons/StorageDrawers-Forestry) | 1.12.0-GTNH |
+| [StorageDrawers-Misc](https://github.com/GTNewHorizons/StorageDrawers-Misc) | 1.12.0-GTNH |
+| [StorageDrawers-Natura](https://github.com/GTNewHorizons/StorageDrawers-Natura) | 1.12.0-GTNH |
+| [StorageDrawers](https://github.com/GTNewHorizons/StorageDrawers) | 1.13.3-GTNH |
+| [StructureCompat](https://github.com/GTNewHorizons/StructureCompat) | 0.5.0 |
+| [StructureLib](https://github.com/GTNewHorizons/StructureLib) | 1.3.0 |
+| [Super-TiC](https://github.com/GTNewHorizons/Super-TiC) | 1.3.0 |
+| [supersolarpanels](https://github.com/GTNewHorizons/supersolarpanels) | 1.1.3 |
+| [Tainted-Magic](https://github.com/GTNewHorizons/Tainted-Magic) | 7.6.4-GTNH |
+| [TC-4-Tweaks](https://www.curseforge.com/minecraft/mc-mods/tc4tweaks) | 1.5.20 |
+| [TCNEIAdditions](https://github.com/GTNewHorizons/TCNEIAdditions) | 1.3.4 |
+| [TCNodeTracker](https://github.com/GTNewHorizons/TCNodeTracker) | 1.2.0 |
+| [TecTech](https://github.com/GTNewHorizons/TecTech) | 5.3.32 |
 | [Thaumcraft NEI Plugin](https://www.curseforge.com/minecraft/mc-mods/thaumcraft-nei-plugin) | 1.7a |
-| [thaumcraft-research-tweaks](https://github.com/GTNewHorizons/thaumcraft-research-tweaks) | 1.0.6 |
+| [thaumcraft-research-tweaks](https://github.com/GTNewHorizons/thaumcraft-research-tweaks) | 1.1.0 |
 | [Thaumcraft](https://www.curseforge.com/minecraft/mc-mods/thaumcraft) | 4.2.3.5a |
-| [ThaumcraftMobAspects](https://github.com/GTNewHorizons/ThaumcraftMobAspects) | 1.0.0-GTNH |
+| [ThaumcraftMobAspects](https://github.com/GTNewHorizons/ThaumcraftMobAspects) | 1.1.0-GTNH |
 | [Thaumic Machina](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/wip-mods/2200956-wip-1-7-10-open-beta-thaumcraft-4-2-addon-thaumic) | 0.2.1 |
-| [Thaumic_Exploration](https://github.com/GTNewHorizons/Thaumic_Exploration) | 1.2.0-GTNH |
-| [ThaumicBases](https://github.com/GTNewHorizons/ThaumicBases) | 1.5.6 |
-| [ThaumicBoots](https://github.com/GTNewHorizons/ThaumicBoots) | 1.1.0 |
-| [ThaumicEnergistics](https://github.com/GTNewHorizons/ThaumicEnergistics) | 1.5.4-GTNH |
-| [ThaumicHorizons](https://github.com/GTNewHorizons/ThaumicHorizons) | 1.4.2 |
-| [thaumicinsurgence](https://github.com/GTNewHorizons/thaumicinsurgence) | 0.2.7 |
-| [ThaumicInventoryScanning](https://github.com/GTNewHorizons/ThaumicInventoryScanning) | 1.0.12-GTNH |
-| [ThaumicTinkerer](https://github.com/GTNewHorizons/ThaumicTinkerer) | 2.8.5 |
-| [TiC-Tooltips](https://github.com/GTNewHorizons/TiC-Tooltips) | 1.3.0 |
-| [Tinkers' Defense](https://www.curseforge.com/minecraft/mc-mods/compendium) | 1.2.1d |
+| [Thaumic_Exploration](https://github.com/GTNewHorizons/Thaumic_Exploration) | 1.2.2-GTNH |
+| [ThaumicBases](https://github.com/GTNewHorizons/ThaumicBases) | 1.6.1 |
+| [ThaumicBoots](https://github.com/GTNewHorizons/ThaumicBoots) | 1.2.1 |
+| [ThaumicEnergistics](https://github.com/GTNewHorizons/ThaumicEnergistics) | 1.6.2-GTNH |
+| [ThaumicHorizons](https://github.com/GTNewHorizons/ThaumicHorizons) | 1.5.1 |
+| [thaumicinsurgence](https://github.com/GTNewHorizons/thaumicinsurgence) | 0.3.1 |
+| [ThaumicInventoryScanning](https://github.com/GTNewHorizons/ThaumicInventoryScanning) | 1.1.2-GTNH |
+| [ThaumicTinkerer](https://github.com/GTNewHorizons/ThaumicTinkerer) | 2.9.2 |
+| [TiC-Tooltips](https://github.com/GTNewHorizons/TiC-Tooltips) | 1.3.1 |
+| [Tinkers-Defense](https://github.com/GTNewHorizons/Tinkers-Defense) | 1.2.2 |
 | [Tinkers-Gregworks](https://github.com/Vexatos/TinkersGregworks/tree/GT-NH) | 1.0.25 |
-| [TinkersConstruct](https://github.com/GTNewHorizons/TinkersConstruct) | 1.10.13-GTNH |
-| [TinkersMechworks](https://github.com/GTNewHorizons/TinkersMechworks) | 0.3.0 |
-| [TooMuchLoot](https://github.com/GTNewHorizons/TooMuchLoot) | 4.1.0-GTNH |
-| [ToroHealth](https://github.com/GTNewHorizons/ToroHealth) | 1.0.4 |
-| [Translocators](https://github.com/GTNewHorizons/Translocators) | 1.1.2.21 |
+| [TinkersConstruct](https://github.com/GTNewHorizons/TinkersConstruct) | 1.11.11-GTNH |
+| [TinkersMechworks](https://github.com/GTNewHorizons/TinkersMechworks) | 0.3.1 |
+| [TooMuchLoot](https://github.com/GTNewHorizons/TooMuchLoot) | 4.2.0-GTNH |
+| [ToroHealth](https://github.com/GTNewHorizons/ToroHealth) | 1.1.0 |
+| [Translocators](https://github.com/GTNewHorizons/Translocators) | 1.2.1 |
 | [Travellers Gear](https://www.curseforge.com/minecraft/mc-mods/travellers-gear) | 1.16.6 |
-| [TravellersGearNeo](https://github.com/GTNewHorizons/TravellersGearNeo) | 1.0 |
-| [twilightforest](https://github.com/GTNewHorizons/twilightforest) | 2.5.1 |
-| [TX-Loader](https://github.com/GTNewHorizons/TX-Loader) | 1.6.3 |
-| [UniMixins](https://github.com/LegacyModdingMC/UniMixins) | 0.1.14 |
-| [Universal-Singularities](https://github.com/GTNewHorizons/Universal-Singularities) | 8.6.7 |
-| [VisualProspecting](https://github.com/GTNewHorizons/VisualProspecting) | 1.2.1 |
-| [waila](https://github.com/GTNewHorizons/waila) | 1.6.5 |
-| [WailaHarvestability](https://github.com/GTNewHorizons/WailaHarvestability) | 1.1.10-GTNH |
-| [WAILAPlugins](https://github.com/GTNewHorizons/WAILAPlugins) | 0.3.0 |
-| [WanionLib](https://github.com/GTNewHorizons/WanionLib) | 1.8.4 |
-| [WarpTheory](https://github.com/GTNewHorizons/WarpTheory) | 1.2.17-GTNH |
-| [WAWLA](https://github.com/GTNewHorizons/WAWLA) | 1.1.3-GTNH |
-| [WirelessCraftingTerminal](https://github.com/GTNewHorizons/WirelessCraftingTerminal) | 1.10.1 |
-| [WirelessRedstone-CBE](https://github.com/GTNewHorizons/WirelessRedstone-CBE) | 1.4.8 |
+| [TravellersGearNeo](https://github.com/GTNewHorizons/TravellersGearNeo) | 1.1.0 |
+| [twilightforest](https://github.com/GTNewHorizons/twilightforest) | 2.5.17 |
+| [TX-Loader](https://github.com/GTNewHorizons/TX-Loader) | 1.7.0 |
+| [UniMixins](https://github.com/LegacyModdingMC/UniMixins) | 0.1.16 |
+| [Universal-Singularities](https://github.com/GTNewHorizons/Universal-Singularities) | 8.7.0 |
+| [VisualProspecting](https://github.com/GTNewHorizons/VisualProspecting) | 1.2.10 |
+| [waila](https://github.com/GTNewHorizons/waila) | 1.7.1 |
+| [WailaHarvestability](https://github.com/GTNewHorizons/WailaHarvestability) | 1.2.0-GTNH |
+| [WAILAPlugins](https://github.com/GTNewHorizons/WAILAPlugins) | 0.4.0 |
+| [WanionLib](https://github.com/GTNewHorizons/WanionLib) | 1.9.0 |
+| [WarpTheory](https://github.com/GTNewHorizons/WarpTheory) | 1.3.2-GTNH |
+| [WAWLA](https://github.com/GTNewHorizons/WAWLA) | 1.2.0-GTNH |
+| [WirelessCraftingTerminal](https://github.com/GTNewHorizons/WirelessCraftingTerminal) | 1.11.1 |
+| [WirelessRedstone-CBE](https://github.com/GTNewHorizons/WirelessRedstone-CBE) | 1.5.0 |
 | [Witchery](https://www.curseforge.com/minecraft/mc-mods/witchery) | 0.24.1 |
-| [WitcheryExtras](https://github.com/GTNewHorizons/WitcheryExtras) | 1.1.14 |
-| [WitchingGadgets](https://github.com/GTNewHorizons/WitchingGadgets) | 1.3.6-GTNH |
-| [Yamcl](https://github.com/GTNewHorizons/Yamcl) | 0.5.86 |
+| [WitcheryExtras](https://github.com/GTNewHorizons/WitcheryExtras) | 1.2.0 |
+| [WitchingGadgets](https://github.com/GTNewHorizons/WitchingGadgets) | 1.4.2-GTNH |
+| [Yamcl](https://github.com/GTNewHorizons/Yamcl) | 0.6.0 |
 | [Ztones](https://www.curseforge.com/minecraft/mc-mods/ztones) | 2.2.2 |
 
 ---

--- a/server_assets/forge/java9args.txt
+++ b/server_assets/forge/java9args.txt
@@ -1,6 +1,6 @@
---illegal-access=warn
--Djava.security.manager=allow
 -Dfile.encoding=UTF-8
+-Djava.system.class.loader=com.gtnewhorizons.retrofuturabootstrap.RfbSystemClassLoader
+-Djava.security.manager=allow
 --add-opens
 java.base/jdk.internal.loader=ALL-UNNAMED
 --add-opens
@@ -22,12 +22,12 @@ java.base/jdk.internal.reflect=ALL-UNNAMED
 --add-opens
 java.base/sun.nio.ch=ALL-UNNAMED
 --add-opens
+jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming
+--add-opens
 java.desktop/sun.awt.image=ALL-UNNAMED
---add-modules jdk.dynalink
+--add-opens
+java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED
 --add-opens
 jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED
---add-modules java.sql.rowset
 --add-opens
 java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED
--jar
-lwjgl3ify-forgePatches.jar

--- a/server_assets/forge/startserver-java9.bat
+++ b/server_assets/forge/startserver-java9.bat
@@ -1,2 +1,2 @@
 rem don't forget to accept the EULA or it won't boot
-java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt nogui
+java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt -jar lwjgl3ify-forgePatches.jar nogui

--- a/server_assets/forge/startserver-java9.sh
+++ b/server_assets/forge/startserver-java9.sh
@@ -3,7 +3,7 @@
 # don't forget to accept the EULA or it won't boot
 while true
 do
-   java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt nogui
+   java -Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt -jar lwjgl3ify-forgePatches.jar nogui
     echo "If you want to completely stop the server process now, press Ctrl+C before the time is up!"
     echo "Rebooting in:"
     for i in 12 11 10 9 8 7 6 5 4 3 2 1

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,7 +1,5 @@
 import asyncclick as click
 import httpx
-from colorama import Fore
-from httpx import AsyncClient
 from structlog import get_logger
 
 from gtnh.defs import Side
@@ -10,28 +8,22 @@ from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)
 
+
 @click.command()
 @click.argument("side", type=click.Choice([Side.CLIENT, Side.SERVER, Side.CLIENT_JAVA9, Side.SERVER_JAVA9]))
 @click.argument("minecraft_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
-async def update_pack_inplace(side: Side, minecraft_dir: str) -> None:
+@click.option("--use-symlink", is_flag=True, help="Use symlinks instead of copying files")
+async def update_pack_inplace(side: Side, minecraft_dir: str, use_symlink: bool = False) -> None:
     async with httpx.AsyncClient(http2=True) as client:
         m = GTNHModpackManager(client)
-        existing_release = m.get_release("nightly")
-        if not existing_release:
+        release = m.get_release("nightly")
+        if not release:
             raise ReleaseNotFoundException("Nightly release not found")
-
-        release = await m.update_release(
-            "nightly", existing_release=existing_release, update_available=True
-        )
-
-        if m.add_release(release, update=True):
-            log.info("Release generated!")
-            m.save_assets()
-            m.save_modpack()
 
         await m.download_release(release)
 
-        await m.update_pack_inplace(side, minecraft_dir)
+        await m.update_pack_inplace(release, side, minecraft_dir, use_symlink)
+
 
 if __name__ == "__main__":
     update_pack_inplace()

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,18 +1,37 @@
+import asyncclick as click
+import httpx
 from colorama import Fore
 from httpx import AsyncClient
 from structlog import get_logger
 
 from gtnh.defs import Side
+from gtnh.exceptions import ReleaseNotFoundException
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)
 
+@click.command()
+@click.argument("side", type=click.Choice([Side.CLIENT, Side.SERVER, Side.CLIENT_JAVA9, Side.SERVER_JAVA9]))
+@click.argument("minecraft_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+async def update_pack_inplace(side: Side, minecraft_dir: str) -> None:
+    async with httpx.AsyncClient(http2=True) as client:
+        m = GTNHModpackManager(client)
+        existing_release = m.get_release("nightly")
+        if not existing_release:
+            raise ReleaseNotFoundException("Nightly release not found")
 
-async def update_pack_inplace(side: Side, minecraft_dir: str, verbose: bool = False) -> None:
-    modpack_manager = GTNHModpackManager(AsyncClient(http2=True))
-    release = modpack_manager.get_release("nightly")
-    if not release:
-        log.error(f"Release `{Fore.LIGHTRED_EX}nightly{Fore.RESET}` not found! Error building the nightly archive.")
-        return
+        release = await m.update_release(
+            "nightly", existing_release=existing_release, update_available=True
+        )
 
-    await modpack_manager.update_pack_inplace(side, minecraft_dir, verbose)
+        if m.add_release(release, update=True):
+            log.info("Release generated!")
+            m.save_assets()
+            m.save_modpack()
+
+        await m.download_release(release)
+
+        await m.update_pack_inplace(side, minecraft_dir)
+
+if __name__ == "__main__":
+    update_pack_inplace()

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,0 +1,18 @@
+from colorama import Fore
+from httpx import AsyncClient
+from structlog import get_logger
+
+from gtnh.defs import Side
+from gtnh.modpack_manager import GTNHModpackManager
+
+log = get_logger(__name__)
+
+
+async def update_pack_inplace(side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    modpack_manager = GTNHModpackManager(AsyncClient(http2=True))
+    release = modpack_manager.get_release("nightly")
+    if not release:
+        log.error(f"Release `{Fore.LIGHTRED_EX}nightly{Fore.RESET}` not found! Error building the nightly archive.")
+        return
+
+    await modpack_manager.update_pack_inplace(side, minecraft_dir, verbose)

--- a/src/gtnh/defs.py
+++ b/src/gtnh/defs.py
@@ -40,6 +40,7 @@ class Archive(str, Enum):
 AVAILABLE_ASSETS_FILE = "gtnh-assets.json"
 GTNH_MODPACK_FILE = "gtnh-modpack.json"
 BLACKLISTED_REPOS_FILE = "repo-blacklist.json"
+LOCAL_EXCLUDES_FILE = ".inplace_mod_exclusions"
 UNKNOWN = "Unknown"
 OTHER = "Other"
 MAVEN_BASE_URL = "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/GTNewHorizons/"

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -706,7 +706,7 @@ class GTNHModpackManager:
 
             headers = {"Accept": "application/octet-stream"}
             if is_github:
-                headers |= {"Authorization": f"token {get_github_token()}"}
+                headers |= {"Authorization": f"token {get_github_token()}", "X-GitHub-Api-Version": "2022-11-28"}
 
             async with self.client.stream(url=download_url, headers=headers, method="GET", follow_redirects=True) as r:
                 try:
@@ -930,7 +930,7 @@ class GTNHModpackManager:
         else:
             raise ValueError(f"{side} isn't a valid side")
 
-    def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    async def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
 
         if not os.path.exists(minecraft_dir):
             log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
@@ -953,35 +953,37 @@ class GTNHModpackManager:
         for mod in self.assets.mods:
 
             if mod.name in exclusions:
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
-            if mod.side != side:
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
+            if mod.side not in side.valid_mod_sides():
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
                 continue
 
             if not mod.is_github():
-                log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
+                #log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
                 continue
 
             version = mod.get_latest_version()
             if not version:
-                log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+                #log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
                 continue
 
             mod_cache = get_asset_version_cache_location(mod, version)
 
             mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
             if os.path.exists(mod_dest):
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
             if not os.path.exists(mod_cache):
-                self.download_asset(mod, version.version_tag, is_github=True)
-
-            if not os.path.exists(mod_cache):
-                log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                #log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
                 continue
 
-            log.info(f"Copying {Fore.GREEN}{mod_cache}{Fore.RESET} to {Fore.GREEN}{mod_dest}{Fore.RESET}")
-            shutil.copy(mod_cache, mod_dest)
+            # use symlink if on unix, otherwise copy
+            if os.name == "posix":
+                log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                os.symlink(mod_cache, mod_dest)
+            else:
+                log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                shutil.copy(mod_cache, mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import shutil
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Optional, Tuple
@@ -15,6 +16,7 @@ from retry import retry
 from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
+from gtnh.assembler.exclusions import Exclusions
 from gtnh.defs import (
     AVAILABLE_ASSETS_FILE,
     BLACKLISTED_REPOS_FILE,
@@ -927,3 +929,59 @@ class GTNHModpackManager:
                 return True
         else:
             raise ValueError(f"{side} isn't a valid side")
+
+    def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+
+        if not os.path.exists(minecraft_dir):
+            log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
+            return
+
+        mods_dir = os.path.join(minecraft_dir, "mods")
+        if not os.path.exists(mods_dir):
+            log.error(f"{Fore.RED}Mods directory `{mods_dir}` does not exist{Fore.RESET}")
+            return
+
+        log.info(f"Updating {Fore.GREEN}{side.name}{Fore.RESET} side mods in place")
+
+        exclusions = {
+            Side.CLIENT: Exclusions(self.mod_pack.client_exclusions + self.mod_pack.client_java8_exclusions),
+            Side.SERVER: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java8_exclusions),
+            Side.CLIENT_JAVA9: Exclusions(self.mod_pack.client_exclusions + self.mod_pack.client_java9_exclusions),
+            Side.SERVER_JAVA9: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java9_exclusions),
+        }[side]
+
+        for mod in self.assets.mods:
+
+            if mod.name in exclusions:
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                continue
+
+            if mod.side != side:
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
+                continue
+
+            if not mod.is_github():
+                log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
+                continue
+
+            version = mod.get_latest_version()
+            if not version:
+                log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+                continue
+
+            mod_cache = get_asset_version_cache_location(mod, version)
+
+            mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
+            if os.path.exists(mod_dest):
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
+                continue
+
+            if not os.path.exists(mod_cache):
+                self.download_asset(mod, version.version_tag, is_github=True)
+
+            if not os.path.exists(mod_cache):
+                log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                continue
+
+            log.info(f"Copying {Fore.GREEN}{mod_cache}{Fore.RESET} to {Fore.GREEN}{mod_dest}{Fore.RESET}")
+            shutil.copy(mod_cache, mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -714,7 +714,7 @@ class GTNHModpackManager:
 
             headers = {"Accept": "application/octet-stream"}
             if is_github:
-                headers |= {"Authorization": f"token {get_github_token()}", "X-GitHub-Api-Version": "2022-11-28"}
+                headers |= {"Authorization": f"token {get_github_token()}"}
 
             async with self.client.stream(url=download_url, headers=headers, method="GET", follow_redirects=True) as r:
                 try:

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -22,6 +22,7 @@ from gtnh.defs import (
     BLACKLISTED_REPOS_FILE,
     GREEN_CHECK,
     GTNH_MODPACK_FILE,
+    LOCAL_EXCLUDES_FILE,
     MAVEN_BASE_URL,
     OTHER,
     RED_CROSS,
@@ -660,6 +661,13 @@ class GTNHModpackManager:
         """
         return ROOT_DIR / BLACKLISTED_REPOS_FILE
 
+    @property
+    def local_exclusions_path(self) -> Path:
+        """
+        Helper property for the local exclusions file location
+        """
+        return ROOT_DIR / LOCAL_EXCLUDES_FILE
+
     @retry(delay=5, tries=3)
     async def download_asset(
         self,
@@ -930,7 +938,9 @@ class GTNHModpackManager:
         else:
             raise ValueError(f"{side} isn't a valid side")
 
-    async def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    async def update_pack_inplace(
+        self, release: GTNHRelease, side: Side, minecraft_dir: str, use_symlink: bool = False
+    ) -> None:
 
         if not os.path.exists(minecraft_dir):
             log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
@@ -950,40 +960,63 @@ class GTNHModpackManager:
             Side.SERVER_JAVA9: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java9_exclusions),
         }[side]
 
-        for mod in self.assets.mods:
+        if os.path.exists(self.local_exclusions_path):
+            with open(self.local_exclusions_path, "r") as f:
+                local_exclusions = f.read().splitlines()
+
+        for mod_dict in release.github_mods.items():
+            mod_ver = self.assets.get_mod_and_version(
+                mod_dict[0], mod_dict[1], side.valid_mod_sides(), source=ModSource.github
+            )
+            if not mod_ver:
+                continue
+
+            mod = mod_ver[0]
+            version = mod_ver[1]
 
             if mod.name in exclusions:
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
-            if mod.side not in side.valid_mod_sides():
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
-                continue
-
-            if not mod.is_github():
-                #log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
-                continue
-
-            version = mod.get_latest_version()
-            if not version:
-                #log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+            if mod.name in local_exclusions if local_exclusions else []:
                 continue
 
             mod_cache = get_asset_version_cache_location(mod, version)
+            if not os.path.exists(mod_cache):
+                # log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                continue
+
+            # delete older versions
+            for old_version in mod.versions:
+                if old_version.version_tag == version.version_tag:
+                    continue
+
+                mod_dest = os.path.join(mods_dir, os.path.basename(get_asset_version_cache_location(mod, old_version)))
+                if os.path.exists(mod_dest):
+                    log.info(
+                        f"Deleting old version {Fore.CYAN}{old_version.version_tag}{Fore.RESET} of {Fore.CYAN}{mod.name}{Fore.RESET}"
+                    )
+                    os.remove(mod_dest)
 
             mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
             if os.path.exists(mod_dest):
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
-                continue
-
-            if not os.path.exists(mod_cache):
-                #log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
             # use symlink if on unix, otherwise copy
-            if os.name == "posix":
+            if use_symlink and os.name == "posix":
                 log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 os.symlink(mod_cache, mod_dest)
             else:
                 log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 shutil.copy(mod_cache, mod_dest)
+
+            for excluded_mod in local_exclusions if local_exclusions else []:
+                mod = self.assets.get_mod(excluded_mod)
+                if mod:
+                    for ver in mod.versions:
+                        mod_cache = get_asset_version_cache_location(mod, ver)
+                        mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
+                        if os.path.exists(mod_dest):
+                            log.info(f"Deleting {Fore.CYAN}{mod.name}{Fore.RESET} from the mods directory")
+                            os.remove(mod_dest)


### PR DESCRIPTION
Currently, this is mods only. Configs are not touched.

`generate_nightly` will need to be ran before hand

```
poetry run python -m gtnh.cli.generate_nightly --update-available
poetry run python -m gtnh.cli.update_pack_inplace [--use-symlink] <Side> "<.minecraft path>"
```

Side can be one of: CLIENT, SERVER, CLIENT_JAVA9, SERVER_JAVA9  
The `--use-symlink` flag can be supplied if you want mods to be symlinked from the cache (only on posix systems)

An example to update the mods on my server:
`poetry run python -m gtnh.cli.update_pack_inplace SERVER_JAVA9 "/mnt/rootshare/appdata/minecraft/gtnh/"`

and on my local computer:  
`poetry run python -m gtnh.cli.update_pack_inplace CLIENT_JAVA9 "/mnt/games/Minecraft/Instances/GTNH Nightly/.minecraft/"`

Quotes are only needed if the path contains spaces which can be escaped instead if you want.


To have certain mods excluded from the local pack, create a `.inplace_mod_exclusions` file in the root of the project and include the mod names from gtnh-assets.json  

Example (I use RTG + CC, ModernControlling, and Xaero's)
```
Realistic-World-Gen
DefaultWorldGenerator
Controlling
JourneyMap
JourneyMap Server
```