### PR TITLE
Change schedule of nightly build run

### DIFF
--- a/.github/workflows/nightly-modpack-build.yml
+++ b/.github/workflows/nightly-modpack-build.yml
@@ -3,7 +3,7 @@ name: Nightly modpack build
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 2 * * *' # 2:30am UTC every day
+    - cron: '30 3 * * *' # 3:30am UTC every day
 
 jobs:
   nightly-modpack-build:


### PR DESCRIPTION
Even though `GTNH-Translations` nightly build is configured to run on 1:20, it actually runs on 2:30, probably due to runner queue. This made race condition between translation repo and this repo: https://github.com/GTNewHorizons/DreamAssemblerXXL/actions/runs/12616014008/job/35156775395
By moving modpack build to later, there should be less chance of conflict.