### PR TITLE
Revert "fix nightly changelog being marked as pushed by raven"

### DIFF
--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.NIGHTLY_GITHUB_TOKEN }}
           fetch-depth: 0
           ref: master
       - name: Set up python


### PR DESCRIPTION
Reverts GTNewHorizons/DreamAssemblerXXL#155

apparently after so many years github-action simply cannot just be listed on the bypass. since no one would probably want to create an app for this I'd just rollback the changes https://github.com/orgs/community/discussions/13836