### PR TITLE
Last touches for 2.7.3 manifest

### DIFF
--- a/releases/manifests/2.7.3.json
+++ b/releases/manifests/2.7.3.json
@@ -237,7 +237,7 @@
       "side": "BOTH"
     },
     "GT5-Unofficial": {
-      "version": "5.09.50.117",
+      "version": "5.09.50.118",
       "side": "BOTH"
     },
     "GTNH-TC-Wands": {

--- a/releases/manifests/2.7.3.json
+++ b/releases/manifests/2.7.3.json
@@ -233,7 +233,7 @@
       "side": "BOTH"
     },
     "gendustry": {
-      "version": "1.8.3-GTNH",
+      "version": "1.9.0-GTNH",
       "side": "BOTH"
     },
     "GT5-Unofficial": {
@@ -261,7 +261,7 @@
       "side": "BOTH"
     },
     "HoloInventory": {
-      "version": "2.4.13-GTNH",
+      "version": "2.5.0-GTNH",
       "side": "BOTH"
     },
     "HydroEnergy": {
@@ -273,7 +273,7 @@
       "side": "BOTH"
     },
     "IguanaTweaksTConstruct": {
-      "version": "2.5.0",
+      "version": "2.6.0",
       "side": "BOTH"
     },
     "Infernal-Mobs": {
@@ -289,7 +289,7 @@
       "side": "CLIENT"
     },
     "ironchest": {
-      "version": "6.0.87",
+      "version": "6.1.1",
       "side": "BOTH"
     },
     "IronChestMinecarts": {
@@ -305,7 +305,7 @@
       "side": "BOTH"
     },
     "LittleTiles": {
-      "version": "1.3.1-GTNH",
+      "version": "1.4.0-GTNH",
       "side": "BOTH"
     },
     "LogisticsPipes": {
@@ -325,11 +325,11 @@
       "side": "BOTH"
     },
     "MalisisDoors": {
-      "version": "1.17.4-GTNH",
+      "version": "1.18.0-GTNH",
       "side": "BOTH"
     },
     "Mantle": {
-      "version": "0.4.2",
+      "version": "0.5.0",
       "side": "BOTH"
     },
     "Minecraft-Backpack-Mod": {
@@ -377,7 +377,7 @@
       "side": "BOTH"
     },
     "Nodal-Mechanics": {
-      "version": "1.2.1-GTNH",
+      "version": "1.3.0-GTNH",
       "side": "BOTH"
     },
     "NotEnoughEnergistics": {
@@ -417,7 +417,7 @@
       "side": "BOTH"
     },
     "OpenSecurity": {
-      "version": "1.1.1-GTNH",
+      "version": "1.2.0-GTNH",
       "side": "BOTH"
     },
     "Opis": {
@@ -437,7 +437,7 @@
       "side": "BOTH"
     },
     "ProjectRed": {
-      "version": "4.10.5-GTNH",
+      "version": "4.11.0-GTNH",
       "side": "BOTH"
     },
     "Railcraft": {
@@ -457,11 +457,11 @@
       "side": "BOTH"
     },
     "SC2": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "side": "BOTH"
     },
     "Schematica": {
-      "version": "1.11.2-GTNH",
+      "version": "1.12.2-GTNH",
       "side": "CLIENT"
     },
     "SGCraft": {
@@ -493,7 +493,7 @@
       "side": "BOTH"
     },
     "StorageDrawers": {
-      "version": "2.0.5-GTNH",
+      "version": "2.1.0-GTNH",
       "side": "BOTH"
     },
     "StructureCompat": {
@@ -529,7 +529,7 @@
       "side": "BOTH"
     },
     "Thaumic_Exploration": {
-      "version": "1.3.7-GTNH",
+      "version": "1.4.0-GTNH",
       "side": "BOTH"
     },
     "ThaumicBases": {
@@ -541,7 +541,7 @@
       "side": "BOTH"
     },
     "ThaumicHorizons": {
-      "version": "1.6.5",
+      "version": "1.7.0",
       "side": "BOTH"
     },
     "thaumicinsurgence": {
@@ -565,7 +565,7 @@
       "side": "BOTH"
     },
     "TinkersMechworks": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "side": "BOTH"
     },
     "TooMuchLoot": {
@@ -577,7 +577,7 @@
       "side": "CLIENT"
     },
     "Translocators": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "side": "BOTH"
     },
     "twilightforest": {
@@ -585,7 +585,7 @@
       "side": "BOTH"
     },
     "Universal-Singularities": {
-      "version": "8.8.0",
+      "version": "8.9.0",
       "side": "BOTH"
     },
     "VisualProspecting": {
@@ -621,7 +621,7 @@
       "side": "BOTH"
     },
     "WirelessRedstone-CBE": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "side": "BOTH"
     },
     "WitcheryExtras": {
@@ -705,7 +705,7 @@
       "side": "BOTH"
     },
     "Random-Things": {
-      "version": "2.5.3",
+      "version": "2.6.0",
       "side": "BOTH"
     },
     "Tainted-Magic": {
@@ -765,7 +765,7 @@
       "side": "BOTH"
     },
     "Tinkers-Defense": {
-      "version": "1.2.2",
+      "version": "1.3.1",
       "side": "BOTH"
     },
     "neiaddons": {

--- a/releases/manifests/2.7.3.json
+++ b/releases/manifests/2.7.3.json
@@ -249,7 +249,7 @@
       "side": "BOTH"
     },
     "Hardcore-Ender-Expansion": {
-      "version": "1.11.4-GTNH",
+      "version": "1.12.1-GTNH",
       "side": "BOTH"
     },
     "harvestcraft": {
@@ -321,7 +321,7 @@
       "side": "BOTH"
     },
     "MagicBees": {
-      "version": "2.9.0-GTNH",
+      "version": "2.9.1-GTNH",
       "side": "BOTH"
     },
     "MalisisDoors": {
@@ -625,7 +625,7 @@
       "side": "BOTH"
     },
     "WitcheryExtras": {
-      "version": "1.2.3",
+      "version": "1.3.0",
       "side": "BOTH"
     },
     "WitchingGadgets": {


### PR DESCRIPTION
Most of these are localization PRs that didn't get included in the 2.7.3 manifest. The noteworthy ones:

- Hardcore-Ender-Expansion:
  - Fixes for music disks in the GT electric jukebox
- MagicBees
  - Bug fix for Hibeescus mana drain
- WitcheryExtras
  - Dupe fix for Brew of Substitution