### PR TITLE
Don't try overwriting mod cache during nightly build

### DIFF
--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -58,7 +58,7 @@ jobs:
           echo "cachedate=$(date '+%G-w%V')" >> "$GITHUB_OUTPUT"
 
       - name: Load cached mod zips
-        id: load_cache
+        id: load_mod_cache
         uses: actions/cache/restore@v4
         with:
           path: cache
@@ -77,7 +77,7 @@ jobs:
 
       - name: Save cached mod zips
         uses: actions/cache/save@v4
-        if: success() || failure()
+        if: steps.load_mod_cache.outputs.cache-hit != 'true'
         with:
           path: cache
           key: daxxl-${{ runner.os }}-${{ steps.date.outputs.cachedate }}


### PR DESCRIPTION
Fixes a warning we are getting in the nightly jobs:

```
Run actions/cache/save@v4
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/DreamAssemblerXXL/DreamAssemblerXXL --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key daxxl-Linux-2024-w44, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: daxxl-Linux-2024-w44, Version: 48840183904feb892faeaa56412d7014a19c2d726aad7885122645d312345145
Warning: Cache save failed.
```

The cache action doesn't support updating a cache in place, so since we are trying to use the cache for a week, all jobs after the first in the week will try to save into an existing cache repo and fail.