### PR TITLE
Add mod sidedness comment to compressed changelog

### DIFF
--- a/src/gtnh/defs.py
+++ b/src/gtnh/defs.py
@@ -220,6 +220,7 @@ class ModEntry:
     def __init__(self, name: str, version: str, is_new: bool) -> None:
         self.name: str = name
         self.version: str = version
+        self.side_info: str = ""
         self.is_new: bool = is_new
         self.changes: List[str] = []
         self.new_contributors: List[str] = []

--- a/src/gtnh/utils.py
+++ b/src/gtnh/utils.py
@@ -176,7 +176,9 @@ def compress_changelog(file_path: Path) -> None:
                 in_changes_mode = False
                 entries.append(current_entry)
             elif current_entry:
-                if line == ">## What's Changed":
+                if line.startswith("Mod is ") or line.startswith("Mod side changed from "):
+                    current_entry.side_info = line
+                elif line == ">## What's Changed":
                     in_changes_mode = True
                 elif line == ">## New Contributors":
                     in_changes_mode = False
@@ -212,6 +214,9 @@ def compress_changelog(file_path: Path) -> None:
                 lines.append(
                     "# Updated " + ent.name + " (" + re.sub("^(.*)\\.\\.\\.(.*)$", r"\1 --> \2", ent.version) + ")\n"
                 )
+
+            if ent.side_info != "":
+                lines.append(ent.side_info + "\n")
 
             if ent.is_new or ent.newest_link_version == "":
                 lines.append(


### PR DESCRIPTION
I noticed the mod sidedness changes from #176 did not appear in our release changelogs. I was unaware that changes to `utils.compress_changelog()` also had to be made, as I was only testing nightly changelogs at the time which don't go through that method.