### PR TITLE
Ignore needs_attention flag when updating in place

### DIFF
--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1165,7 +1165,7 @@ class GTNHModpackManager:
 
             # delete older versions
             for old_version in mod.versions:
-                if old_version.version_tag == version.version_tag and not mod.needs_attention:
+                if old_version.version_tag == version.version_tag:
                     continue
                 to_remove = os.path.basename(get_asset_version_cache_location(mod, old_version))
                 for file in active_mods:


### PR DESCRIPTION
Fixes an issue when using the pack update in place cli where when a mod has the needs_attention flag set (from the version in the assets file not being the "latest" due to 2.6.1 based mods)