### PR TITLE
In-place pack mod updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 updated_mods.json
 releases/**/*.zip
 releases/curse/
+.inplace_mod_exclusions

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,7 +1,5 @@
 import asyncclick as click
 import httpx
-from colorama import Fore
-from httpx import AsyncClient
 from structlog import get_logger
 
 from gtnh.defs import Side
@@ -10,28 +8,22 @@ from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)
 
+
 @click.command()
 @click.argument("side", type=click.Choice([Side.CLIENT, Side.SERVER, Side.CLIENT_JAVA9, Side.SERVER_JAVA9]))
 @click.argument("minecraft_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
-async def update_pack_inplace(side: Side, minecraft_dir: str) -> None:
+@click.option("--use-symlink", is_flag=True, help="Use symlinks instead of copying files")
+async def update_pack_inplace(side: Side, minecraft_dir: str, use_symlink: bool = False) -> None:
     async with httpx.AsyncClient(http2=True) as client:
         m = GTNHModpackManager(client)
-        existing_release = m.get_release("nightly")
-        if not existing_release:
+        release = m.get_release("nightly")
+        if not release:
             raise ReleaseNotFoundException("Nightly release not found")
-
-        release = await m.update_release(
-            "nightly", existing_release=existing_release, update_available=True
-        )
-
-        if m.add_release(release, update=True):
-            log.info("Release generated!")
-            m.save_assets()
-            m.save_modpack()
 
         await m.download_release(release)
 
-        await m.update_pack_inplace(side, minecraft_dir)
+        await m.update_pack_inplace(release, side, minecraft_dir, use_symlink)
+
 
 if __name__ == "__main__":
     update_pack_inplace()

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,18 +1,37 @@
+import asyncclick as click
+import httpx
 from colorama import Fore
 from httpx import AsyncClient
 from structlog import get_logger
 
 from gtnh.defs import Side
+from gtnh.exceptions import ReleaseNotFoundException
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)
 
