### PR TITLE
Add log wrapper + move some logs to debug

### DIFF
--- a/src/gtnh/assembler/assembler.py
+++ b/src/gtnh/assembler/assembler.py
@@ -1,14 +1,13 @@
 from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, Optional
 
-from structlog import get_logger
-
 from gtnh.assembler.curse import CurseAssembler
 from gtnh.assembler.modrinth import ModrinthAssembler
 from gtnh.assembler.multi_poly import MMCAssembler
 from gtnh.assembler.technic import TechnicAssembler
 from gtnh.assembler.zip_assembler import ZipAssembler
 from gtnh.defs import RELEASE_CHANGELOG_DIR, Archive, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.modpack_manager import GTNHModpackManager
 from gtnh.utils import compress_changelog

--- a/src/gtnh/assembler/curse.py
+++ b/src/gtnh/assembler/curse.py
@@ -6,11 +6,11 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 import httpx
 from colorama import Fore
-from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.assembler.generic_assembler import GenericAssembler
 from gtnh.defs import CACHE_DIR, RELEASE_CURSE_DIR, ROOT_DIR, ModSource, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion

--- a/src/gtnh/assembler/downloader.py
+++ b/src/gtnh/assembler/downloader.py
@@ -3,9 +3,8 @@ import os
 import re
 from pathlib import Path
 
-from structlog import get_logger
-
 from gtnh.defs import CACHE_DIR
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_version import ExtraAsset, GTNHVersion
 from gtnh.models.versionable import Versionable
 

--- a/src/gtnh/assembler/generic_assembler.py
+++ b/src/gtnh/assembler/generic_assembler.py
@@ -4,11 +4,11 @@ from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from colorama import Fore
-from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.assembler.exclusions import Exclusions
 from gtnh.defs import README_TEMPLATE, RELEASE_README_DIR, ModSource, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion

--- a/src/gtnh/assembler/technic.py
+++ b/src/gtnh/assembler/technic.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import shutil
 from pathlib import Path
@@ -8,14 +7,14 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.assembler.generic_assembler import GenericAssembler
 from gtnh.defs import RELEASE_TECHNIC_DIR, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.modpack_manager import GTNHModpackManager
 
-log = logging.getLogger("technic process")
-log.setLevel(logging.INFO)
+log = get_logger("technic process")
 
 
 def technify(string: str) -> str:

--- a/src/gtnh/assembler/zip_assembler.py
+++ b/src/gtnh/assembler/zip_assembler.py
@@ -3,11 +3,10 @@ from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 from zipfile import ZIP_DEFLATED, ZipFile
 
-from structlog import get_logger
-
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.assembler.generic_assembler import GenericAssembler
 from gtnh.defs import RELEASE_ZIP_DIR, SERVER_ASSETS_DIR, ServerBrand, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion

--- a/src/gtnh/cli/add_mod.py
+++ b/src/gtnh/cli/add_mod.py
@@ -1,7 +1,7 @@
 import asyncclick as click
 import httpx
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/assemble_nightly.py
+++ b/src/gtnh/cli/assemble_nightly.py
@@ -1,10 +1,10 @@
 import asyncclick as click
 from colorama import Fore
 from httpx import AsyncClient
-from structlog import get_logger
 
 from gtnh.assembler.assembler import ReleaseAssembler
 from gtnh.defs import Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/assemble_release.py
+++ b/src/gtnh/cli/assemble_release.py
@@ -1,10 +1,10 @@
 import asyncclick as click
 from colorama import Fore
 from httpx import AsyncClient
-from structlog import get_logger
 
 from gtnh.assembler.assembler import ReleaseAssembler
 from gtnh.defs import Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/close_old_issues.py
+++ b/src/gtnh/cli/close_old_issues.py
@@ -5,9 +5,9 @@ import asyncclick as click
 import httpx
 from dateutil.parser import parse as parse_date
 from gidgethub.httpx import GitHubAPI
-from structlog import get_logger
 
 from gtnh.github.uri import API_BASE_URI, repo_issues_uri
+from gtnh.gtnh_logger import get_logger
 from gtnh.utils import AttributeDict, get_github_token
 
 log = get_logger(__name__)
@@ -17,7 +17,7 @@ log = get_logger(__name__)
 async def close_old_issues() -> None:
     async with httpx.AsyncClient(http2=True) as client:
         gh = GitHubAPI(client, "DreamAssemblerXXL", oauth_token=get_github_token())
