### PR TITLE
Extract all contributors into the changelog credits section in the compressed changelog

### DIFF
--- a/releases/changelogs/changelog from 2.7.0-RC-2 to 2.7.0-RC-3.md
+++ b/releases/changelogs/changelog from 2.7.0-RC-2 to 2.7.0-RC-3.md
@@ -66,4 +66,4 @@
 >
 
 # Credits
-A special thanks to @Ableytner, @wlhlm, who contributed to this release!
+Special thanks to @Ableytner, @Alexdoru, @Cleptomania, @Connor-Colenso, @FourIsTheNumber, @Glease, @ah-OOG-ah, @kurrycat2004, @lordIcocain, @serenibyss, @slprime, @wlhlm, for their code contributions listed above, and to everyone else who helped, including all of our beta testers! <3

--- a/src/gtnh/defs.py
+++ b/src/gtnh/defs.py
@@ -222,6 +222,7 @@ class ModEntry:
         self.version: str = version
         self.is_new: bool = is_new
         self.changes: List[str] = []
+        self.contributors: Set[str] = set()
         self.new_contributors: List[str] = []
         self.oldest_link_version = ""
         self.newest_link_version = ""


### PR DESCRIPTION
The previous behavior was to only include "new" contributors in the credits sections which where drawn from the changelog itself from the new contributor sections for each changed mod. However that does not account for people who have contributed to other repositories in our organization and it sweeps returning contributors under the rug.

It's a good idea to make special mention of new contributors, but that needs a more comprehensive approach most likely pulling from the GitHub API to do it across all repositories.

For demonstration, I have included an updated 2.7.0-RC-2 to -RC-3 changelog.