+@click.command()
+@click.argument("side", type=click.Choice([Side.CLIENT, Side.SERVER, Side.CLIENT_JAVA9, Side.SERVER_JAVA9]))
+@click.argument("minecraft_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+async def update_pack_inplace(side: Side, minecraft_dir: str) -> None:
+    async with httpx.AsyncClient(http2=True) as client:
+        m = GTNHModpackManager(client)
+        existing_release = m.get_release("nightly")
+        if not existing_release:
+            raise ReleaseNotFoundException("Nightly release not found")
 
-async def update_pack_inplace(side: Side, minecraft_dir: str, verbose: bool = False) -> None:
-    modpack_manager = GTNHModpackManager(AsyncClient(http2=True))
-    release = modpack_manager.get_release("nightly")
-    if not release:
-        log.error(f"Release `{Fore.LIGHTRED_EX}nightly{Fore.RESET}` not found! Error building the nightly archive.")
-        return
+        release = await m.update_release(
+            "nightly", existing_release=existing_release, update_available=True
+        )
 
-    await modpack_manager.update_pack_inplace(side, minecraft_dir, verbose)
+        if m.add_release(release, update=True):
+            log.info("Release generated!")
+            m.save_assets()
+            m.save_modpack()
+
+        await m.download_release(release)
+
+        await m.update_pack_inplace(side, minecraft_dir)
+
+if __name__ == "__main__":
+    update_pack_inplace()

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,0 +1,18 @@
+from colorama import Fore
+from httpx import AsyncClient
+from structlog import get_logger
+
+from gtnh.defs import Side
+from gtnh.modpack_manager import GTNHModpackManager
+
+log = get_logger(__name__)
+
+
+async def update_pack_inplace(side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    modpack_manager = GTNHModpackManager(AsyncClient(http2=True))
+    release = modpack_manager.get_release("nightly")
+    if not release:
+        log.error(f"Release `{Fore.LIGHTRED_EX}nightly{Fore.RESET}` not found! Error building the nightly archive.")
+        return
+
+    await modpack_manager.update_pack_inplace(side, minecraft_dir, verbose)

--- a/src/gtnh/cli/update_pack_inplace.py
+++ b/src/gtnh/cli/update_pack_inplace.py
@@ -1,9 +1,9 @@
 import asyncclick as click
 import httpx
-from structlog import get_logger
 
 from gtnh.defs import Side
 from gtnh.exceptions import ReleaseNotFoundException
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/defs.py
+++ b/src/gtnh/defs.py
@@ -40,6 +40,7 @@ class Archive(str, Enum):
 AVAILABLE_ASSETS_FILE = "gtnh-assets.json"
 GTNH_MODPACK_FILE = "gtnh-modpack.json"
 BLACKLISTED_REPOS_FILE = "repo-blacklist.json"
+LOCAL_EXCLUDES_FILE = ".inplace_mod_exclusions"
 UNKNOWN = "Unknown"
 OTHER = "Other"
 MAVEN_BASE_URL = "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/GTNewHorizons/"

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -706,7 +706,7 @@ class GTNHModpackManager:
 
             headers = {"Accept": "application/octet-stream"}
             if is_github:
-                headers |= {"Authorization": f"token {get_github_token()}"}
+                headers |= {"Authorization": f"token {get_github_token()}", "X-GitHub-Api-Version": "2022-11-28"}
 
             async with self.client.stream(url=download_url, headers=headers, method="GET", follow_redirects=True) as r:
                 try:
@@ -930,7 +930,7 @@ class GTNHModpackManager:
         else:
             raise ValueError(f"{side} isn't a valid side")
 
-    def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    async def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
 
         if not os.path.exists(minecraft_dir):
             log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
@@ -953,35 +953,37 @@ class GTNHModpackManager:
         for mod in self.assets.mods:
 
             if mod.name in exclusions:
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
-            if mod.side != side:
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
+            if mod.side not in side.valid_mod_sides():
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
                 continue
 
             if not mod.is_github():
-                log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
+                #log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
                 continue
 
             version = mod.get_latest_version()
             if not version:
-                log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+                #log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
                 continue
 
             mod_cache = get_asset_version_cache_location(mod, version)
 
             mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
             if os.path.exists(mod_dest):
-                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
+                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
             if not os.path.exists(mod_cache):
-                self.download_asset(mod, version.version_tag, is_github=True)
-
-            if not os.path.exists(mod_cache):
-                log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                #log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
                 continue
 
-            log.info(f"Copying {Fore.GREEN}{mod_cache}{Fore.RESET} to {Fore.GREEN}{mod_dest}{Fore.RESET}")
-            shutil.copy(mod_cache, mod_dest)
+            # use symlink if on unix, otherwise copy
+            if os.name == "posix":
+                log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                os.symlink(mod_cache, mod_dest)
+            else:
+                log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                shutil.copy(mod_cache, mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -994,9 +994,7 @@ class GTNHModpackManager:
                     continue
                 mod_dest = os.path.join(mods_dir, os.path.basename(get_asset_version_cache_location(mod, old_version)))
                 if os.path.exists(mod_dest):
-                    log.info(
-                        f"Deleting old version [{Fore.CYAN}{mod.name}:{old_version.version_tag}{Fore.RESET}]"
-                    )
+                    log.info(f"Deleting old version [{Fore.CYAN}{mod.name}:{old_version.version_tag}{Fore.RESET}]")
                     os.remove(mod_dest)
 
             mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
@@ -1016,10 +1014,14 @@ class GTNHModpackManager:
 
             # use symlink if set and on unix, otherwise copy
             if use_symlink and os.name == "posix":
-                log.info(f"Symlinking [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                log.info(
+                    f"Symlinking [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}"
+                )
                 os.symlink(mod_cache, mod_dest)
             else:
-                log.info(f"Copying [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                log.info(
+                    f"Copying [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}"
+                )
                 shutil.copy(mod_cache, mod_dest)
 
         log.info("Cleaning up the mods directory of excluded mods")
@@ -1031,5 +1033,7 @@ class GTNHModpackManager:
                     mod_cache = get_asset_version_cache_location(mod, ver)
                     mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
                     if os.path.exists(mod_dest):
-                        log.info(f"Deleting [{Fore.CYAN}{mod.name}:{ver.version_tag}{Fore.RESET}] from the mods directory")
+                        log.info(
+                            f"Deleting [{Fore.CYAN}{mod.name}:{ver.version_tag}{Fore.RESET}] from the mods directory"
+                        )
                         os.remove(mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -979,6 +979,7 @@ class GTNHModpackManager:
                 # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
+            # ignore mods that are excluded in the target mods directory
             if mod.name in local_exclusions if local_exclusions else []:
                 continue
 
@@ -1011,7 +1012,7 @@ class GTNHModpackManager:
                 # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
-            # use symlink if on unix, otherwise copy
+            # use symlink if set and on unix, otherwise copy
             if use_symlink and os.name == "posix":
                 log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 os.symlink(mod_cache, mod_dest)
@@ -1019,6 +1020,7 @@ class GTNHModpackManager:
                 log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 shutil.copy(mod_cache, mod_dest)
 
+            # delete excluded mods from target mods directory
             for excluded_mod in local_exclusions if local_exclusions else []:
                 mod = self.assets.get_mod(excluded_mod)
                 if mod:

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import shutil
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Optional, Tuple
@@ -15,6 +16,7 @@ from retry import retry
 from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
+from gtnh.assembler.exclusions import Exclusions
 from gtnh.defs import (
     AVAILABLE_ASSETS_FILE,
     BLACKLISTED_REPOS_FILE,
@@ -927,3 +929,59 @@ class GTNHModpackManager:
                 return True
         else:
             raise ValueError(f"{side} isn't a valid side")
+
+    def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+
+        if not os.path.exists(minecraft_dir):
+            log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
+            return
+
+        mods_dir = os.path.join(minecraft_dir, "mods")
+        if not os.path.exists(mods_dir):
+            log.error(f"{Fore.RED}Mods directory `{mods_dir}` does not exist{Fore.RESET}")
+            return
+
+        log.info(f"Updating {Fore.GREEN}{side.name}{Fore.RESET} side mods in place")
+
+        exclusions = {
+            Side.CLIENT: Exclusions(self.mod_pack.client_exclusions + self.mod_pack.client_java8_exclusions),
+            Side.SERVER: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java8_exclusions),
+            Side.CLIENT_JAVA9: Exclusions(self.mod_pack.client_exclusions + self.mod_pack.client_java9_exclusions),
+            Side.SERVER_JAVA9: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java9_exclusions),
+        }[side]
+
+        for mod in self.assets.mods:
+
+            if mod.name in exclusions:
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                continue
+
+            if mod.side != side:
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
+                continue
+
+            if not mod.is_github():
+                log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
+                continue
+
+            version = mod.get_latest_version()
+            if not version:
+                log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+                continue
+
+            mod_cache = get_asset_version_cache_location(mod, version)
+
+            mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
+            if os.path.exists(mod_dest):
+                log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
+                continue
+
+            if not os.path.exists(mod_cache):
+                self.download_asset(mod, version.version_tag, is_github=True)
+
+            if not os.path.exists(mod_cache):
+                log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                continue
+
+            log.info(f"Copying {Fore.GREEN}{mod_cache}{Fore.RESET} to {Fore.GREEN}{mod_dest}{Fore.RESET}")
+            shutil.copy(mod_cache, mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -714,7 +714,7 @@ class GTNHModpackManager:
 
             headers = {"Accept": "application/octet-stream"}
             if is_github:
-                headers |= {"Authorization": f"token {get_github_token()}", "X-GitHub-Api-Version": "2022-11-28"}
+                headers |= {"Authorization": f"token {get_github_token()}"}
 
             async with self.client.stream(url=download_url, headers=headers, method="GET", follow_redirects=True) as r:
                 try:

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -22,6 +22,7 @@ from gtnh.defs import (
     BLACKLISTED_REPOS_FILE,
     GREEN_CHECK,
     GTNH_MODPACK_FILE,
+    LOCAL_EXCLUDES_FILE,
     MAVEN_BASE_URL,
     OTHER,
     RED_CROSS,
@@ -660,6 +661,13 @@ class GTNHModpackManager:
         """
         return ROOT_DIR / BLACKLISTED_REPOS_FILE
 
+    @property
+    def local_exclusions_path(self) -> Path:
+        """
+        Helper property for the local exclusions file location
+        """
+        return ROOT_DIR / LOCAL_EXCLUDES_FILE
+
     @retry(delay=5, tries=3)
     async def download_asset(
         self,
@@ -930,7 +938,9 @@ class GTNHModpackManager:
         else:
             raise ValueError(f"{side} isn't a valid side")
 
-    async def update_pack_inplace(self, side: Side, minecraft_dir: str, verbose: bool = False) -> None:
+    async def update_pack_inplace(
+        self, release: GTNHRelease, side: Side, minecraft_dir: str, use_symlink: bool = False
+    ) -> None:
 
         if not os.path.exists(minecraft_dir):
             log.error(f"{Fore.RED}Minecraft directory `{minecraft_dir}` does not exist{Fore.RESET}")
@@ -950,40 +960,63 @@ class GTNHModpackManager:
             Side.SERVER_JAVA9: Exclusions(self.mod_pack.server_exclusions + self.mod_pack.server_java9_exclusions),
         }[side]
 
-        for mod in self.assets.mods:
+        if os.path.exists(self.local_exclusions_path):
+            with open(self.local_exclusions_path, "r") as f:
+                local_exclusions = f.read().splitlines()
+
+        for mod_dict in release.github_mods.items():
+            mod_ver = self.assets.get_mod_and_version(
+                mod_dict[0], mod_dict[1], side.valid_mod_sides(), source=ModSource.github
+            )
+            if not mod_ver:
+                continue
+
+            mod = mod_ver[0]
+            version = mod_ver[1]
 
             if mod.name in exclusions:
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
-            if mod.side not in side.valid_mod_sides():
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is not a {side.name} side mod, skipping")
-                continue
-
-            if not mod.is_github():
-                #log.error(f"{Fore.RED}{mod.name}{Fore.RESET} is not a github mod, skipping")
-                continue
-
-            version = mod.get_latest_version()
-            if not version:
-                #log.error(f"{Fore.RED}No version found for {mod.name}{Fore.RESET}")
+            if mod.name in local_exclusions if local_exclusions else []:
                 continue
 
             mod_cache = get_asset_version_cache_location(mod, version)
+            if not os.path.exists(mod_cache):
+                # log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                continue
+
+            # delete older versions
+            for old_version in mod.versions:
+                if old_version.version_tag == version.version_tag:
+                    continue
+
+                mod_dest = os.path.join(mods_dir, os.path.basename(get_asset_version_cache_location(mod, old_version)))
+                if os.path.exists(mod_dest):
+                    log.info(
+                        f"Deleting old version {Fore.CYAN}{old_version.version_tag}{Fore.RESET} of {Fore.CYAN}{mod.name}{Fore.RESET}"
+                    )
+                    os.remove(mod_dest)
 
             mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
             if os.path.exists(mod_dest):
-                #log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
-                continue
-
-            if not os.path.exists(mod_cache):
-                #log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
             # use symlink if on unix, otherwise copy
-            if os.name == "posix":
+            if use_symlink and os.name == "posix":
                 log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 os.symlink(mod_cache, mod_dest)
             else:
                 log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 shutil.copy(mod_cache, mod_dest)
+
+            for excluded_mod in local_exclusions if local_exclusions else []:
+                mod = self.assets.get_mod(excluded_mod)
+                if mod:
+                    for ver in mod.versions:
+                        mod_cache = get_asset_version_cache_location(mod, ver)
+                        mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
+                        if os.path.exists(mod_dest):
+                            log.info(f"Deleting {Fore.CYAN}{mod.name}{Fore.RESET} from the mods directory")
+                            os.remove(mod_dest)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -976,7 +976,7 @@ class GTNHModpackManager:
             version = mod_ver[1]
 
             if mod.name in exclusions:
-                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
+                log.debug(f"{Fore.YELLOW}{mod.name}{Fore.RESET} is excluded from the {side.name} side, skipping")
                 continue
 
             # ignore mods that are excluded in the target mods directory
@@ -985,7 +985,7 @@ class GTNHModpackManager:
 
             mod_cache = get_asset_version_cache_location(mod, version)
             if not os.path.exists(mod_cache):
-                # log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
+                log.error(f"{Fore.RED}{mod_cache}{Fore.RESET} does not exist after downloading, skipping")
                 continue
 
             # delete older versions
@@ -995,7 +995,7 @@ class GTNHModpackManager:
                 mod_dest = os.path.join(mods_dir, os.path.basename(get_asset_version_cache_location(mod, old_version)))
                 if os.path.exists(mod_dest):
                     log.info(
-                        f"Deleting old version {Fore.CYAN}{old_version.version_tag}{Fore.RESET} of {Fore.CYAN}{mod.name}{Fore.RESET}"
+                        f"Deleting old version [{Fore.CYAN}{mod.name}:{old_version.version_tag}{Fore.RESET}]"
                     )
                     os.remove(mod_dest)
 
@@ -1005,28 +1005,31 @@ class GTNHModpackManager:
             version_pattern = os.path.basename(mod_cache).replace(version.version_tag, "*")
             for file in glob.glob(os.path.join(mods_dir, version_pattern)):
                 if file != mod_dest:
-                    log.info(f"Deleting old version {Fore.CYAN}{file}{Fore.RESET} of {Fore.CYAN}{mod.name}{Fore.RESET}")
+                    log.debug(
+                        f"Deleting unmatched version [{Fore.CYAN}{mod.name} - {os.path.basename(file)}{Fore.RESET}]"
+                    )
                     os.remove(file)
 
             if os.path.exists(mod_dest):
-                # log.info(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
+                log.debug(f"{Fore.YELLOW}{mod.name}{Fore.RESET} already exists in the mods directory, skipping")
                 continue
 
             # use symlink if set and on unix, otherwise copy
             if use_symlink and os.name == "posix":
-                log.info(f"Symlinking {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                log.info(f"Symlinking [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 os.symlink(mod_cache, mod_dest)
             else:
-                log.info(f"Copying {Fore.CYAN}{mod.name}{Fore.RESET} to {Fore.CYAN}{mod_dest}{Fore.RESET}")
+                log.info(f"Copying [{Fore.CYAN}{mod.name}:{version.version_tag}{Fore.RESET}] to {Fore.CYAN}{mod_dest}{Fore.RESET}")
                 shutil.copy(mod_cache, mod_dest)
 
-            # delete excluded mods from target mods directory
-            for excluded_mod in local_exclusions if local_exclusions else []:
-                mod = self.assets.get_mod(excluded_mod)
-                if mod:
-                    for ver in mod.versions:
-                        mod_cache = get_asset_version_cache_location(mod, ver)
-                        mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
-                        if os.path.exists(mod_dest):
-                            log.info(f"Deleting {Fore.CYAN}{mod.name}{Fore.RESET} from the mods directory")
-                            os.remove(mod_dest)
+        log.info("Cleaning up the mods directory of excluded mods")
+        # delete excluded mods from target mods directory
+        for excluded_mod in local_exclusions if local_exclusions else []:
+            mod = self.assets.get_mod(excluded_mod)
+            if mod:
+                for ver in mod.versions:
+                    mod_cache = get_asset_version_cache_location(mod, ver)
+                    mod_dest = os.path.join(mods_dir, os.path.basename(mod_cache))
+                    if os.path.exists(mod_dest):
+                        log.info(f"Deleting [{Fore.CYAN}{mod.name}:{ver.version_tag}{Fore.RESET}] from the mods directory")
+                        os.remove(mod_dest)


### PR DESCRIPTION
This is mainly for me, but it could be useful to other devs who update to nightly often.
Currently, this is mods only. Configs are not touched.

`generate_nightly` will need to be ran before hand

```
poetry run python -m gtnh.cli.generate_nightly --update-available
poetry run python -m gtnh.cli.update_pack_inplace [--use-symlink] <Side> "<.minecraft path>"
```

Side can be one of: CLIENT, SERVER, CLIENT_JAVA9, SERVER_JAVA9  
The `--use-symlink` flag can be supplied if you want mods to be symlinked from the cache (only on posix systems)

An example to update the mods on my server:
`poetry run python -m gtnh.cli.update_pack_inplace SERVER_JAVA9 "/mnt/rootshare/appdata/minecraft/gtnh/"`

and on my local computer:  
`poetry run python -m gtnh.cli.update_pack_inplace CLIENT_JAVA9 "/mnt/games/Minecraft/Instances/GTNH Nightly/.minecraft/"`

Quotes are only needed if the path contains spaces which can be escaped instead if you want.


To have certain mods excluded from the local pack, create a `.inplace_mod_exclusions` file in the root of the project and include the mod names from gtnh-assets.json  

Example (I use RTG + CC, ModernControlling, and Xaero's)
```
Realistic-World-Gen
DefaultWorldGenerator
Controlling
JourneyMap
JourneyMap Server
```