-        log.info("Closing older issues")
+        log.debug("Closing older issues")
         org = "GTNewHorizons"
         repo = "GT-New-Horizons-Modpack"
         issues = gh.getiter(repo_issues_uri(org, repo))
@@ -44,7 +44,7 @@ async def close_old_issues() -> None:
 async def get_issue(num: int) -> AttributeDict:
     async with httpx.AsyncClient(http2=True) as client:
         gh = GitHubAPI(client, "DreamAssemblerXXL", oauth_token=get_github_token())
-        log.info(f"Getting issue {num}")
+        log.debug(f"Getting issue {num}")
         return AttributeDict(
             await gh.getitem(f"{API_BASE_URI}/repos/GTNewHorizons/GT-New-Horizons-Modpack/issues/{num}")
         )
@@ -55,7 +55,7 @@ def display(issue: AttributeDict) -> str:
 
 
 def log_reason(issue: AttributeDict, should_close: bool, reason: str) -> None:
-    log.info(f""" {"Will" if should_close else "Won't"} close issue {display(issue)} - {reason}""")
+    log.debug(f""" {"Will" if should_close else "Won't"} close issue {display(issue)} - {reason}""")
 
 
 def should_close_issue(issue: AttributeDict) -> bool:

--- a/src/gtnh/cli/download_mod.py
+++ b/src/gtnh/cli/download_mod.py
@@ -1,8 +1,8 @@
 import asyncclick as click
 import httpx
 from colorama import Fore
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/download_release.py
+++ b/src/gtnh/cli/download_release.py
@@ -1,8 +1,8 @@
 import asyncclick as click
 import httpx
 from colorama import Fore
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/generate_changelog.py
+++ b/src/gtnh/cli/generate_changelog.py
@@ -1,7 +1,7 @@
 import click
 from httpx import AsyncClient
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/generate_nightly.py
+++ b/src/gtnh/cli/generate_nightly.py
@@ -1,8 +1,8 @@
 import asyncclick as click
 import httpx
-from structlog import get_logger
 
 from gtnh.exceptions import ReleaseNotFoundException
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/generate_old_changelogs.py
+++ b/src/gtnh/cli/generate_old_changelogs.py
@@ -2,10 +2,10 @@ import asyncclick as click
 import gidgethub
 import httpx
 from gidgethub.httpx import GitHubAPI
-from structlog import get_logger
 
 from gtnh.defs import ModSource
 from gtnh.github.uri import repo_releases_uri
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 from gtnh.utils import get_github_token
 

--- a/src/gtnh/cli/remove_version.py
+++ b/src/gtnh/cli/remove_version.py
@@ -2,8 +2,8 @@
 import asyncclick as click
 import httpx
 from colorama import init
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/update_check.py
+++ b/src/gtnh/cli/update_check.py
@@ -2,8 +2,8 @@
 import asyncclick as click
 import httpx
 from colorama import Fore, Style, init
-from structlog import get_logger
 
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)

--- a/src/gtnh/cli/update_deps.py
+++ b/src/gtnh/cli/update_deps.py
@@ -19,9 +19,9 @@ import re
 import asyncclick as click
 import httpx
 from in_place import InPlace
-from structlog import get_logger
 
 from gtnh.defs import ModSource
+from gtnh.gtnh_logger import get_logger
 from gtnh.modpack_manager import GTNHModpackManager
 
 log = get_logger(__name__)
@@ -66,9 +66,9 @@ async def find_and_update_deps() -> None:
                         fp.write(line)
                         continue
                     else:
-                        log.info(f"{mod_name} is already at the latest version '{latest_version}'")
+                        log.debug(f"{mod_name} is already at the latest version '{latest_version}'")
                 else:
-                    log.info(f"No latest version info for mod {mod_name}")
+                    log.warn(f"No latest version info for mod {mod_name}")
 
             # No match
             fp.write(line)
@@ -82,7 +82,7 @@ def verify_gtnh_maven() -> None:
     with open(REPO_FILE) as fp:
         repos = fp.read()
         if repos.find("http://jenkins.usrv.eu:8081/nexus/content/groups/public/") != -1:
-            log.info("GTNH Maven already found")
+            log.debug("GTNH Maven already found")
             return
 
     with InPlace(REPO_FILE) as fp:

--- a/src/gtnh/gtnh_logger.py
+++ b/src/gtnh/gtnh_logger.py
@@ -1,0 +1,11 @@
+import logging
+import os
+
+import structlog
+
+
+def get_logger(name: str) -> structlog.BoundLogger:
+    if not structlog.is_configured():
+        LOG_LEVEL = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper())
+        structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(LOG_LEVEL))
+    return structlog.get_logger(name)

