### PR TITLE
Address warnings in workflows

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       # load cached venv if cache exists
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -36,7 +36,7 @@ jobs:
       # load cached venv if cache exists
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Load cached mod zips
         id: load_cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: cache
           key: daxxl-${{ runner.os }}-${{ steps.date.outputs.cachedate }}
@@ -76,7 +76,7 @@ jobs:
           poetry run python -m gtnh.cli.assemble_nightly
 
       - name: Save cached mod zips
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: success() || failure()
         with:
           path: cache

--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock', '*/poetry.lock') }}
 
       # install dependencies if cache does not exist
       - name: Install dependencies


### PR DESCRIPTION
- Update `actions/cache` to address this warning: `The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3, actions/cache/restore@v3, actions/cache/save@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`
- `Load cached venv` failed because of too many files. Following [this workaround](https://github.com/actions/runner/issues/449#issuecomment-1242625786) should address that. It's also confirmed to be working on translation repo: https://github.com/GTNewHorizons/GTNH-Translations/commit/afa607d1827e26a2d64c48ebd510a09e204956ba