--- a/src/gtnh/gtnh_logger.py
+++ b/src/gtnh/gtnh_logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import typing
 
 import structlog
 
@@ -8,4 +9,4 @@ def get_logger(name: str) -> structlog.BoundLogger:
     if not structlog.is_configured():
         LOG_LEVEL = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper())
         structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(LOG_LEVEL))
-    return structlog.get_logger(name)
+    return typing.cast(structlog.BoundLogger ,structlog.get_logger(name))

--- a/src/gtnh/gtnh_logger.py
+++ b/src/gtnh/gtnh_logger.py
@@ -9,4 +9,4 @@ def get_logger(name: str) -> structlog.BoundLogger:
     if not structlog.is_configured():
         LOG_LEVEL = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper())
         structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(LOG_LEVEL))
-    return typing.cast(structlog.BoundLogger ,structlog.get_logger(name))
+    return typing.cast(structlog.BoundLogger, structlog.get_logger(name))

--- a/src/gtnh/gui/gui.py
+++ b/src/gtnh/gui/gui.py
@@ -7,12 +7,12 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, U
 
 import httpx
 from colorama import Fore
-from structlog import get_logger
 from ttkthemes import ThemedTk
 
 from gtnh.assembler.assembler import ReleaseAssembler
 from gtnh.defs import Archive, ModSource, Position, Side
 from gtnh.exceptions import NoModAssetFound, ReleaseNotFoundException
+from gtnh.gtnh_logger import get_logger
 from gtnh.gui.exclusion.exclusion_panel import ExclusionPanel, ExclusionPanelCallback
 from gtnh.gui.external.external_panel import ExternalPanel, ExternalPanelCallback
 from gtnh.gui.github.github_panel import GithubPanel, GithubPanelCallback

--- a/src/gtnh/models/available_assets.py
+++ b/src/gtnh/models/available_assets.py
@@ -3,10 +3,10 @@ from functools import cached_property
 from typing import Dict, List
 
 from pydantic import Field
-from structlog import get_logger
 
 from gtnh.defs import ModSource, Side
 from gtnh.exceptions import NoModAssetFound
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.base import GTNHBaseModel
 from gtnh.models.gtnh_config import GTNHConfig
 from gtnh.models.gtnh_version import GTNHVersion

--- a/src/gtnh/models/gtnh_release.py
+++ b/src/gtnh/models/gtnh_release.py
@@ -3,9 +3,9 @@ from typing import Dict
 
 from colorama import Fore
 from pydantic import Field, ValidationError
-from structlog import get_logger
 
 from gtnh.defs import GREEN_CHECK, RED_CROSS, RELEASE_MANIFEST_DIR
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.available_assets import AvailableAssets
 from gtnh.models.base import GTNHBaseModel
 from gtnh.models.mod_version_info import ModVersionInfo

--- a/src/gtnh/models/gtnh_version.py
+++ b/src/gtnh/models/gtnh_version.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from typing import List, Optional, Tuple
 
 from pydantic import Field
-from structlog import get_logger
 
 from gtnh.defs import VersionableType
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.base import GTNHBaseModel
 from gtnh.utils import AttributeDict
 

--- a/src/gtnh/models/mod_info.py
+++ b/src/gtnh/models/mod_info.py
@@ -1,8 +1,8 @@
 # Using LegacyVersion because we want everything to be comparable
 from pydantic import Field
-from structlog import get_logger
 
 from gtnh.defs import UNKNOWN, ModSource, Side
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.base import GTNHBaseModel
 from gtnh.models.versionable import Versionable
 

--- a/src/gtnh/models/versionable.py
+++ b/src/gtnh/models/versionable.py
@@ -2,9 +2,9 @@ import bisect
 
 from packaging.version import LegacyVersion
 from pydantic import BaseModel, Field
-from structlog import get_logger
 
 from gtnh.defs import VersionableType
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_version import GTNHVersion
 
 log = get_logger(__name__)

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -227,7 +227,7 @@ class GTNHModpackManager:
             maven = await self.get_maven(mod.name)
             if maven:
                 mod.maven = maven
-                log.info(f"Updated Maven: {mod.maven}")
+                log.debug(f"Updated Maven: {mod.maven}")
                 mod_updated = True
 
         if mod.private != repo.get("private"):

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -12,7 +12,6 @@ from gidgethub.httpx import GitHubAPI
 from httpx import AsyncClient, HTTPStatusError
 from packaging.version import LegacyVersion
 from retry import retry
-from structlog import get_logger
 
 from gtnh.assembler.downloader import get_asset_version_cache_location
 from gtnh.defs import (
@@ -31,6 +30,7 @@ from gtnh.defs import (
 )
 from gtnh.exceptions import InvalidReleaseException, RepoNotFoundException
 from gtnh.github.uri import latest_release_uri, org_repos_uri, repo_releases_uri, repo_uri
+from gtnh.gtnh_logger import get_logger
 from gtnh.models.available_assets import AvailableAssets
 from gtnh.models.gtnh_config import CONFIG_REPO_NAME
 from gtnh.models.gtnh_modpack import GTNHModpack
@@ -165,7 +165,7 @@ class GTNHModpackManager:
         version_updated = False
         versionable_updated = False
         version_outdated = False
-        log.info(
+        log.debug(
             f"Checking {Fore.CYAN}{versionable.name}:{Fore.YELLOW}{versionable.latest_version}{Fore.RESET} for updates"
         )
         latest_release = await self.get_latest_github_release(repo)
@@ -175,7 +175,7 @@ class GTNHModpackManager:
         if version_is_newer(latest_version, versionable.latest_version):
             # Candidate update found
             version_updated = True
-            log.info(
+            log.debug(
                 f"Found candidate newer version for mod {Fore.CYAN}{versionable.name}:{Fore.YELLOW}{latest_version}"
                 f"{Fore.RESET}"
             )
@@ -197,7 +197,7 @@ class GTNHModpackManager:
 
         if versionable_updated:
             self.needs_attention = False
-            log.info(f"Updated {Fore.CYAN}{versionable.name}{Fore.RESET}!")
+            log.debug(f"Updated {Fore.CYAN}{versionable.name}{Fore.RESET}!")
 
         return versionable_updated or version_outdated  # If outdated we've flagged it and want to save the asset
 
@@ -277,14 +277,14 @@ class GTNHModpackManager:
                 continue
 
             if version_is_newer(version.version_tag, asset.latest_version):
-                log.info(
+                log.debug(
                     f"Updating latest version for `{Fore.CYAN}{asset.name}{Fore.RESET}` "
                     f"{Style.DIM}{Fore.GREEN}{asset.latest_version}{Style.RESET_ALL} -> "
                     f"{Fore.GREEN}{version.version_tag}{Style.RESET_ALL}"
                 )
                 asset.latest_version = version.version_tag
 
-            log.info(
+            log.debug(
                 f"Adding version {Fore.GREEN}`{version.version_tag}`{Style.RESET_ALL} for asset "
                 f"`{Fore.CYAN}{asset.name}{Fore.RESET}`"
             )
@@ -306,7 +306,7 @@ class GTNHModpackManager:
                 mod_license = repo_license.name
                 log.info(f"Found license `{Fore.YELLOW}{mod_license}{Fore.RESET}` from repo")
         except BadRequest:
-            log.info("No license found from repo")
+            log.warn("No license found from repo")
 
         if mod_license in [None, UNKNOWN, OTHER] and allow_fallback:
             with open(ROOT_DIR / "licenses_from_boubou.json") as f:
@@ -378,7 +378,7 @@ class GTNHModpackManager:
 
         log.info(f"Assembling release: `{Fore.GREEN}{version}{Fore.RESET}`")
         if overrides:
-            log.info(f"Using overrides: `{Fore.GREEN}{overrides}{Fore.RESET}`")
+            log.debug(f"Using overrides: `{Fore.GREEN}{overrides}{Fore.RESET}`")
 
         exclude = exclude or set()
 
@@ -438,7 +438,7 @@ class GTNHModpackManager:
                     continue
 
                 overide_str = f"{Fore.RED} ** OVERRIDE **{Fore.RESET}" if override else ""
-                log.info(
+                log.debug(
                     f"{source_str} Using `{Fore.CYAN}{mod.name}{Fore.RESET}:{Fore.YELLOW}{mod_version}{Fore.RESET}{overide_str}"
                 )
 
@@ -482,7 +482,7 @@ class GTNHModpackManager:
 
         new_repo = await self.get_repo(name)
         if self.assets.has_mod(new_repo.name):
-            log.info(f"Mod `{name}` already exists.")
+            log.debug(f"Mod `{name}` already exists.")
             return None
 
         new_mod = await self.mod_from_repo(new_repo)
@@ -502,7 +502,7 @@ class GTNHModpackManager:
         log.info(f"Trying to delete `{name}`.")
 
         if not self.assets.has_mod(name):
-            log.info(f"Mod `{name}` is not present in the assets.")
+            log.warn(f"Mod `{name}` is not present in the assets.")
             return False
 
         mod_index: int = 0
@@ -520,7 +520,7 @@ class GTNHModpackManager:
         return True
 
     async def regen_github_assets(self, callback: Optional[Callable[[float, str], None]] = None) -> None:
-        log.info("refreshing all the github mods")
+        log.debug("refreshing all the github mods")
         repo_names = [mod.name for mod in self.assets.mods if mod.source == ModSource.github]
         delta_progress: float = 100 / len(repo_names)
         for repo_name in repo_names:
@@ -580,7 +580,7 @@ class GTNHModpackManager:
         """
         Load the Available Mods manifest
         """
-        log.info(f"Loading mods from {self.gtnh_asset_manifest_path}")
+        log.debug(f"Loading mods from {self.gtnh_asset_manifest_path}")
         with open(self.gtnh_asset_manifest_path, encoding="utf-8") as f:
             return AvailableAssets.parse_raw(f.read())
 
@@ -588,7 +588,7 @@ class GTNHModpackManager:
         """
         Load the GTNH Modpack manifest
         """
-        log.info(f"Loading GTNH Modpack from {self.modpack_manifest_path}")
+        log.debug(f"Loading GTNH Modpack from {self.modpack_manifest_path}")
         with open(self.modpack_manifest_path, encoding="utf-8") as f:
             return GTNHModpack.parse_raw(f.read())
 
@@ -596,7 +596,7 @@ class GTNHModpackManager:
         """
         Save the GTNH Modpack manifest
         """
-        log.info(f"Saving modpack asset to from {self.modpack_manifest_path}")
+        log.debug(f"Saving modpack asset to from {self.modpack_manifest_path}")
         dumped = self.mod_pack.json(exclude_unset=True, exclude_none=True, exclude_defaults=True)
         if dumped:
             with open(self.modpack_manifest_path, "w", encoding="utf-8") as f:
@@ -608,7 +608,7 @@ class GTNHModpackManager:
         """
         Saves the Available Mods Manifest
         """
-        log.info(f"Saving assets to from {self.gtnh_asset_manifest_path}")
+        log.debug(f"Saving assets to from {self.gtnh_asset_manifest_path}")
         dumped = self.assets.json(exclude={"_modmap"}, exclude_unset=True, exclude_none=True)
         if dumped:
             with open(self.gtnh_asset_manifest_path, "w", encoding="utf-8") as f:
@@ -683,7 +683,7 @@ class GTNHModpackManager:
 
         private_repo = f" {Fore.MAGENTA}<PRIVATE REPO>{Fore.RESET}" if asset.private else ""
 
-        log.info(
+        log.debug(
             f"Downloading {type} Asset `{Fore.CYAN}{asset.name}:{Fore.YELLOW}{asset_version}{Fore.RESET}` from "
             f"{version.browser_download_url}{private_repo}"
         )
@@ -697,7 +697,7 @@ class GTNHModpackManager:
 
         for mod_filename, download_url in files_to_download:
             if os.path.exists(mod_filename):
-                log.info(f"{Fore.YELLOW}Skipping re-redownload of {mod_filename}{Fore.RESET}")
+                log.debug(f"{Fore.YELLOW}Skipping re-redownload of {mod_filename}{Fore.RESET}")
                 if download_callback:
                     download_callback(str(mod_filename.name))
                 continue
@@ -748,7 +748,7 @@ class GTNHModpackManager:
                 mod.
         """
 
-        log.info(f"Downloading mods for Release `{Fore.LIGHTYELLOW_EX}{release.version}{Fore.RESET}`")
+        log.debug(f"Downloading mods for Release `{Fore.LIGHTYELLOW_EX}{release.version}{Fore.RESET}`")
 
         # computation of the progress per mod for the progressbar
         delta_progress = 100 / (len(release.github_mods) + len(release.external_mods) + 1)  # +1 for the config


### PR DESCRIPTION

Preview
![image](https://github.com/GTNewHorizons/DreamAssemblerXXL/assets/18713839/226330f4-1eb0-4953-b6e1-9fe50e010282)


The `LOG_LEVEL` env controls the log level (duh). Default of INFO. [Python's logging levels can be used](https://docs.python.org/3/library/logging.html#levels).
Preview:
![image](https://github.com/GTNewHorizons/DreamAssemblerXXL/assets/18713839/d067ba35-4eb0-4fcd-b9b9-2914138725d2)
