### PR TITLE
Changelog

### DIFF
--- a/releases/changelogs/changelog from 2.7.4 to daily.md
+++ b/releases/changelogs/changelog from 2.7.4 to daily.md
@@ -21,12223 +21,3162 @@
 > * TravellersGearNeo
 > * inventory-tweaks
 # Updated - AE2FluidCraft-Rework - 1.3.55-gtnh --> 1.4.99-gtnh
-## *1.4.99-gtnh*
->## What's Changed
->* Use CraftingID to check CraftingLink equivalence in Level Maintainer by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/317
->* extend level maintainer feedback by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/316
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.98-gtnh...1.4.99-gtnh
->
+**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.3.55-gtnh...1.4.99-gtnh
 
-## *1.4.98-gtnh*
->## What's Changed
->* implement pins by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/315
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.96-gtnh...1.4.98-gtnh
->
-
-## *1.4.96-gtnh*
->## What's Changed
->* Make P2P Tunnel - ME Dual Interface share storage slot contents between input and outputs by @Inphysible in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/302
->
->## New Contributors
->* @Inphysible made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/302
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.93-gtnh...1.4.96-gtnh
->
-
-## *1.4.93-gtnh*
->## What's Changed
->* Fix FluidExportBus NPE by @zyf051520 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/314
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/314
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.91-gtnh...1.4.93-gtnh
->
-
-## *1.4.91-gtnh*
->## What's Changed
->* Add Super Stock Replenisher by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/278
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.89-gtnh...1.4.91-gtnh
->
-
-## *1.4.89-gtnh*
->## What's Changed
->* Rewrite Level Maintainer/Terminal Logic by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/294
->* Fix Universal Terminal restock hotkey chat message saying the opposite of the current state by @michaeldoylecs in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/308
->* Account for client /server desync when teleporting items with magnet by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/305
->* fix player null crash magnet by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/309
->* Hide EC stuff if EC is not loaded. by @Ethryan in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/312
->* always use fluid packet for partition by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/310
->
->## New Contributors
->* @Ethryan made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/312
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.86-gtnh...1.4.89-gtnh
->
-
-## *1.4.86-gtnh*
->## What's Changed
->* Magnet improvements by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/303
->* Fix div by zero by @RecursivePineapple in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/306
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.80-gtnh...1.4.86-gtnh
->
-
-## *1.4.80-gtnh*
->## What's Changed
->* Add magnet and restock to Universal terminal by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/275
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.76-gtnh...1.4.80-gtnh
->
-
-## *1.4.76-gtnh*
->## What's Changed
->* Fix fluid import/export bus GUI when WAILA is disabled by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/298
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.75-gtnh...1.4.76-gtnh
->
-
-## *1.4.75-gtnh*
->## What's Changed
->* Fix NEI search always showing void cell by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/300
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.72-gtnh...1.4.75-gtnh
->
-
-## *1.4.72-gtnh*
->## What's Changed
->* Restore NEI highlighting when searching for fluid in cells by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/299
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.69-gtnh...1.4.72-gtnh
->
-
-## *1.4.69-gtnh*
->## What's Changed
->* make baubles optional by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/296
->* Use long stack size in NEI CellView by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/297
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.67-gtnh...1.4.69-gtnh
->
-
-## *1.4.67-gtnh*
->## What's Changed
->* Update dependencies.gradle by @Caedis in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/292
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.65-gtnh...1.4.67-gtnh
->
-
-## *1.4.65-gtnh*
->## What's Changed
->* Fix cell math for distribution card by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/291
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.63-gtnh...1.4.65-gtnh
->
-
-## *1.4.63-gtnh*
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.61-gtnh...1.4.63-gtnh
->
-
-## *1.4.61-gtnh*
->## What's Changed
->* fix player inventory position in interface terminal by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/290
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.58-gtnh...1.4.61-gtnh
->
-
-## *1.4.58-gtnh*
->## What's Changed
->* Use interface terminal gui from ae2, instead of copy code from ae2 by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/286
->* order from crafting status by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/287
->* item renamer by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/288
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.56-gtnh...1.4.58-gtnh
->
-
-## *1.4.56-gtnh*
->## What's Changed
->* Artificial universe cell recipe by @glowredman in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/289
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.53-gtnh...1.4.56-gtnh
->
-
-## *1.4.53-gtnh*
->## What's Changed
->* Fix math when cell restricted and new fluid added by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/284
->* copy of fix interface terminal crash by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/285
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.50-gtnh...1.4.53-gtnh
->
-
-## *1.4.50-gtnh*
->## What's Changed
->* Small improvements to the Level Maintainer GUI by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/283
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.46-gtnh...1.4.50-gtnh
->
-
-## *1.4.46-gtnh*
->## What's Changed
->* Backport NEI Cell View by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/282
->* Fix isConduit check by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/281
->* Make the fluid handler more resilient. by @C0bra5 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/272
->
->## New Contributors
->* @C0bra5 made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/272
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.42-gtnh...1.4.46-gtnh
->
-
-## *1.4.42-gtnh*
->## What's Changed
->* Change Creative Cell Capacity by @StaffiX in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/276
->* Fix pattern multi by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/277
->* made ItemBaseWirelessTerminal.canHandle null-safe by @guid118 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/274
->* Partition gregtech fluids by @jurrejelle in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/273
->* Allow math expression in Fluid Level Emitter GUI by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/279
->
->## New Contributors
->* @StaffiX made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/276
->* @guid118 made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/274
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/273
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.36-gtnh...1.4.42-gtnh
->
-
-## *1.4.36-gtnh*
->## What's Changed
->* Fix terminal key bindings for mouse by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/270
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.34-gtnh...1.4.36-gtnh
->
-
-## *1.4.34-gtnh*
->## What's Changed
->* Fix an issue that GT and AE2FC fluids could not be used with Creative Fluid Cell by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/271
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/271
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.32-gtnh...1.4.34-gtnh
->
-
-## *1.4.32-gtnh*
->## What's Changed
->* Fix fluid containers with null empty items not deleting in fluid terminal by @serenibyss in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/267
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.30-gtnh...1.4.32-gtnh
->
-
-## *1.4.30-gtnh*
->## What's Changed
->* Read NBT tags `combine` and `beSubstitute` from `ItemStack` when converting them to `FluidPattern` by @TwoDCube in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/268
->
->## New Contributors
->* @TwoDCube made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/268
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.29-gtnh...1.4.30-gtnh
->
-
-## *1.4.29-gtnh*
->## What's Changed
->* Improve ME Fluid Auto Filler Performance by @Vlamonster in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/266
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/266
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.28-gtnh...1.4.29-gtnh
->
-
-## *1.4.28-gtnh*
->## What's Changed
->* No more drop drops from interface by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/265
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.27-gtnh...1.4.28-gtnh
->
-
-## *1.4.27-gtnh*
->## What's Changed
->* Option to restrict fluid cell  by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/263
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.25-gtnh...1.4.27-gtnh
->
-
-## *1.4.25-gtnh*
->## What's Changed
->* Allow exotic cells use upgrade cards by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/264
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.23-gtnh...1.4.25-gtnh
->
-
-## *1.4.23-gtnh*
->## What's Changed
->* Add Support Void and Distribution card for cells and increase card limit for cells by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/262
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.22-gtnh...1.4.23-gtnh
->
-
-## *1.4.22-gtnh*
->## What's Changed
->* Add fluid pattern support to fake crafting card by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/260
->* Fixed essentia level maintaining by @RecursivePineapple in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/245
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/245
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.21-gtnh...1.4.22-gtnh
->
-
-## *1.4.21-gtnh*
->## What's Changed
->* [Feature] Shift to pause terminal view movement by @michaeldoylecs in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/256
->* Fix/same network multiple extract only storage buses by @hiroscho in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/244
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.19-gtnh...1.4.21-gtnh
->
-
-## *1.4.19-gtnh*
->## What's Changed
->* Add cell + pattern disassemble recipes like AE2 by @serenibyss in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/257
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/257
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.16-gtnh...1.4.19-gtnh
->
-
-## *1.4.16-gtnh*
->## What's Changed
->* x2 button funtional for fluid pattern terminals. And varions fixes. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/252
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.14-gtnh...1.4.16-gtnh
->
-
-## *1.4.14-gtnh*
->## What's Changed
->* Scalable Walrus by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/248
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.12-gtnh...1.4.14-gtnh
->
-
-## *1.4.12-gtnh*
->## What's Changed
->* Add class dump agrs by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/239
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.10-gtnh...1.4.12-gtnh
->
-
-## *1.4.10-gtnh*
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.8-gtnh...1.4.10-gtnh
->
-
-## *1.4.8-gtnh*
->## What's Changed
->* Prevent Universal Wireless crafting terminal void items. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/254
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.6-gtnh...1.4.8-gtnh
->
-
-## *1.4.6-gtnh*
->## What's Changed
->* Cleanup by @glowredman in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/253
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.4-gtnh...1.4.6-gtnh
->
-
-## *1.4.4-gtnh*
->## What's Changed
->* Change default texture name and add new texture by @EnderProyects in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251
->* Add Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/234
->* Skip this side check if fluid conduit not connected. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/249
->
->## New Contributors
->* @EnderProyects made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.3.51-gtnh...1.4.4-gtnh
->
-
-## *1.4.2-gtnh*
->## What's Changed
->* Add Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/234
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.4.0-gtnh...1.4.2-gtnh
->
-
-## *1.4.0-gtnh*
->## What's Changed
->* Fix pattern dividing by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/246
->* Change default texture name and add new texture by @EnderProyects in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251
->
->## New Contributors
->* @EnderProyects made their first contribution in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251
->
->**Full Changelog**: https://github.com/GTNewHorizons/AE2FluidCraft-Rework/compare/1.3.50-gtnh...1.4.0-gtnh
->
+## What's Changed:
+>* Use CraftingID to check CraftingLink equivalence in Level Maintainer by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/317 (1.4.99-gtnh)
+>* extend level maintainer feedback by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/316 (1.4.99-gtnh)
+>* implement pins by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/315 (1.4.98-gtnh)
+>* Make P2P Tunnel - ME Dual Interface share storage slot contents between input and outputs by @Inphysible in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/302 (1.4.96-gtnh)
+>* Fix FluidExportBus NPE by @zyf051520 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/314 (1.4.93-gtnh)
+>* Add Super Stock Replenisher by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/278 (1.4.91-gtnh)
+>* Rewrite Level Maintainer/Terminal Logic by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/294 (1.4.89-gtnh)
+>* Fix Universal Terminal restock hotkey chat message saying the opposite of the current state by @michaeldoylecs in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/308 (1.4.89-gtnh)
+>* Account for client /server desync when teleporting items with magnet by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/305 (1.4.89-gtnh)
+>* fix player null crash magnet by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/309 (1.4.89-gtnh)
+>* Hide EC stuff if EC is not loaded. by @Ethryan in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/312 (1.4.89-gtnh)
+>* always use fluid packet for partition by @lc-1337 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/310 (1.4.89-gtnh)
+>* Magnet improvements by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/303 (1.4.86-gtnh)
+>* Fix div by zero by @RecursivePineapple in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/306 (1.4.86-gtnh)
+>* Add magnet and restock to Universal terminal by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/275 (1.4.80-gtnh)
+>* Fix fluid import/export bus GUI when WAILA is disabled by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/298 (1.4.76-gtnh)
+>* Fix NEI search always showing void cell by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/300 (1.4.75-gtnh)
+>* Restore NEI highlighting when searching for fluid in cells by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/299 (1.4.72-gtnh)
+>* make baubles optional by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/296 (1.4.69-gtnh)
+>* Use long stack size in NEI CellView by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/297 (1.4.69-gtnh)
+>* Update dependencies.gradle by @Caedis in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/292 (1.4.67-gtnh)
+>* Fix cell math for distribution card by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/291 (1.4.65-gtnh)
+>* fix player inventory position in interface terminal by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/290 (1.4.61-gtnh)
+>* Use interface terminal gui from ae2, instead of copy code from ae2 by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/286 (1.4.58-gtnh)
+>* order from crafting status by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/287 (1.4.58-gtnh)
+>* item renamer by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/288 (1.4.58-gtnh)
+>* Artificial universe cell recipe by @glowredman in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/289 (1.4.56-gtnh)
+>* Fix math when cell restricted and new fluid added by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/284 (1.4.53-gtnh)
+>* copy of fix interface terminal crash by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/285 (1.4.53-gtnh)
+>* Small improvements to the Level Maintainer GUI by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/283 (1.4.50-gtnh)
+>* Backport NEI Cell View by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/282 (1.4.46-gtnh)
+>* Fix isConduit check by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/281 (1.4.46-gtnh)
+>* Make the fluid handler more resilient. by @C0bra5 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/272 (1.4.46-gtnh)
+>* Change Creative Cell Capacity by @StaffiX in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/276 (1.4.42-gtnh)
+>* Fix pattern multi by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/277 (1.4.42-gtnh)
+>* made ItemBaseWirelessTerminal.canHandle null-safe by @guid118 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/274 (1.4.42-gtnh)
+>* Partition gregtech fluids by @jurrejelle in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/273 (1.4.42-gtnh)
+>* Allow math expression in Fluid Level Emitter GUI by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/279 (1.4.42-gtnh)
+>* Fix terminal key bindings for mouse by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/270 (1.4.36-gtnh)
+>* Fix an issue that GT and AE2FC fluids could not be used with Creative Fluid Cell by @Kogepan229 in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/271 (1.4.34-gtnh)
+>* Fix fluid containers with null empty items not deleting in fluid terminal by @serenibyss in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/267 (1.4.32-gtnh)
+>* Read NBT tags `combine` and `beSubstitute` from `ItemStack` when converting them to `FluidPattern` by @TwoDCube in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/268 (1.4.30-gtnh)
+>* Improve ME Fluid Auto Filler Performance by @Vlamonster in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/266 (1.4.29-gtnh)
+>* No more drop drops from interface by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/265 (1.4.28-gtnh)
+>* Option to restrict fluid cell  by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/263 (1.4.27-gtnh)
+>* Allow exotic cells use upgrade cards by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/264 (1.4.25-gtnh)
+>* Add Support Void and Distribution card for cells and increase card limit for cells by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/262 (1.4.23-gtnh)
+>* Add fluid pattern support to fake crafting card by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/260 (1.4.22-gtnh)
+>* Fixed essentia level maintaining by @RecursivePineapple in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/245 (1.4.22-gtnh)
+>* [Feature] Shift to pause terminal view movement by @michaeldoylecs in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/256 (1.4.21-gtnh)
+>* Fix/same network multiple extract only storage buses by @hiroscho in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/244 (1.4.21-gtnh)
+>* Add cell + pattern disassemble recipes like AE2 by @serenibyss in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/257 (1.4.19-gtnh)
+>* x2 button funtional for fluid pattern terminals. And varions fixes. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/252 (1.4.16-gtnh)
+>* Scalable Walrus by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/248 (1.4.14-gtnh)
+>* Add class dump agrs by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/239 (1.4.12-gtnh)
+>* Prevent Universal Wireless crafting terminal void items. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/254 (1.4.8-gtnh)
+>* Cleanup by @glowredman in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/253 (1.4.6-gtnh)
+>* Change default texture name and add new texture by @EnderProyects in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251 (1.4.4-gtnh)
+>* Add Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/234 (1.4.4-gtnh)
+>* Skip this side check if fluid conduit not connected. by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/249 (1.4.4-gtnh)
+>* Add Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/234 (1.4.2-gtnh)
+>* Fix pattern dividing by @Alexdoru in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/246 (1.4.0-gtnh)
+>* Change default texture name and add new texture by @EnderProyects in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/251 (1.4.0-gtnh)
 
 # New Mod - AE2NoUltimatePatterns:1.0.0
-## *1.0.0*
->**Full Changelog**: https://github.com/GTNewHorizons/AE2NoUltimatePatterns/commits/1.0.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/AE2NoUltimatePatterns/commits/1.0.0/compare/1.0.0...1.0.0
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - AdventureBackpack2 - 1.3.5-GTNH --> 1.3.9-GTNH
-## *1.3.9-GTNH*
->## What's Changed
->* Fixed russian translation + Backported Hose textures by @Gordon-Frohman in https://github.com/GTNewHorizons/AdventureBackpack2/pull/31
->
->## New Contributors
->* @Gordon-Frohman made their first contribution in https://github.com/GTNewHorizons/AdventureBackpack2/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.3.7-GTNH...1.3.9-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.3.5-GTNH...1.3.9-GTNH
 
-## *1.3.7-GTNH*
->## What's Changed
->* fix: crash when rendering component with damage 0 by @leumasme in https://github.com/GTNewHorizons/AdventureBackpack2/pull/30
->
->## New Contributors
->* @leumasme made their first contribution in https://github.com/GTNewHorizons/AdventureBackpack2/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/AdventureBackpack2/compare/1.3.5-GTNH...1.3.7-GTNH
->
+## What's Changed:
+>* Fixed russian translation + Backported Hose textures by @Gordon-Frohman in https://github.com/GTNewHorizons/AdventureBackpack2/pull/31 (1.3.9-GTNH)
+>* fix: crash when rendering component with damage 0 by @leumasme in https://github.com/GTNewHorizons/AdventureBackpack2/pull/30 (1.3.7-GTNH)
 
 # Updated - AkashicTome - 1.2.1 --> 1.2.4
-## *1.2.4*
->## What's Changed
->* Fix NPE for combining books by @cargocats in https://github.com/GTNewHorizons/AkashicTome/pull/18
->
->## New Contributors
->* @cargocats made their first contribution in https://github.com/GTNewHorizons/AkashicTome/pull/18
->
->**Full Changelog**: https://github.com/GTNewHorizons/AkashicTome/compare/1.2.3...1.2.4
->
+**Full Changelog**: https://github.com/GTNewHorizons/AkashicTome/compare/1.2.1...1.2.4
 
-## *1.2.3*
->## What's Changed
->* Add missing IDs to both the whitelist and blacklist by @Kynake in https://github.com/GTNewHorizons/AkashicTome/pull/17
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AkashicTome/compare/1.2.2...1.2.3
->
-
-## *1.2.2*
->## What's Changed
->* Fix Tome losing enchantments when morphed by @serenibyss in https://github.com/GTNewHorizons/AkashicTome/pull/16
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/AkashicTome/pull/16
->
->**Full Changelog**: https://github.com/GTNewHorizons/AkashicTome/compare/1.2.1...1.2.2
->
+## What's Changed:
+>* Fix NPE for combining books by @cargocats in https://github.com/GTNewHorizons/AkashicTome/pull/18 (1.2.4)
+>* Add missing IDs to both the whitelist and blacklist by @Kynake in https://github.com/GTNewHorizons/AkashicTome/pull/17 (1.2.3)
+>* Fix Tome losing enchantments when morphed by @serenibyss in https://github.com/GTNewHorizons/AkashicTome/pull/16 (1.2.2)
 
 # Updated - AlchemyGrate - 1.2.1-GTNH --> 1.3.1-GTNH
-## *1.3.1-GTNH*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/AlchemyGrate/pull/7
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/AlchemyGrate/pull/7
->
->**Full Changelog**: https://github.com/GTNewHorizons/AlchemyGrate/compare/1.3.0-GTNH...1.3.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/AlchemyGrate/compare/1.2.1-GTNH...1.3.1-GTNH
 
-## *1.3.0-GTNH*
->## What's Changed
->* Fix accidental botania hard dependency by @serenibyss in https://github.com/GTNewHorizons/AlchemyGrate/pull/6
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/AlchemyGrate/pull/6
->
->**Full Changelog**: https://github.com/GTNewHorizons/AlchemyGrate/compare/1.2.1-GTNH...1.3.0-GTNH
->
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/AlchemyGrate/pull/7 (1.3.1-GTNH)
+>* Fix accidental botania hard dependency by @serenibyss in https://github.com/GTNewHorizons/AlchemyGrate/pull/6 (1.3.0-GTNH)
 
 # Updated - Amazing-Trophies - 1.3.0 --> 1.3.8
-## *1.3.8*
->## What's Changed
->* Fix flickering on "Graphics: Fast" by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/14
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.5...1.3.8
->
+**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.0...1.3.8
 
-## *1.3.5*
->## What's Changed
->* [Wiki] Fix Image URLs by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/15
->* Reduce (Un)Boxing by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/16
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.3...1.3.5
->
-
-## *1.3.3*
->## What's Changed
->* Add Wiki Sync by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/12
->* Add `/trophy` command by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/13
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.2...1.3.3
->
-
-## *1.3.2*
->**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.1...1.3.2
->
-
-## *1.3.1*
->## What's Changed
->* Trophy Model Handler Fixes by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/11
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Amazing-Trophies/compare/1.3.0...1.3.1
->
+## What's Changed:
+>* Fix flickering on "Graphics: Fast" by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/14 (1.3.8)
+>* [Wiki] Fix Image URLs by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/15 (1.3.5)
+>* Reduce (Un)Boxing by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/16 (1.3.5)
+>* Add Wiki Sync by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/12 (1.3.3)
+>* Add `/trophy` command by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/13 (1.3.3)
+>* Trophy Model Handler Fixes by @glowredman in https://github.com/GTNewHorizons/Amazing-Trophies/pull/11 (1.3.1)
 
 # Updated - Angelica - 1.0.0-beta29 --> 1.0.0-beta49
 Mod is client-side only.
-## *1.0.0-beta49*
->## What's Changed
->* Fix MCPF link in readme by @Radk6 in https://github.com/GTNewHorizons/Angelica/pull/981
->* Initial FluidLogged compat by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/985
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta48...1.0.0-beta49
->
+**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta29...1.0.0-beta49
 
-## *1.0.0-beta48*
->## What's Changed
->* Add a guard to only init once by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/984
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta47...1.0.0-beta48
->
-
-## *1.0.0-beta47*
->## What's Changed
->* Sync NotFine changes by @jss2a98aj in https://github.com/GTNewHorizons/Angelica/pull/974
->* Enforce exact limit on amount of dropped EntityItem rendered by @Alexdoru in https://github.com/GTNewHorizons/Angelica/pull/973
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta46...1.0.0-beta47
->
-
-## *1.0.0-beta46*
->## What's Changed
->* No longer use Reflection for `SplashProgress.fontRenderer` by @glowredman in https://github.com/GTNewHorizons/Angelica/pull/966
->* Stop loading HoloInventory too early in the compat class, which was causing fake fluids to not render properly. by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/972
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta45...1.0.0-beta46
->
-
-## *1.0.0-beta45*
->## What's Changed
->* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/Angelica/pull/962
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/962
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta44...1.0.0-beta45
->
-
-## *1.0.0-beta44*
->## What's Changed
->* Don't throw exception when trying to forward block+meta to shader while in non-world rendering pass (inventory, preview) by @dvdmandt in https://github.com/GTNewHorizons/Angelica/pull/960
->
->## New Contributors
->* @dvdmandt made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/960
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta43...1.0.0-beta44
->
-
-## *1.0.0-beta43*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/949
->* Capture shader outline by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/953
->* Backhand & HoloInventory Compat via Reflection by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/955
->* Fix `COLOR_BUFFER_BIT` leak in ShaderPackScreen by @kotmatross28729 in https://github.com/GTNewHorizons/Angelica/pull/958
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta42...1.0.0-beta43
->
-
-## *1.0.0-beta42*
->## What's Changed
->* enable ctm, disable everything unnecessary by @Pxx500 in https://github.com/GTNewHorizons/Angelica/pull/944
->* Compat for security craft by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/948
->
->## New Contributors
->* @Pxx500 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/944
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta41...1.0.0-beta42
->
-
-## *1.0.0-beta41*
->## What's Changed
->* Apply linear filter to unifont glyphs at odd scale factors by @Vlamonster in https://github.com/GTNewHorizons/Angelica/pull/907
->* Fix Notfine default config are not applied without changing a entry. by @Quarri6343 in https://github.com/GTNewHorizons/Angelica/pull/914
->* liteloader docs update by @Midnight145 in https://github.com/GTNewHorizons/Angelica/pull/931
->* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/870
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/907
->* @Midnight145 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/931
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta40...1.0.0-beta41
->
-
-## *1.0.0-beta40*
->## What's Changed
->* Fix stencil buffer does not exist by @Quarri6343 in https://github.com/GTNewHorizons/Angelica/pull/912
->
->## New Contributors
->* @Quarri6343 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/912
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta39...1.0.0-beta40
->
-
-## *1.0.0-beta39*
->## What's Changed
->* Adds two new overloads by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/906
->* Support for custom uniforms by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/902
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta38...1.0.0-beta39
->
-
-## *1.0.0-beta38*
->## What's Changed
->* Update dependencies & build script by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/899
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta37...1.0.0-beta38
->
-
-## *1.0.0-beta37*
->## What's Changed
->* add an API to retrieve world instance from WorldSlice by @Glease in https://github.com/GTNewHorizons/Angelica/pull/897
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta36...1.0.0-beta37
->
-
-## *1.0.0-beta36*
->## What's Changed
->* Update GTNHLib dependency version in README by @OBlankenship in https://github.com/GTNewHorizons/Angelica/pull/885
->* Optimize NEI rendering by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/882
->* Various Mixin-related Fixes by @glowredman in https://github.com/GTNewHorizons/Angelica/pull/890
->* Fix hologlasses crash by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/891
->* Catch CancellationException while building chunks by @amyavi in https://github.com/GTNewHorizons/Angelica/pull/889
->* Add an option to disable terrain fog by @ah-OOG-ah in https://github.com/GTNewHorizons/Angelica/pull/896
->
->## New Contributors
->* @OBlankenship made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/885
->* @amyavi made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/889
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta35...1.0.0-beta36
->
-
-## *1.0.0-beta35*
->## What's Changed
->* Avoid checking frustum visibility of infinite bounding boxes by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/875
->* Fix a handful of broken animations by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/868
->* Fix PBR specular & normal textures getting ignored by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/874
->* Fix IC2 universal cell rendering w/offhand by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/876
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta34...1.0.0-beta35
->
-
-## *1.0.0-beta34*
->## What's Changed
->* Fix crash when keycode is negative by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/871
->* Fix issue with dynamic lights world mixin not respecting opaque blocks by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/872
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/871
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta33...1.0.0-beta34
->
-
-## *1.0.0-beta33*
->## What's Changed
->* add offhand support via Backhand (up required version to 1.6.9) by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/859
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta32...1.0.0-beta33
->
-
-## *1.0.0-beta32*
->## What's Changed
->* Fix slider dragging in iris options by @TotallyNotOndre in https://github.com/GTNewHorizons/Angelica/pull/858
->* Fix any dimension without a sky getting flagged as the nether by @calreveraster in https://github.com/GTNewHorizons/Angelica/pull/857
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta31...1.0.0-beta32
->
-
-## *1.0.0-beta31*
->## What's Changed
->* fix crash when connected textures are disabled & custom colors are enabled by @calreveraster in https://github.com/GTNewHorizons/Angelica/pull/855
->* Fix shadow render distance reset to 32 by @TotallyNotOndre in https://github.com/GTNewHorizons/Angelica/pull/856
->
->## New Contributors
->* @calreveraster made their first contribution in https://github.com/GTNewHorizons/Angelica/pull/855
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta30...1.0.0-beta31
->
-
-## *1.0.0-beta30*
->## What's Changed
->* Fix Hodgepodge animation speedup breaking animated textures by @MellowArpeggiation in https://github.com/GTNewHorizons/Angelica/pull/850
->* Use GTNHLib MemoryUtils instead of the builtin compat ones by @eigenraven in https://github.com/GTNewHorizons/Angelica/pull/853
->
->** Note: Requires GTNHLib 0.6.6+
->
->**Full Changelog**: https://github.com/GTNewHorizons/Angelica/compare/1.0.0-beta29...1.0.0-beta30
->
+## What's Changed:
+>* Fix MCPF link in readme by @Radk6 in https://github.com/GTNewHorizons/Angelica/pull/981 (1.0.0-beta49)
+>* Initial FluidLogged compat by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/985 (1.0.0-beta49)
+>* Add a guard to only init once by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/984 (1.0.0-beta48)
+>* Sync NotFine changes by @jss2a98aj in https://github.com/GTNewHorizons/Angelica/pull/974 (1.0.0-beta47)
+>* Enforce exact limit on amount of dropped EntityItem rendered by @Alexdoru in https://github.com/GTNewHorizons/Angelica/pull/973 (1.0.0-beta47)
+>* No longer use Reflection for `SplashProgress.fontRenderer` by @glowredman in https://github.com/GTNewHorizons/Angelica/pull/966 (1.0.0-beta46)
+>* Stop loading HoloInventory too early in the compat class, which was causing fake fluids to not render properly. by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/972 (1.0.0-beta46)
+>* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/Angelica/pull/962 (1.0.0-beta45)
+>* Don't throw exception when trying to forward block+meta to shader while in non-world rendering pass (inventory, preview) by @dvdmandt in https://github.com/GTNewHorizons/Angelica/pull/960 (1.0.0-beta44)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/949 (1.0.0-beta43)
+>* Capture shader outline by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/953 (1.0.0-beta43)
+>* Backhand & HoloInventory Compat via Reflection by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/955 (1.0.0-beta43)
+>* Fix `COLOR_BUFFER_BIT` leak in ShaderPackScreen by @kotmatross28729 in https://github.com/GTNewHorizons/Angelica/pull/958 (1.0.0-beta43)
+>* enable ctm, disable everything unnecessary by @Pxx500 in https://github.com/GTNewHorizons/Angelica/pull/944 (1.0.0-beta42)
+>* Compat for security craft by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/948 (1.0.0-beta42)
+>* Apply linear filter to unifont glyphs at odd scale factors by @Vlamonster in https://github.com/GTNewHorizons/Angelica/pull/907 (1.0.0-beta41)
+>* Fix Notfine default config are not applied without changing a entry. by @Quarri6343 in https://github.com/GTNewHorizons/Angelica/pull/914 (1.0.0-beta41)
+>* liteloader docs update by @Midnight145 in https://github.com/GTNewHorizons/Angelica/pull/931 (1.0.0-beta41)
+>* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/870 (1.0.0-beta41)
+>* Fix stencil buffer does not exist by @Quarri6343 in https://github.com/GTNewHorizons/Angelica/pull/912 (1.0.0-beta40)
+>* Adds two new overloads by @mitchej123 in https://github.com/GTNewHorizons/Angelica/pull/906 (1.0.0-beta39)
+>* Support for custom uniforms by @Cleptomania in https://github.com/GTNewHorizons/Angelica/pull/902 (1.0.0-beta39)
+>* Update dependencies & build script by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/899 (1.0.0-beta38)
+>* add an API to retrieve world instance from WorldSlice by @Glease in https://github.com/GTNewHorizons/Angelica/pull/897 (1.0.0-beta37)
+>* Update GTNHLib dependency version in README by @OBlankenship in https://github.com/GTNewHorizons/Angelica/pull/885 (1.0.0-beta36)
+>* Optimize NEI rendering by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/882 (1.0.0-beta36)
+>* Various Mixin-related Fixes by @glowredman in https://github.com/GTNewHorizons/Angelica/pull/890 (1.0.0-beta36)
+>* Fix hologlasses crash by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/891 (1.0.0-beta36)
+>* Catch CancellationException while building chunks by @amyavi in https://github.com/GTNewHorizons/Angelica/pull/889 (1.0.0-beta36)
+>* Add an option to disable terrain fog by @ah-OOG-ah in https://github.com/GTNewHorizons/Angelica/pull/896 (1.0.0-beta36)
+>* Avoid checking frustum visibility of infinite bounding boxes by @embeddedt in https://github.com/GTNewHorizons/Angelica/pull/875 (1.0.0-beta35)
+>* Fix a handful of broken animations by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/868 (1.0.0-beta35)
+>* Fix PBR specular & normal textures getting ignored by @RecursivePineapple in https://github.com/GTNewHorizons/Angelica/pull/874 (1.0.0-beta35)
+>* Fix IC2 universal cell rendering w/offhand by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/876 (1.0.0-beta35)
+>* Fix crash when keycode is negative by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/871 (1.0.0-beta34)
+>* Fix issue with dynamic lights world mixin not respecting opaque blocks by @DarkShadow44 in https://github.com/GTNewHorizons/Angelica/pull/872 (1.0.0-beta34)
+>* add offhand support via Backhand (up required version to 1.6.9) by @Caedis in https://github.com/GTNewHorizons/Angelica/pull/859 (1.0.0-beta33)
+>* Fix slider dragging in iris options by @TotallyNotOndre in https://github.com/GTNewHorizons/Angelica/pull/858 (1.0.0-beta32)
+>* Fix any dimension without a sky getting flagged as the nether by @calreveraster in https://github.com/GTNewHorizons/Angelica/pull/857 (1.0.0-beta32)
+>* fix crash when connected textures are disabled & custom colors are enabled by @calreveraster in https://github.com/GTNewHorizons/Angelica/pull/855 (1.0.0-beta31)
+>* Fix shadow render distance reset to 32 by @TotallyNotOndre in https://github.com/GTNewHorizons/Angelica/pull/856 (1.0.0-beta31)
+>* Fix Hodgepodge animation speedup breaking animated textures by @MellowArpeggiation in https://github.com/GTNewHorizons/Angelica/pull/850 (1.0.0-beta30)
+>* Use GTNHLib MemoryUtils instead of the builtin compat ones by @eigenraven in https://github.com/GTNewHorizons/Angelica/pull/853 (1.0.0-beta30)
 
 # Updated - AngerMod - 0.8.2 --> 0.9.0
-## *0.9.0*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/AngerMod/pull/11
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/AngerMod/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/AngerMod/compare/0.8.2...0.9.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/AngerMod/compare/0.8.2...0.9.0
+
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/AngerMod/pull/11 (0.9.0)
 
 # Updated - AppleCore - 3.3.4 --> 3.3.5
-## *3.3.5*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/AppleCore/pull/34
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/AppleCore/compare/3.3.4...3.3.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/AppleCore/compare/3.3.4...3.3.5
+
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/AppleCore/pull/34 (3.3.5)
 
 # Updated - Applied-Energistics-2-Unofficial - rv3-beta-485-GTNH --> rv3-beta-655-GTNH
-## *rv3-beta-655-GTNH*
->## What's Changed
->* Meteorite World Generation Expansion for Dimensions and Custom JSON Loot Tables by @Gamingb3ast in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/733
->* ui: improve Storage Cell tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/789
->* Refactor localization system: unify chat message and text locate with `Localization` interface and methods  by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/791
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-652-GTNH...rv3-beta-655-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-485-GTNH...rv3-beta-655-GTNH
 
-## *rv3-beta-652-GTNH*
->## What's Changed
->* fix buttons duplication on gui when re init gui by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/785
->* reset craftable status on io port move by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/784
->* fix terminals gone by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/786
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-649-GTNH...rv3-beta-652-GTNH
->
+## What's Changed:
+>* Meteorite World Generation Expansion for Dimensions and Custom JSON Loot Tables by @Gamingb3ast in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/733 (rv3-beta-655-GTNH)
+>* ui: improve Storage Cell tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/789 (rv3-beta-655-GTNH)
+>* Refactor localization system: unify chat message and text locate with `Localization` interface and methods  by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/791 (rv3-beta-655-GTNH)
+>* fix buttons duplication on gui when re init gui by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/785 (rv3-beta-652-GTNH)
+>* reset craftable status on io port move by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/784 (rv3-beta-652-GTNH)
+>* fix terminals gone by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/786 (rv3-beta-652-GTNH)
+>* make extreme cells use tooltips generator from super class by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/783 (rv3-beta-649-GTNH)
+>* Storage Bus keep filter when remove Capacity Card or it is break with wrench by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/742 (rv3-beta-649-GTNH)
+>* Crafting pins / pins by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/705 (rv3-beta-649-GTNH)
+>* Make P2P Tunnel - ME Interface share storage slot contents between input and outputs by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/759 (rv3-beta-649-GTNH)
+>* Highlight network machine in world with shift click in network tool gui and open machine gui through network tool by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/703 (rv3-beta-645-GTNH)
+>* Make the charge rate of the Charger be affected by the multiplier of the power config by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/781 (rv3-beta-645-GTNH)
+>* Fix bug when on merge you got weird behavior by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/766 (rv3-beta-645-GTNH)
+>* Smart partition button by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/756 (rv3-beta-643-GTNH)
+>* Reduce ME Chest Display Updates by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/780 (rv3-beta-641-GTNH)
+>* Fix CompassService waiting for tasks on world stop by @Caedis in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/776 (rv3-beta-639-GTNH)
+>* Added a Baubles Slot for the Wireless Terminal by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/773 (rv3-beta-639-GTNH)
+>* Always try distribute (same) patterns between interfaces by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/739 (rv3-beta-636-GTNH)
+>* Add missing equals sign to lang file by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/772 (rv3-beta-632-GTNH)
+>* Reduce lag from substitute check by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/767 (rv3-beta-629-GTNH)
+>* Cells tooltip displays the number of filters used by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/762 (rv3-beta-629-GTNH)
+>* Fix Interface Terminal search function. by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/768 (rv3-beta-629-GTNH)
+>* Make ME Interface and P2P Tunnel - ME Interface support fuzzy card by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/755 (rv3-beta-629-GTNH)
+>* Update NEI Bookmark API by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/764 (rv3-beta-626-GTNH)
+>* Some QOL imporve for cpu table's tooltips by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/763 (rv3-beta-626-GTNH)
+>* Add check integrated circuit by @evgengoldwar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/748 (rv3-beta-626-GTNH)
+>* Allow View Cell to be toggled on or off by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/731 (rv3-beta-619-GTNH)
+>* add the ability to the Storage Bus to interface to see non-extractable items if option is enabled by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/749 (rv3-beta-619-GTNH)
+>* Improve Interface Terminal search function. by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/757 (rv3-beta-619-GTNH)
+>* Draw bottom outline when height less than 20 px by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/754 (rv3-beta-615-GTNH)
+>* Use long stack size in NEI CellView by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/760 (rv3-beta-613-GTNH)
+>* Update EnderIO P2P Integrations by @dibbydoda in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/758 (rv3-beta-612-GTNH)
+>* Make export busses with fuzzy cards pull from storages in order of priority by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/737 (rv3-beta-605-GTNH)
+>* Fix cell math for distribution card by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/751 (rv3-beta-602-GTNH)
+>* Move cursor at end when use +- buttons in amount field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/738 (rv3-beta-600-GTNH)
+>* Add button for show only interfaces with substitute patterns by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/740 (rv3-beta-600-GTNH)
+>* Prepair gui to cooperation with ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/741 (rv3-beta-597-GTNH)
+>* order from status for ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/743 (rv3-beta-597-GTNH)
+>* item renamer for ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/744 (rv3-beta-597-GTNH)
+>* Fix crafting calculation aborted by NPE by @zyf051520 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/747 (rv3-beta-597-GTNH)
+>* ME push harder by @jurrejelle in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/722 (rv3-beta-592-GTNH)
+>* Add missing default recipes by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/745 (rv3-beta-592-GTNH)
+>* Mitigate crashes caused by invalid CraftingLinks by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/728 (rv3-beta-586-GTNH)
+>* Fix missing list not reset sometimes by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/729 (rv3-beta-586-GTNH)
+>* Fix lag caused by 'setAccessible(true);' being called millions of times by @EverNife in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/727 (rv3-beta-584-GTNH)
+>* Improve pattern tooltip by @evgengoldwar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/692 (rv3-beta-580-GTNH)
+>* Make IO Port behavior more consistent and snappy by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/725 (rv3-beta-580-GTNH)
+>* Improve memory card by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/713 (rv3-beta-580-GTNH)
+>* Extraneous grass block generation in certain biomes when spawning meteors by @Gamingb3ast in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/721 (rv3-beta-580-GTNH)
+>* Backport NEI Cell View by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/723 (rv3-beta-580-GTNH)
+>* Fix MENetworkChannelChanged not woking by @reobf in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/712 (rv3-beta-576-GTNH)
+>* Add press items to blocking mode ignore list by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/711 (rv3-beta-576-GTNH)
+>* Change Creative Cell Capacity by @StaffiX in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/708 (rv3-beta-576-GTNH)
+>* Order to craft item from crafting status gui by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/704 (rv3-beta-576-GTNH)
+>* Add process bar in crafting cpu table by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/698 (rv3-beta-576-GTNH)
+>* Fix number input in search field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/709 (rv3-beta-576-GTNH)
+>* Improve GuiAmount input field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/714 (rv3-beta-576-GTNH)
+>* Rename pattern item by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/710 (rv3-beta-576-GTNH)
+>* cpu request limitation by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/694 (rv3-beta-576-GTNH)
+>* Allow math expression in Level Emitter GUI by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/717 (rv3-beta-576-GTNH)
+>* Build in InvTweak sorting by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/707 (rv3-beta-576-GTNH)
+>* Remove stack capture from GridAccessException by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/695 (rv3-beta-563-GTNH)
+>* Fix mouse click coordinate calculation on Interface Terminal by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/693 (rv3-beta-561-GTNH)
+>* change network energy storage display to infinity when it is so by @Glease in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/696 (rv3-beta-561-GTNH)
+>* Expansion of Quick Cell Partitioning (And a bugfix) by @ReignOfFROZE in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/697 (rv3-beta-561-GTNH)
+>* Quick Fix for Sticky Carding by @ReignOfFROZE in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/701 (rv3-beta-561-GTNH)
+>* Fix that self powered controller didnt count as controller in grid. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/691 (rv3-beta-554-GTNH)
+>* Redo self powered me controller textures by @GDCloudstrike in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/690 (rv3-beta-552-GTNH)
+>* add ME controller + Creative Energy cell in one block by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/686 (rv3-beta-551-GTNH)
+>* Make AE2 cell restrictions respect copy mode  by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/689 (rv3-beta-551-GTNH)
+>* Remove internal packet size limit by @eigenraven in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/683 (rv3-beta-549-GTNH)
+>* Fix GT sound acquisition by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/685 (rv3-beta-549-GTNH)
+>* Fix memory leak with WAILA by @amyavi in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/684 (rv3-beta-549-GTNH)
+>* Fix ME Chest accepting Cells with items into its internal inventory by @54M44R in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/681 (rv3-beta-548-GTNH)
+>* Ctrl+F feature for Crafting Plan/Tree/Status by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/680 (rv3-beta-548-GTNH)
+>* Refactor blocking mode ignore item list by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/678 (rv3-beta-547-GTNH)
+>* Update required GTNHLib version to 0.6.11 by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/676 (rv3-beta-546-GTNH)
+>* Use capability for SoundP2P and CraftingIconProvider by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/675 (rv3-beta-545-GTNH)
+>* Add throughput monitor by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/674 (rv3-beta-544-GTNH)
+>* Add priority to patterns in (dual) interfaces by @Vlamonster in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/673 (rv3-beta-542-GTNH)
+>* Change Craft Ordering Quantity to Allow Longs by @Ruling-0 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/672 (rv3-beta-542-GTNH)
+>* Add a button to follow the crafting job when start it by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/671 (rv3-beta-538-GTNH)
+>* Fix weird gap in cpu table by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/667 (rv3-beta-537-GTNH)
+>* Add craftable icon in terminal by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/665 (rv3-beta-536-GTNH)
+>* Fix NPE in stack size render by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/664 (rv3-beta-535-GTNH)
+>* Prevent move whole stack of upgrade cards into ae storage in interface by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/663 (rv3-beta-534-GTNH)
+>* For "No more drop drops from interface" by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/661 (rv3-beta-533-GTNH)
+>* Make smart mode aware of other interfaces by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/660 (rv3-beta-532-GTNH)
+>* Option to restrict cell by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/659 (rv3-beta-532-GTNH)
+>* fix overlap of "craft" and "0" in ME Terminals by @Yoshy2002 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/658 (rv3-beta-525-GTNH)
+>* Add Void and Distribution card for cells and increase card limit for cells by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/655 (rv3-beta-523-GTNH)
+>* [Feature] Shift to pause terminal view movement by @michaeldoylecs in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/652 (rv3-beta-521-GTNH)
+>* Fix/same network multiple extract only storage buses by @hiroscho in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/612 (rv3-beta-521-GTNH)
+>* Improve missing mode 2 by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/645 (rv3-beta-521-GTNH)
+>* cleanup: Deprecate and remove usages of GridCacheWrapper by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/650 (rv3-beta-518-GTNH)
+>* Fix unnecessary mmap'ing of compass .dat files by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/648 (rv3-beta-518-GTNH)
+>* Breaking change: Remove ultra dense cables by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/638 (rv3-beta-516-GTNH)
+>* Remove ultra dense cable textures by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/639 (rv3-beta-516-GTNH)
+>* Remove ultra dense cable recipes by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/640 (rv3-beta-516-GTNH)
+>* Remove UI strings for ultra dense cables by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/641 (rv3-beta-516-GTNH)
+>* Remove AECableType.ULTRA_DENSE and ULTRA_DENSE_SMART by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/642 (rv3-beta-516-GTNH)
+>* Remove GridFlags.ULTRA_DENSE_CAPACITY by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/643 (rv3-beta-516-GTNH)
+>* Remove BackbonePathSegment and PathGridCache.backbone by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/644 (rv3-beta-516-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/647 (rv3-beta-516-GTNH)
+>* Fix IO port early returning before processing queue by @S4mpsa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/646 (rv3-beta-516-GTNH)
+>* Make "unusable" IO port modes useful & add cell movement queue by @S4mpsa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/626 (rv3-beta-514-GTNH)
+>* Fix r-click divide and mid-click on processing pattern terminal by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/631 (rv3-beta-514-GTNH)
+>* Update follow button by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/634 (rv3-beta-514-GTNH)
+>* Remove Enable(P2p|QuantumBridge)BackboneTransfer config options by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/637 (rv3-beta-514-GTNH)
+>* Fix formation plane voiding items rarely by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/628 (rv3-beta-511-GTNH)
+>* Missing mode, forgot add reset. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/630 (rv3-beta-511-GTNH)
+>* Notify player when ingredient cannot be extracted in required amount. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/629 (rv3-beta-511-GTNH)
+>* Add Superluminal Acceleration Card for IOPort by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/617 (rv3-beta-509-GTNH)
+>* Improve missing mode. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/627 (rv3-beta-509-GTNH)
+>* Add Creative Energy Anchor (Neutronium energy cell attached on cable) by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/624 (rv3-beta-507-GTNH)
+>* Add fake crafting card for AE by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/622 (rv3-beta-507-GTNH)
+>* Feature: option to hide "stored" items in ae2 crafting plan by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/620 (rv3-beta-505-GTNH)
+>* Fix crash Adv blocking in configurated interface by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/625 (rv3-beta-504-GTNH)
+>* Add Search Cache to Terminal by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/621 (rv3-beta-503-GTNH)
+>* Painted ME chest will not connect to different color ME chest/cable. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/623 (rv3-beta-502-GTNH)
+>* Fix NEI Synchronization by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/619 (rv3-beta-501-GTNH)
+>* Change the texture offset so that the chest and drive use different parts of the same file instead of overlapping by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/618 (rv3-beta-500-GTNH)
+>* Display custom name in MemoryCard tooltip by @Worive in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/614 (rv3-beta-500-GTNH)
 
-## *rv3-beta-649-GTNH*
->## What's Changed
->* make extreme cells use tooltips generator from super class by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/783
->* Storage Bus keep filter when remove Capacity Card or it is break with wrench by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/742
->* Crafting pins / pins by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/705
->* Make P2P Tunnel - ME Interface share storage slot contents between input and outputs by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/759
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-645-GTNH...rv3-beta-649-GTNH
->
-
-## *rv3-beta-645-GTNH*
->## What's Changed
->* Highlight network machine in world with shift click in network tool gui and open machine gui through network tool by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/703
->* Make the charge rate of the Charger be affected by the multiplier of the power config by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/781
->* Fix bug when on merge you got weird behavior by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/766
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-643-GTNH...rv3-beta-645-GTNH
->
-
-## *rv3-beta-643-GTNH*
->## What's Changed
->* Smart partition button by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/756
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-641-GTNH...rv3-beta-643-GTNH
->
-
-## *rv3-beta-641-GTNH*
->## What's Changed
->* Reduce ME Chest Display Updates by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/780
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-639-GTNH...rv3-beta-641-GTNH
->
-
-## *rv3-beta-639-GTNH*
->## What's Changed
->* Fix CompassService waiting for tasks on world stop by @Caedis in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/776
->* Added a Baubles Slot for the Wireless Terminal by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/773
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-636-GTNH...rv3-beta-639-GTNH
->
-
-## *rv3-beta-636-GTNH*
->## What's Changed
->* Always try distribute (same) patterns between interfaces by @lc-1337 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/739
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-632-GTNH...rv3-beta-636-GTNH
->
-
-## *rv3-beta-632-GTNH*
->## What's Changed
->* Add missing equals sign to lang file by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/772
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/772
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-629-GTNH...rv3-beta-632-GTNH
->
-
-## *rv3-beta-629-GTNH*
->## What's Changed
->* Reduce lag from substitute check by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/767
->* Cells tooltip displays the number of filters used by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/762
->* Fix Interface Terminal search function. by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/768
->* Make ME Interface and P2P Tunnel - ME Interface support fuzzy card by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/755
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-626-GTNH...rv3-beta-629-GTNH
->
-
-## *rv3-beta-626-GTNH*
->## What's Changed
->* Update NEI Bookmark API by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/764
->* Some QOL imporve for cpu table's tooltips by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/763
->* Add check integrated circuit by @evgengoldwar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/748
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-619-GTNH...rv3-beta-626-GTNH
->
-
-## *rv3-beta-619-GTNH*
->## What's Changed
->* Allow View Cell to be toggled on or off by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/731
->* add the ability to the Storage Bus to interface to see non-extractable items if option is enabled by @NeOzay in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/749
->* Improve Interface Terminal search function. by @AbdielKavash in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/757
->
->## New Contributors
->* @NeOzay made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/749
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-615-GTNH...rv3-beta-619-GTNH
->
-
-## *rv3-beta-615-GTNH*
->## What's Changed
->* Draw bottom outline when height less than 20 px by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/754
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-613-GTNH...rv3-beta-615-GTNH
->
-
-## *rv3-beta-613-GTNH*
->## What's Changed
->* Use long stack size in NEI CellView by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/760
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-612-GTNH...rv3-beta-613-GTNH
->
-
-## *rv3-beta-612-GTNH*
->## What's Changed
->* Update EnderIO P2P Integrations by @dibbydoda in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/758
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/758
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-608-GTNH...rv3-beta-612-GTNH
->
-
-## *rv3-beta-608-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-606-GTNH...rv3-beta-608-GTNH
->
-
-## *rv3-beta-606-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-605-GTNH...rv3-beta-606-GTNH
->
-
-## *rv3-beta-605-GTNH*
->## What's Changed
->* Make export busses with fuzzy cards pull from storages in order of priority by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/737
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-602-GTNH...rv3-beta-605-GTNH
->
-
-## *rv3-beta-602-GTNH*
->## What's Changed
->* Fix cell math for distribution card by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/751
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-600-GTNH...rv3-beta-602-GTNH
->
-
-## *rv3-beta-600-GTNH*
->## What's Changed
->* Move cursor at end when use +- buttons in amount field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/738
->* Add button for show only interfaces with substitute patterns by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/740
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-597-GTNH...rv3-beta-600-GTNH
->
-
-## *rv3-beta-597-GTNH*
->## What's Changed
->* Prepair gui to cooperation with ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/741
->* order from status for ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/743
->* item renamer for ae2fc by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/744
->* Fix crafting calculation aborted by NPE by @zyf051520 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/747
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/747
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-592-GTNH...rv3-beta-597-GTNH
->
-
-## *rv3-beta-592-GTNH*
->## What's Changed
->* ME push harder by @jurrejelle in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/722
->* Add missing default recipes by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/745
->
->## New Contributors
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/722
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-586-GTNH...rv3-beta-592-GTNH
->
-
-## *rv3-beta-586-GTNH*
->## What's Changed
->* Mitigate crashes caused by invalid CraftingLinks by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/728
->* Fix missing list not reset sometimes by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/729
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-584-GTNH...rv3-beta-586-GTNH
->
-
-## *rv3-beta-584-GTNH*
->## What's Changed
->* Fix lag caused by 'setAccessible(true);' being called millions of times by @EverNife in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/727
->
->## New Contributors
->* @EverNife made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/727
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-580-GTNH...rv3-beta-584-GTNH
->
-
-## *rv3-beta-580-GTNH*
->## What's Changed
->* Improve pattern tooltip by @evgengoldwar in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/692
->* Make IO Port behavior more consistent and snappy by @Inphysible in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/725
->* Improve memory card by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/713
->* Extraneous grass block generation in certain biomes when spawning meteors by @Gamingb3ast in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/721
->* Backport NEI Cell View by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/723
->
->## New Contributors
->* @evgengoldwar made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/692
->* @Inphysible made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/725
->* @Gamingb3ast made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/721
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-576-GTNH...rv3-beta-580-GTNH
->
-
-## *rv3-beta-576-GTNH*
->## What's Changed
->* Fix MENetworkChannelChanged not woking by @reobf in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/712
->* Add press items to blocking mode ignore list by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/711
->* Change Creative Cell Capacity by @StaffiX in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/708
->* Order to craft item from crafting status gui by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/704
->* Add process bar in crafting cpu table by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/698
->* Fix number input in search field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/709
->* Improve GuiAmount input field by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/714
->* Rename pattern item by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/710
->* cpu request limitation by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/694
->* Allow math expression in Level Emitter GUI by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/717
->* Build in InvTweak sorting by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/707
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-563-GTNH...rv3-beta-576-GTNH
->
-
-## *rv3-beta-563-GTNH*
->## What's Changed
->* Remove stack capture from GridAccessException by @RecursivePineapple in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/695
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-561-GTNH...rv3-beta-563-GTNH
->
-
-## *rv3-beta-561-GTNH*
->## What's Changed
->* Fix mouse click coordinate calculation on Interface Terminal by @Kogepan229 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/693
->* change network energy storage display to infinity when it is so by @Glease in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/696
->* Expansion of Quick Cell Partitioning (And a bugfix) by @ReignOfFROZE in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/697
->* Quick Fix for Sticky Carding by @ReignOfFROZE in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/701
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/693
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-554-GTNH...rv3-beta-561-GTNH
->
-
-## *rv3-beta-554-GTNH*
->## What's Changed
->* Fix that self powered controller didnt count as controller in grid. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/691
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-552-GTNH...rv3-beta-554-GTNH
->
-
-## *rv3-beta-552-GTNH*
->## What's Changed
->* Redo self powered me controller textures by @GDCloudstrike in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/690
->
->## New Contributors
->* @GDCloudstrike made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/690
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-551-GTNH...rv3-beta-552-GTNH
->
-
-## *rv3-beta-551-GTNH*
->## What's Changed
->* add ME controller + Creative Energy cell in one block by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/686
->* Make AE2 cell restrictions respect copy mode  by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/689
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-549-GTNH...rv3-beta-551-GTNH
->
-
-## *rv3-beta-549-GTNH*
->## What's Changed
->* Remove internal packet size limit by @eigenraven in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/683
->* Fix GT sound acquisition by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/685
->* Fix memory leak with WAILA by @amyavi in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/684
->
->## New Contributors
->* @amyavi made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/684
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-548-GTNH...rv3-beta-549-GTNH
->
-
-## *rv3-beta-548-GTNH*
->## What's Changed
->* Fix ME Chest accepting Cells with items into its internal inventory by @54M44R in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/681
->* Ctrl+F feature for Crafting Plan/Tree/Status by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/680
->
->## New Contributors
->* @54M44R made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/681
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-547-GTNH...rv3-beta-548-GTNH
->
-
-## *rv3-beta-547-GTNH*
->## What's Changed
->* Refactor blocking mode ignore item list by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/678
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-546-GTNH...rv3-beta-547-GTNH
->
-
-## *rv3-beta-546-GTNH*
->## What's Changed
->* Update required GTNHLib version to 0.6.11 by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/676
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-545-GTNH...rv3-beta-546-GTNH
->
-
-## *rv3-beta-545-GTNH*
->## What's Changed
->* Use capability for SoundP2P and CraftingIconProvider by @miozune in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/675
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-544-GTNH...rv3-beta-545-GTNH
->
-
-## *rv3-beta-544-GTNH*
->## What's Changed
->* Add throughput monitor by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/674
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-542-GTNH...rv3-beta-544-GTNH
->
-
-## *rv3-beta-542-GTNH*
->## What's Changed
->* Add priority to patterns in (dual) interfaces by @Vlamonster in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/673
->* Change Craft Ordering Quantity to Allow Longs by @Ruling-0 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/672
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/672
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-538-GTNH...rv3-beta-542-GTNH
->
-
-## *rv3-beta-538-GTNH*
->## What's Changed
->* Add a button to follow the crafting job when start it by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/671
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-537-GTNH...rv3-beta-538-GTNH
->
-
-## *rv3-beta-537-GTNH*
->## What's Changed
->* Fix weird gap in cpu table by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/667
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-536-GTNH...rv3-beta-537-GTNH
->
-
-## *rv3-beta-536-GTNH*
->## What's Changed
->* Add craftable icon in terminal by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/665
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-535-GTNH...rv3-beta-536-GTNH
->
-
-## *rv3-beta-535-GTNH*
->## What's Changed
->* Fix NPE in stack size render by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/664
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-534-GTNH...rv3-beta-535-GTNH
->
-
-## *rv3-beta-534-GTNH*
->## What's Changed
->* Prevent move whole stack of upgrade cards into ae storage in interface by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/663
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-533-GTNH...rv3-beta-534-GTNH
->
-
-## *rv3-beta-533-GTNH*
->## What's Changed
->* For "No more drop drops from interface" by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/661
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-532-GTNH...rv3-beta-533-GTNH
->
-
-## *rv3-beta-532-GTNH*
->## What's Changed
->* Make smart mode aware of other interfaces by @kuba6000 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/660
->* Option to restrict cell by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/659
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-527-GTNH...rv3-beta-532-GTNH
->
-
-## *rv3-beta-527-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-525-GTNH...rv3-beta-527-GTNH
->
-
-## *rv3-beta-525-GTNH*
->## What's Changed
->* fix overlap of "craft" and "0" in ME Terminals by @Yoshy2002 in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/658
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/658
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-523-GTNH...rv3-beta-525-GTNH
->
-
-## *rv3-beta-523-GTNH*
->## What's Changed
->* Add Void and Distribution card for cells and increase card limit for cells by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/655
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-521-GTNH...rv3-beta-523-GTNH
->
-
-## *rv3-beta-521-GTNH*
->## What's Changed
->* [Feature] Shift to pause terminal view movement by @michaeldoylecs in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/652
->* Fix/same network multiple extract only storage buses by @hiroscho in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/612
->* Improve missing mode 2 by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/645
->
->## New Contributors
->* @michaeldoylecs made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/652
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-518-GTNH...rv3-beta-521-GTNH
->
-
-## *rv3-beta-518-GTNH*
->## What's Changed
->* cleanup: Deprecate and remove usages of GridCacheWrapper by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/650
->* Fix unnecessary mmap'ing of compass .dat files by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/648
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-516-GTNH...rv3-beta-518-GTNH
->
-
-## *rv3-beta-516-GTNH*
->## What's Changed
->* Breaking change: Remove ultra dense cables by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/638
->* Remove ultra dense cable textures by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/639
->* Remove ultra dense cable recipes by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/640
->* Remove UI strings for ultra dense cables by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/641
->* Remove AECableType.ULTRA_DENSE and ULTRA_DENSE_SMART by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/642
->* Remove GridFlags.ULTRA_DENSE_CAPACITY by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/643
->* Remove BackbonePathSegment and PathGridCache.backbone by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/644
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/647
->* Fix IO port early returning before processing queue by @S4mpsa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/646
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-514-GTNH...rv3-beta-516-GTNH
->
-
-## *rv3-beta-514-GTNH*
->## What's Changed
->* Make "unusable" IO port modes useful & add cell movement queue by @S4mpsa in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/626
->* Fix r-click divide and mid-click on processing pattern terminal by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/631
->* Update follow button by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/634
->* Remove Enable(P2p|QuantumBridge)BackboneTransfer config options by @szuend in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/637
->
->## New Contributors
->* @szuend made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/637
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-511-GTNH...rv3-beta-514-GTNH
->
-
-## *rv3-beta-511-GTNH*
->## What's Changed
->* Fix formation plane voiding items rarely by @serenibyss in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/628
->* Missing mode, forgot add reset. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/630
->* Notify player when ingredient cannot be extracted in required amount. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/629
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/628
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-509-GTNH...rv3-beta-511-GTNH
->
-
-## *rv3-beta-509-GTNH*
->## What's Changed
->* Add Superluminal Acceleration Card for IOPort by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/617
->* Improve missing mode. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/627
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-507-GTNH...rv3-beta-509-GTNH
->
-
-## *rv3-beta-507-GTNH*
->## What's Changed
->* Add Creative Energy Anchor (Neutronium energy cell attached on cable) by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/624
->* Add fake crafting card for AE by @MCTBL in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/622
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-505-GTNH...rv3-beta-507-GTNH
->
-
-## *rv3-beta-505-GTNH*
->## What's Changed
->* Feature: option to hide "stored" items in ae2 crafting plan by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/620
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-504-GTNH...rv3-beta-505-GTNH
->
-
-## *rv3-beta-504-GTNH*
->## What's Changed
->* Fix crash Adv blocking in configurated interface by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/625
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-503-GTNH...rv3-beta-504-GTNH
->
-
-## *rv3-beta-503-GTNH*
->## What's Changed
->* Add Search Cache to Terminal by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/621
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-502-GTNH...rv3-beta-503-GTNH
->
-
-## *rv3-beta-502-GTNH*
->## What's Changed
->* Painted ME chest will not connect to different color ME chest/cable. by @lordIcocain in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/623
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-501-GTNH...rv3-beta-502-GTNH
->
-
-## *rv3-beta-501-GTNH*
->## What's Changed
->* Fix NEI Synchronization by @slprime in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/619
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-500-GTNH...rv3-beta-501-GTNH
->
-
-## *rv3-beta-500-GTNH*
->## What's Changed
->* Change the texture offset so that the chest and drive use different parts of the same file instead of overlapping by @Ethryan in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/618
->* Display custom name in MemoryCard tooltip by @Worive in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/614
->
->## New Contributors
->* @Worive made their first contribution in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/614
->
->**Full Changelog**: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/compare/rv3-beta-478-GTNH...rv3-beta-500-GTNH
->
-
+# Updated - Archaicfix - 0.7.4 --> 0.7.6
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - ArchitectureCraft - 1.10.2 --> 1.11.2
-## *1.11.2*
->## What's Changed
->* Schematica crash workaround. by @AbdielKavash in https://github.com/GTNewHorizons/ArchitectureCraft/pull/24
->
->## New Contributors
->* @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/24
->
->**Full Changelog**: https://github.com/GTNewHorizons/ArchitectureCraft/compare/1.11.0...1.11.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/ArchitectureCraft/compare/1.10.2...1.11.2
 
-## *1.11.0*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/23
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/23
->
->**Full Changelog**: https://github.com/GTNewHorizons/ArchitectureCraft/compare/1.10.3...1.11.0
->
-
-## *1.10.3*
->## What's Changed
->* Support Lapis Caelestis, AntiBlocks and Neonite properly by @dvdmandt in https://github.com/GTNewHorizons/ArchitectureCraft/pull/21
->* Forward crafting material (block id) to shader engine if Angelica is loaded by @dvdmandt in https://github.com/GTNewHorizons/ArchitectureCraft/pull/22
->
->## New Contributors
->* @dvdmandt made their first contribution in https://github.com/GTNewHorizons/ArchitectureCraft/pull/21
->
->**Full Changelog**: https://github.com/GTNewHorizons/ArchitectureCraft/compare/1.10.2...1.10.3
->
+## What's Changed:
+>* Schematica crash workaround. by @AbdielKavash in https://github.com/GTNewHorizons/ArchitectureCraft/pull/24 (1.11.2)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/ArchitectureCraft/pull/23 (1.11.0)
+>* Support Lapis Caelestis, AntiBlocks and Neonite properly by @dvdmandt in https://github.com/GTNewHorizons/ArchitectureCraft/pull/21 (1.10.3)
+>* Forward crafting material (block id) to shader engine if Angelica is loaded by @dvdmandt in https://github.com/GTNewHorizons/ArchitectureCraft/pull/22 (1.10.3)
 
 # Updated - AsieLib - 0.6.0 --> 0.7.0
-## *0.7.0*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/AsieLib/pull/4
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/AsieLib/pull/4
->
->**Full Changelog**: https://github.com/GTNewHorizons/AsieLib/compare/0.6.0...0.7.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/AsieLib/compare/0.6.0...0.7.0
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/AsieLib/pull/4 (0.7.0)
 
 # Updated - Avaritia - 1.59 --> 1.68
-## *1.68*
->## What's Changed
->* Remove hard dep on codechicken lib by @Alexdoru in https://github.com/GTNewHorizons/Avaritia/pull/55
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.67...1.68
->
+**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.59...1.68
 
-## *1.67*
->## What's Changed
->* Fix dev environment name by @koolkrafter5 in https://github.com/GTNewHorizons/Avaritia/pull/54
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/54
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.66...1.67
->
-
-## *1.66*
->## What's Changed
->* Tag Orb of Armok as creative. by @AbdielKavash in https://github.com/GTNewHorizons/Avaritia/pull/53
->
->## New Contributors
->* @AbdielKavash made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/53
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.63...1.66
->
-
-## *1.63*
->## What's Changed
->* Change infinity armor and block Optional decorators to work with gt6 by @felixfour in https://github.com/GTNewHorizons/Avaritia/pull/50
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/50
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.62...1.63
->
-
-## *1.62*
->## What's Changed
->* Move Infinity Armor to new GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Avaritia/pull/49
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/49
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.61...1.62
->
-
-## *1.61*
->## What's Changed
->* Infinity Armor upwards and downward speed update by @mak8427 in https://github.com/GTNewHorizons/Avaritia/pull/48
->
->## New Contributors
->* @mak8427 made their first contribution in https://github.com/GTNewHorizons/Avaritia/pull/48
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritia/compare/1.59...1.61
->
+## What's Changed:
+>* Remove hard dep on codechicken lib by @Alexdoru in https://github.com/GTNewHorizons/Avaritia/pull/55 (1.68)
+>* Fix dev environment name by @koolkrafter5 in https://github.com/GTNewHorizons/Avaritia/pull/54 (1.67)
+>* Tag Orb of Armok as creative. by @AbdielKavash in https://github.com/GTNewHorizons/Avaritia/pull/53 (1.66)
+>* Change infinity armor and block Optional decorators to work with gt6 by @felixfour in https://github.com/GTNewHorizons/Avaritia/pull/50 (1.63)
+>* Move Infinity Armor to new GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Avaritia/pull/49 (1.62)
+>* Infinity Armor upwards and downward speed update by @mak8427 in https://github.com/GTNewHorizons/Avaritia/pull/48 (1.61)
 
 # Updated - Avaritiaddons - 1.8.4-GTNH --> 1.9.0-GTNH
-## *1.9.0-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Avaritiaddons/pull/16
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Avaritiaddons/pull/16
->
->**Full Changelog**: https://github.com/GTNewHorizons/Avaritiaddons/compare/1.8.4-GTNH...1.9.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Avaritiaddons/compare/1.8.4-GTNH...1.9.0-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Avaritiaddons/pull/16 (1.9.0-GTNH)
 
 # New Mod - Backhand:1.6.38
-## *1.6.38*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Backhand/pull/134
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.37...1.6.38
->
+**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.0...1.6.38
 
-## *1.6.37*
->## What's Changed
->* add stop before bucket check; cancel if slot is null on server by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/132
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.34...1.6.37
->
-
-## *1.6.34*
->## What's Changed
->* Update SyncedKeybind to include keydown arg by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/127
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.33...1.6.34
->
-
-## *1.6.33*
->## What's Changed
->* Fix mob tempting with item in offhand by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/124
->* Remove unneeded HarvestTool deprioritize with new changes by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/126
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.32...1.6.33
->
-
-## *1.6.32*
->## What's Changed
->* Add bucket/IFluidContainerItem check to right click handler by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/116
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.30...1.6.32
->
-
-## *1.6.30*
->## What's Changed
->* Fix offhand block breaking by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/118
->* Fix Bibliocraft Armor Stand slots by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/119
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.28...1.6.30
->
-
-## *1.6.28*
->## What's Changed
->* Fix WCT's armor slot conflict by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/112
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.26...1.6.28
->
-
-## *1.6.26*
->## What's Changed
->* General Rework by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/100
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.24...1.6.26
->
-
-## *1.6.24*
->## What's Changed
->* Change offhand texture to modern texture by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/110
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.22...1.6.24
->
-
-## *1.6.22*
->## What's Changed
->* merge identical mixins in MixinInventoryPlayer by @Alexdoru in https://github.com/GTNewHorizons/Backhand/pull/105
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/105
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.19...1.6.22
->
-
-## *1.6.19*
->## What's Changed
->* Fix DE Tools/Armor Config GUI by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/99
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.17...1.6.19
->
-
-## *1.6.17*
->## What's Changed
->* A bunch of (missing) GL state fixes by @kotmatross28729 in https://github.com/GTNewHorizons/Backhand/pull/95
->
->## New Contributors
->* @kotmatross28729 made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/95
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.16...1.6.17
->
-
-## *1.6.16*
->## What's Changed
->* BG2 compat by @YannickMG in https://github.com/GTNewHorizons/Backhand/pull/93
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/93
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.15...1.6.16
->
-
-## *1.6.15*
->## What's Changed
->* Do nothing when backhand$bg2Stacks is null by @DancingSnow0517 in https://github.com/GTNewHorizons/Backhand/pull/90
->
->## New Contributors
->* @DancingSnow0517 made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/90
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.14...1.6.15
->
-
-## *1.6.14*
->## What's Changed
->* More tfc slot fixes by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/85
->* Allow empty offhand to break blocks & fix pick block by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/86
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.13...1.6.14
->
-
-## *1.6.13*
->## What's Changed
->* Fix offhand slot clashing with TFC back slot by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/80
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.12...1.6.13
->
-
-## *1.6.12*
->## What's Changed
->* Configurable offhand hotbar slot position by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/79
->* Fix GC boot slot clashing with offhand slot by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/78
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.11...1.6.12
->
-
-## *1.6.11*
->## What's Changed
->* Fix gc rockets kicking players out instantly by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/69
->* Fix weird 3rd person rendering when using fishing rod by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/70
->* Better way to prioritize item usage for different hands by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/71
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.10...1.6.11
->
-
-## *1.6.10*
->## What's Changed
->* Fix some items not updating in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/67
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.9...1.6.10
->
-
-## *1.6.9*
->## What's Changed
->* Extract offhand rendering to a hook class for Angelica by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/63
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.7...1.6.9
->
-
-## *1.6.7*
->## What's Changed
->* Refactor packets by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/59
->* Fix some item uis not opening when something is in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/61
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.6...1.6.7
->
-
-## *1.6.6*
->## What's Changed
->* Use gtnhlib config sync by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/51
->* Fix TiC battle sign not working in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/55
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.5...1.6.6
->
-
-## *1.6.5*
->## What's Changed
->* Offhand rendering fixes by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/50
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.6.4...1.6.5
->
-
-## *1.6.4*
->## What's Changed
->* Less hacky offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/46
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.16...1.6.4
->
-
-## *1.5.16*
->## What's Changed
->* Various changes by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/45
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.14...1.5.16
->
-
-## *1.5.14*
->## What's Changed
->* Fix crash when interacting with some TileEntities by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/35
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.12...1.5.14
->
-
-## *1.5.12*
->## What's Changed
->* Update README.md by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/29
->* Fix various issues by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/21
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.5...1.5.12
->
-
-## *1.5.5*
->## What's Changed
->* Fix efr firework interaction by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/13
->* Convert ASM to mixin by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/14
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.2...1.5.5
->
-
-## *1.5.2*
->## What's Changed
->* Fix a bunch of issues by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/10
->
->## New Contributors
->* @Lyfts made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.1...1.5.2
->
-
-## *1.5.1*
->## What's Changed
->* Update gradle.properties by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/3
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.5.0...1.5.1
->
-
-## *1.5.0*
->## What's Changed
->* Update from dev branch + gtnh buildscript + lots of spotless by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/1
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Backhand/pull/1
->
->**Full Changelog**: https://github.com/GTNewHorizons/Backhand/compare/1.4.0...1.5.0
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Backhand/pull/134 (1.6.38)
+>* add stop before bucket check; cancel if slot is null on server by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/132 (1.6.37)
+>* Update SyncedKeybind to include keydown arg by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/127 (1.6.34)
+>* Fix mob tempting with item in offhand by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/124 (1.6.33)
+>* Remove unneeded HarvestTool deprioritize with new changes by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/126 (1.6.33)
+>* Add bucket/IFluidContainerItem check to right click handler by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/116 (1.6.32)
+>* Fix offhand block breaking by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/118 (1.6.30)
+>* Fix Bibliocraft Armor Stand slots by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/119 (1.6.30)
+>* Fix WCT's armor slot conflict by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/112 (1.6.28)
+>* General Rework by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/100 (1.6.26)
+>* Change offhand texture to modern texture by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/110 (1.6.24)
+>* merge identical mixins in MixinInventoryPlayer by @Alexdoru in https://github.com/GTNewHorizons/Backhand/pull/105 (1.6.22)
+>* Fix DE Tools/Armor Config GUI by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/99 (1.6.19)
+>* A bunch of (missing) GL state fixes by @kotmatross28729 in https://github.com/GTNewHorizons/Backhand/pull/95 (1.6.17)
+>* BG2 compat by @YannickMG in https://github.com/GTNewHorizons/Backhand/pull/93 (1.6.16)
+>* Do nothing when backhand$bg2Stacks is null by @DancingSnow0517 in https://github.com/GTNewHorizons/Backhand/pull/90 (1.6.15)
+>* More tfc slot fixes by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/85 (1.6.14)
+>* Allow empty offhand to break blocks & fix pick block by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/86 (1.6.14)
+>* Fix offhand slot clashing with TFC back slot by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/80 (1.6.13)
+>* Configurable offhand hotbar slot position by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/79 (1.6.12)
+>* Fix GC boot slot clashing with offhand slot by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/78 (1.6.12)
+>* Fix gc rockets kicking players out instantly by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/69 (1.6.11)
+>* Fix weird 3rd person rendering when using fishing rod by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/70 (1.6.11)
+>* Better way to prioritize item usage for different hands by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/71 (1.6.11)
+>* Fix some items not updating in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/67 (1.6.10)
+>* Extract offhand rendering to a hook class for Angelica by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/63 (1.6.9)
+>* Refactor packets by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/59 (1.6.7)
+>* Fix some item uis not opening when something is in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/61 (1.6.7)
+>* Use gtnhlib config sync by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/51 (1.6.6)
+>* Fix TiC battle sign not working in offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/55 (1.6.6)
+>* Offhand rendering fixes by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/50 (1.6.5)
+>* Less hacky offhand by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/46 (1.6.4)
+>* Various changes by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/45 (1.5.16)
+>* Fix crash when interacting with some TileEntities by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/35 (1.5.14)
+>* Update README.md by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/29 (1.5.12)
+>* Fix various issues by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/21 (1.5.12)
+>* Fix efr firework interaction by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/13 (1.5.5)
+>* Convert ASM to mixin by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/14 (1.5.5)
+>* Fix a bunch of issues by @Lyfts in https://github.com/GTNewHorizons/Backhand/pull/10 (1.5.2)
+>* Update gradle.properties by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/3 (1.5.1)
+>* Update from dev branch + gtnh buildscript + lots of spotless by @Caedis in https://github.com/GTNewHorizons/Backhand/pull/1 (1.5.0)
 
 # New Mod - Battlegear2-for-Backhand:1.5.5-backhand
-## *1.5.5-backhand*
->## What's Changed
->* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/6
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/6
->
->**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2-for-Backhand/compare/1.5.4-backhand...1.5.5-backhand
->
+**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2-for-Backhand/compare/1.5.0-backhand...1.5.5-backhand
 
-## *1.5.4-backhand*
->## What's Changed
->* Remove now unused keybinds by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/4
->* fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/5
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2-for-Backhand/compare/1.5.3-backhand...1.5.4-backhand
->
-
-## *1.5.3-backhand*
->## What's Changed
->* Remove dynamic-lights compat, BG2 doesn't control it's slots anymore by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/3
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2-for-Backhand/compare/1.5.0-backhand...1.5.3-backhand
->
-
-## *1.5.0-backhand*
->## What's Changed
->* Center the mod around Backhand and remove BG2's own slots by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/1
->* Use an actual Backhand release by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/2
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/1
->
->**Full Changelog**: https://github.com/GTNewHorizons/Battlegear2-for-Backhand/commits/1.5.0-backhand
->
+## What's Changed:
+>* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/6 (1.5.5-backhand)
+>* Remove now unused keybinds by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/4 (1.5.4-backhand)
+>* fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/5 (1.5.4-backhand)
+>* Remove dynamic-lights compat, BG2 doesn't control it's slots anymore by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/3 (1.5.3-backhand)
+>* Center the mod around Backhand and remove BG2's own slots by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/1 (1.5.0-backhand)
+>* Use an actual Backhand release by @YannickMG in https://github.com/GTNewHorizons/Battlegear2-for-Backhand/pull/2 (1.5.0-backhand)
 
 # Updated - Baubles-Expanded - 2.0.3 --> 2.1.9-GTNH
-## *2.1.9-GTNH*
->## What's Changed
->* Add CF Project ID by @mitchej123 in https://github.com/GTNewHorizons/Baubles-Expanded/pull/7
->* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/Baubles-Expanded/pull/9
->
->## New Contributors
->* @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Baubles-Expanded/pull/7
->
->**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.1.8-GTNH...2.1.9-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.0.3...2.1.9-GTNH
 
-## *2.1.8-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.1.7-GTNH...2.1.8-GTNH
->
-
-## *2.1.7-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.1.5-GTNH...2.1.7-GTNH
->
-
-## *2.1.6-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.1.5-GTNH...2.1.6-GTNH
->
-
-## *2.1.5-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Baubles-Expanded/compare/2.0.3...2.1.5-GTNH
->
+## What's Changed:
+>* Add CF Project ID by @mitchej123 in https://github.com/GTNewHorizons/Baubles-Expanded/pull/7 (2.1.9-GTNH)
+>* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/Baubles-Expanded/pull/9 (2.1.9-GTNH)
 
 # Updated - BetterBuildersWands - 0.13.1-GTNH --> 0.13.3-GTNH
-## *0.13.3-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/BetterBuildersWands/pull/19
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/BetterBuildersWands/pull/19
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterBuildersWands/compare/0.13.2-GTNH...0.13.3-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/BetterBuildersWands/compare/0.13.1-GTNH...0.13.3-GTNH
 
-## *0.13.2-GTNH*
->## What's Changed
->* Restrict build limit by @jurrejelle in https://github.com/GTNewHorizons/BetterBuildersWands/pull/18
->
->## New Contributors
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/BetterBuildersWands/pull/18
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterBuildersWands/compare/0.13.1-GTNH...0.13.2-GTNH
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/BetterBuildersWands/pull/19 (0.13.3-GTNH)
+>* Restrict build limit by @jurrejelle in https://github.com/GTNewHorizons/BetterBuildersWands/pull/18 (0.13.2-GTNH)
 
 # Updated - BetterP2P - 1.3.0 --> 1.3.1
-## *1.3.1*
->## What's Changed
->* update dependencies by @lc-1337 in https://github.com/GTNewHorizons/BetterP2P/pull/36
->
->## New Contributors
->* @lc-1337 made their first contribution in https://github.com/GTNewHorizons/BetterP2P/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterP2P/compare/1.3.0...1.3.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/BetterP2P/compare/1.3.0...1.3.1
+
+## What's Changed:
+>* update dependencies by @lc-1337 in https://github.com/GTNewHorizons/BetterP2P/pull/36 (1.3.1)
 
 # Updated - BetterQuesting - 3.6.24-GTNH --> 3.7.7-GTNH
-## *3.7.7-GTNH*
->## What's Changed
->* Make custom quest sounds decent volume by @dibbydoda in https://github.com/GTNewHorizons/BetterQuesting/pull/162
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/162
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.5-GTNH...3.7.7-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.6.24-GTNH...3.7.7-GTNH
 
-## *3.7.5-GTNH*
->## What's Changed
->* Add button to auto-claim choice rewards by @serenibyss in https://github.com/GTNewHorizons/BetterQuesting/pull/161
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/161
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.4-GTNH...3.7.5-GTNH
->
-
-## *3.7.4-GTNH*
->## What's Changed
->* fix depth test GL state leak by @kurrycat2004 in https://github.com/GTNewHorizons/BetterQuesting/pull/160
->* Localized quest names on pop-ups by @ChromaPIE in https://github.com/GTNewHorizons/BetterQuesting/pull/159
->
->## New Contributors
->* @kurrycat2004 made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/160
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/BetterQuesting/pull/159
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.3-GTNH...3.7.4-GTNH
->
-
-## *3.7.3-GTNH*
->## What's Changed
->* Don't go back to previous screen when r-clicking searchbar by @Lyfts in https://github.com/GTNewHorizons/BetterQuesting/pull/158
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.2-GTNH...3.7.3-GTNH
->
-
-## *3.7.2-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.1-GTNH...3.7.2-GTNH
->
-
-## *3.7.1-GTNH*
->## What's Changed
->* Add Localization by @glowredman in https://github.com/GTNewHorizons/BetterQuesting/pull/156
->* Sort the JSON keys alphabetically before saving to ensure consistent order by @eigenraven in https://github.com/GTNewHorizons/BetterQuesting/pull/157
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.7.0-GTNH...3.7.1-GTNH
->
-
-## *3.7.0-GTNH*
->## What's Changed
->* add disable reward mode :Gigachad: by @Glease in https://github.com/GTNewHorizons/BetterQuesting/pull/155
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BetterQuesting/compare/3.6.22-GTNH...3.7.0-GTNH
->
+## What's Changed:
+>* Make custom quest sounds decent volume by @dibbydoda in https://github.com/GTNewHorizons/BetterQuesting/pull/162 (3.7.7-GTNH)
+>* Add button to auto-claim choice rewards by @serenibyss in https://github.com/GTNewHorizons/BetterQuesting/pull/161 (3.7.5-GTNH)
+>* fix depth test GL state leak by @kurrycat2004 in https://github.com/GTNewHorizons/BetterQuesting/pull/160 (3.7.4-GTNH)
+>* Localized quest names on pop-ups by @ChromaPIE in https://github.com/GTNewHorizons/BetterQuesting/pull/159 (3.7.4-GTNH)
+>* Don't go back to previous screen when r-clicking searchbar by @Lyfts in https://github.com/GTNewHorizons/BetterQuesting/pull/158 (3.7.3-GTNH)
+>* Add Localization by @glowredman in https://github.com/GTNewHorizons/BetterQuesting/pull/156 (3.7.1-GTNH)
+>* Sort the JSON keys alphabetically before saving to ensure consistent order by @eigenraven in https://github.com/GTNewHorizons/BetterQuesting/pull/157 (3.7.1-GTNH)
+>* add disable reward mode :Gigachad: by @Glease in https://github.com/GTNewHorizons/BetterQuesting/pull/155 (3.7.0-GTNH)
 
 # Updated - Binnie - 2.4.8 --> 2.5.12
-## *2.5.12*
->## What's Changed
->* Properly apply hunger effect by @Alexdoru in https://github.com/GTNewHorizons/Binnie/pull/62
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/62
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.10...2.5.12
->
+**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.4.8...2.5.12
 
-## *2.5.10*
->## What's Changed
->* Remove mutator mutation chance cap by @Ruling-0 in https://github.com/GTNewHorizons/Binnie/pull/61
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/61
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.8...2.5.10
->
-
-## *2.5.8*
->## What's Changed
->* Extend Lab Stand GUI width by 80 units by @czerwonogrodzki in https://github.com/GTNewHorizons/Binnie/pull/60
->
->## New Contributors
->* @czerwonogrodzki made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/60
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.7...2.5.8
->
-
-## *2.5.7*
->## What's Changed
->* Fix stained block hardness by @serenibyss in https://github.com/GTNewHorizons/Binnie/pull/59
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.6...2.5.7
->
-
-## *2.5.6*
->## What's Changed
->* Revert 5x multiplier removal by @2ndDerivative in https://github.com/GTNewHorizons/Binnie/pull/58
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/58
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.4...2.5.6
->
-
-## *2.5.4*
->## What's Changed
->* Isolator crash fix revision by @Astatine5985 in https://github.com/GTNewHorizons/Binnie/pull/56
->
->## New Contributors
->* @Astatine5985 made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/56
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.2...2.5.4
->
-
-## *2.5.2*
->## What's Changed
->* Yeet custom config in favor of NHLib by @ah-OOG-ah in https://github.com/GTNewHorizons/Binnie/pull/53
->* Add Localization, Fix Carpentry Hammer / Master Carpentry Hammer Names being reverse by @glowredman in https://github.com/GTNewHorizons/Binnie/pull/57
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/57
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.5.0...2.5.2
->
-
-## *2.5.0*
->## What's Changed
->* prevent npe and log bad requests by @C0bra5 in https://github.com/GTNewHorizons/Binnie/pull/55
->
->## New Contributors
->* @C0bra5 made their first contribution in https://github.com/GTNewHorizons/Binnie/pull/55
->
->**Full Changelog**: https://github.com/GTNewHorizons/Binnie/compare/2.4.4...2.5.0
->
+## What's Changed:
+>* Properly apply hunger effect by @Alexdoru in https://github.com/GTNewHorizons/Binnie/pull/62 (2.5.12)
+>* Remove mutator mutation chance cap by @Ruling-0 in https://github.com/GTNewHorizons/Binnie/pull/61 (2.5.10)
+>* Extend Lab Stand GUI width by 80 units by @czerwonogrodzki in https://github.com/GTNewHorizons/Binnie/pull/60 (2.5.8)
+>* Fix stained block hardness by @serenibyss in https://github.com/GTNewHorizons/Binnie/pull/59 (2.5.7)
+>* Revert 5x multiplier removal by @2ndDerivative in https://github.com/GTNewHorizons/Binnie/pull/58 (2.5.6)
+>* Isolator crash fix revision by @Astatine5985 in https://github.com/GTNewHorizons/Binnie/pull/56 (2.5.4)
+>* Yeet custom config in favor of NHLib by @ah-OOG-ah in https://github.com/GTNewHorizons/Binnie/pull/53 (2.5.2)
+>* Add Localization, Fix Carpentry Hammer / Master Carpentry Hammer Names being reverse by @glowredman in https://github.com/GTNewHorizons/Binnie/pull/57 (2.5.2)
+>* prevent npe and log bad requests by @C0bra5 in https://github.com/GTNewHorizons/Binnie/pull/55 (2.5.0)
 
 # Updated - BlockLimiter - 0.6.0 --> 0.7.0
-## *0.7.0*
->## What's Changed
->* Disable `useDependencyInformation` by @glowredman in https://github.com/GTNewHorizons/BlockLimiter/pull/7
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/BlockLimiter/pull/7
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockLimiter/compare/0.6.0...0.7.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/BlockLimiter/compare/0.6.0...0.7.0
+
+## What's Changed:
+>* Disable `useDependencyInformation` by @glowredman in https://github.com/GTNewHorizons/BlockLimiter/pull/7 (0.7.0)
 
 # Updated - BlockRenderer6343 - 1.2.16 --> 1.3.16
-## *1.3.16*
->## What's Changed
->* Fix cleanroom only having one tier by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/32
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.14...1.3.16
->
+**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.2.16...1.3.16
 
-## *1.3.14*
->## What's Changed
->* Fix some tiered elements not being recognized by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/31
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.11...1.3.14
->
-
-## *1.3.11*
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.10...1.3.11
->
-
-## *1.3.10*
->## What's Changed
->* fix coil tier detection and untangle IStructureElementChain handling by @Glease in https://github.com/GTNewHorizons/BlockRenderer6343/pull/30
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.9...1.3.10
->
-
-## *1.3.9*
->## What's Changed
->* Enable max tier to appear both earlier and at end of tiering by @Ruling-0 in https://github.com/GTNewHorizons/BlockRenderer6343/pull/27
->* Misc fixes and optimizations by @RecursivePineapple in https://github.com/GTNewHorizons/BlockRenderer6343/pull/28
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/27
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/28
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.6...1.3.9
->
-
-## *1.3.6*
->## What's Changed
->* "All" and "Not set" localizable by @ChromaPIE in https://github.com/GTNewHorizons/BlockRenderer6343/pull/29
->
->## New Contributors
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/BlockRenderer6343/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.2...1.3.6
->
-
-## *1.3.2*
->## What's Changed
->* Make gt multiblocks able to better modify their preview by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/26
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.1...1.3.2
->
-
-## *1.3.1*
->## What's Changed
->* Fix some multiblock placements aborting too early by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/25
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.3.0...1.3.1
->
-
-## *1.3.0*
->## What's Changed
->* Several improvements & QOL by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/23
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BlockRenderer6343/compare/1.2.16...1.3.0
->
+## What's Changed:
+>* Fix cleanroom only having one tier by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/32 (1.3.16)
+>* Fix some tiered elements not being recognized by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/31 (1.3.14)
+>* fix coil tier detection and untangle IStructureElementChain handling by @Glease in https://github.com/GTNewHorizons/BlockRenderer6343/pull/30 (1.3.10)
+>* Enable max tier to appear both earlier and at end of tiering by @Ruling-0 in https://github.com/GTNewHorizons/BlockRenderer6343/pull/27 (1.3.9)
+>* Misc fixes and optimizations by @RecursivePineapple in https://github.com/GTNewHorizons/BlockRenderer6343/pull/28 (1.3.9)
+>* "All" and "Not set" localizable by @ChromaPIE in https://github.com/GTNewHorizons/BlockRenderer6343/pull/29 (1.3.6)
+>* Make gt multiblocks able to better modify their preview by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/26 (1.3.2)
+>* Fix some multiblock placements aborting too early by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/25 (1.3.1)
+>* Several improvements & QOL by @Lyfts in https://github.com/GTNewHorizons/BlockRenderer6343/pull/23 (1.3.0)
 
 # Updated - BloodArsenal - 1.3.6 --> 1.4.6
-## *1.4.6*
->## What's Changed
->* Fix corrupted line in lang file. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/BloodArsenal/pull/32
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/32
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.5...1.4.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.3.6...1.4.6
 
-## *1.4.5*
->## What's Changed
->* Transparent Orb Tooltip by @koolkrafter5 in https://github.com/GTNewHorizons/BloodArsenal/pull/31
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.4...1.4.5
->
-
-## *1.4.4*
->## What's Changed
->* Fix FluidEvent usage by @zyf051520 in https://github.com/GTNewHorizons/BloodArsenal/pull/30
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.3...1.4.4
->
-
-## *1.4.3*
->## What's Changed
->* Guard against divide by 0 by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/29
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.2...1.4.3
->
-
-## *1.4.2*
->## What's Changed
->* Move Transparent Orb Texture Metadata to NBT by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/28
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.1...1.4.2
->
-
-## *1.4.1*
->## What's Changed
->* Fix enchantress ritual LP subtraction by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/27
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/BloodArsenal/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.4.0...1.4.1
->
-
-## *1.4.0*
->**Full Changelog**: https://github.com/GTNewHorizons/BloodArsenal/compare/1.3.5...1.4.0
->
+## What's Changed:
+>* Fix corrupted line in lang file. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/BloodArsenal/pull/32 (1.4.6)
+>* Transparent Orb Tooltip by @koolkrafter5 in https://github.com/GTNewHorizons/BloodArsenal/pull/31 (1.4.5)
+>* Fix FluidEvent usage by @zyf051520 in https://github.com/GTNewHorizons/BloodArsenal/pull/30 (1.4.4)
+>* Guard against divide by 0 by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/29 (1.4.3)
+>* Move Transparent Orb Texture Metadata to NBT by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/28 (1.4.2)
+>* Fix enchantress ritual LP subtraction by @Ruling-0 in https://github.com/GTNewHorizons/BloodArsenal/pull/27 (1.4.1)
 
 # Updated - BloodMagic - 1.6.11 --> 1.7.46
-## *1.7.46*
->## What's Changed
->* Refactor Teleposers by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/100
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.43...1.7.46
->
+**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.6.11...1.7.46
 
-## *1.7.43*
->## What's Changed
->* Backport WayofTime/BloodMagic@64660d2d282c620e36abf262cc26f49486b7d903 by @ctrlaltmilk in https://github.com/GTNewHorizons/BloodMagic/pull/99
->
->## New Contributors
->* @ctrlaltmilk made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/99
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.40...1.7.43
->
-
-## *1.7.40*
->## What's Changed
->* Fix "Vis discount" Tooltip for Sanguine Armor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/98
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.39...1.7.40
->
-
-## *1.7.39*
->## What's Changed
->* Fix ritual diviner lang by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/97
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.38...1.7.39
->
-
-## *1.7.38*
->## What's Changed
->* Show Required Reagents for Fillers Replaced by Reagents by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/93
->* Re-encode `it_IT.lang` to UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/BloodMagic/pull/96
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/96
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.36...1.7.38
->
-
-## *1.7.36*
->## What's Changed
->* Show capacity of Blood Orbs in the tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/BloodMagic/pull/95
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.35...1.7.36
->
-
-## *1.7.35*
->## What's Changed
->* Lang Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/90
->* Registry Ordering by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/91
->* Texture Improvements by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/92
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.32...1.7.35
->
-
-## *1.7.32*
->## What's Changed
->* Update Readme by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/88
->* Allow the Orb of Armok to work from within a Blood Altar. by @AbdielKavash in https://github.com/GTNewHorizons/BloodMagic/pull/89
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.31...1.7.32
->
-
-## *1.7.31*
->## What's Changed
->* Orchestra of the Phantom Hands Improvements by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/85
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.29...1.7.31
->
-
-## *1.7.29*
->## What's Changed
->* Add an Alchemic Calcinator handler for NEI by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/87
->* Inscription Tools Refactor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/86
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.25...1.7.29
->
-
-## *1.7.25*
->## What's Changed
->* NEI Meteor Handler Revamp by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/77
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.23...1.7.25
->
-
-## *1.7.23*
->## What's Changed
->* Lil fix for PR #83, shift down Purpura yet another tier by @srdr2k3 in https://github.com/GTNewHorizons/BloodMagic/pull/84
->* Polishes Alchemic Calcinator & Belljars by @tiflu in https://github.com/GTNewHorizons/BloodMagic/pull/79
->
->## New Contributors
->* @tiflu made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/79
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.19...1.7.23
->
-
-## *1.7.19*
->## What's Changed
->* Enable Jabel and Generic Injection by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/82
->* Buff the Incenses in the Incense Crucible by @srdr2k3 in https://github.com/GTNewHorizons/BloodMagic/pull/83
->
->## New Contributors
->* @srdr2k3 made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/83
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.17...1.7.19
->
-
-## *1.7.17*
->## What's Changed
->* Big item refactor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/73
->* Migrate StructureLib Blood Altar handler from StructureCompat by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/81
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.15...1.7.17
->
-
-## *1.7.15*
->## What's Changed
->* Add config to disable potion flask repairability by @FourIsTheNumber in https://github.com/GTNewHorizons/BloodMagic/pull/80
->
->## New Contributors
->* @FourIsTheNumber made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/80
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.11...1.7.15
->
-
-## *1.7.11*
->## What's Changed
->* Remove Profanity by @C0bra5 in https://github.com/GTNewHorizons/BloodMagic/pull/78
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.9...1.7.11
->
-
-## *1.7.9*
->## What's Changed
->* Fix rituals not working when doDaylightCycle is set to false. by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/72
->* More comma-separation by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/74
->* Fix Mark of the Falling Tower does not check item stack and does not immediately remove entities by @ABKQPO in https://github.com/GTNewHorizons/BloodMagic/pull/75
->
->## New Contributors
->* @ABKQPO made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/75
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.8...1.7.9
->
-
-## *1.7.8*
->## What's Changed
->* Show LP comma-separated with divination sigil by @serenibyss in https://github.com/GTNewHorizons/BloodMagic/pull/71
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/71
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.7...1.7.8
->
-
-## *1.7.7*
->## What's Changed
->* Config to Allow Altar Components to be Any Block by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/68
->* NEI Meteor Oredict Support by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/69
->* Ritual of Speed bugfix and cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/70
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.5...1.7.7
->
-
-## *1.7.5*
->## What's Changed
->* New TypeAdapter for ItemStack by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/67
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.4...1.7.5
->
-
-## *1.7.4*
->## What's Changed
->* Misc. interconnected meteor loose ends and code cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/66
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.3...1.7.4
->
-
-## *1.7.3*
->## What's Changed
->* GSON Hotfix by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/65
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.2...1.7.3
->
-
-## *1.7.2*
->## What's Changed
->* Make meteor reagents completely configurable and add some new options to their functionality. by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/63
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.1...1.7.2
->
-
-## *1.7.1*
->## What's Changed
->* Fix ability to int overflow when adding to LP network by @Ruling-0 in https://github.com/GTNewHorizons/BloodMagic/pull/64
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/BloodMagic/pull/64
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.7.0...1.7.1
->
-
-## *1.7.0*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/BloodMagic/pull/62
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BloodMagic/compare/1.6.9...1.7.0
->
+## What's Changed:
+>* Refactor Teleposers by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/100 (1.7.46)
+>* Backport WayofTime/BloodMagic@64660d2d282c620e36abf262cc26f49486b7d903 by @ctrlaltmilk in https://github.com/GTNewHorizons/BloodMagic/pull/99 (1.7.43)
+>* Fix "Vis discount" Tooltip for Sanguine Armor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/98 (1.7.40)
+>* Fix ritual diviner lang by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/97 (1.7.39)
+>* Show Required Reagents for Fillers Replaced by Reagents by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/93 (1.7.38)
+>* Re-encode `it_IT.lang` to UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/BloodMagic/pull/96 (1.7.38)
+>* Show capacity of Blood Orbs in the tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/BloodMagic/pull/95 (1.7.36)
+>* Lang Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/90 (1.7.35)
+>* Registry Ordering by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/91 (1.7.35)
+>* Texture Improvements by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/92 (1.7.35)
+>* Update Readme by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/88 (1.7.32)
+>* Allow the Orb of Armok to work from within a Blood Altar. by @AbdielKavash in https://github.com/GTNewHorizons/BloodMagic/pull/89 (1.7.32)
+>* Orchestra of the Phantom Hands Improvements by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/85 (1.7.31)
+>* Add an Alchemic Calcinator handler for NEI by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/87 (1.7.29)
+>* Inscription Tools Refactor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/86 (1.7.29)
+>* NEI Meteor Handler Revamp by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/77 (1.7.25)
+>* Lil fix for PR #83, shift down Purpura yet another tier by @srdr2k3 in https://github.com/GTNewHorizons/BloodMagic/pull/84 (1.7.23)
+>* Polishes Alchemic Calcinator & Belljars by @tiflu in https://github.com/GTNewHorizons/BloodMagic/pull/79 (1.7.23)
+>* Enable Jabel and Generic Injection by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/82 (1.7.19)
+>* Buff the Incenses in the Incense Crucible by @srdr2k3 in https://github.com/GTNewHorizons/BloodMagic/pull/83 (1.7.19)
+>* Big item refactor by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/73 (1.7.17)
+>* Migrate StructureLib Blood Altar handler from StructureCompat by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/81 (1.7.17)
+>* Add config to disable potion flask repairability by @FourIsTheNumber in https://github.com/GTNewHorizons/BloodMagic/pull/80 (1.7.15)
+>* Remove Profanity by @C0bra5 in https://github.com/GTNewHorizons/BloodMagic/pull/78 (1.7.11)
+>* Fix rituals not working when doDaylightCycle is set to false. by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/72 (1.7.9)
+>* More comma-separation by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/74 (1.7.9)
+>* Fix Mark of the Falling Tower does not check item stack and does not immediately remove entities by @ABKQPO in https://github.com/GTNewHorizons/BloodMagic/pull/75 (1.7.9)
+>* Show LP comma-separated with divination sigil by @serenibyss in https://github.com/GTNewHorizons/BloodMagic/pull/71 (1.7.8)
+>* Config to Allow Altar Components to be Any Block by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/68 (1.7.7)
+>* NEI Meteor Oredict Support by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/69 (1.7.7)
+>* Ritual of Speed bugfix and cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/70 (1.7.7)
+>* New TypeAdapter for ItemStack by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/67 (1.7.5)
+>* Misc. interconnected meteor loose ends and code cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/66 (1.7.4)
+>* GSON Hotfix by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/65 (1.7.3)
+>* Make meteor reagents completely configurable and add some new options to their functionality. by @koolkrafter5 in https://github.com/GTNewHorizons/BloodMagic/pull/63 (1.7.2)
+>* Fix ability to int overflow when adding to LP network by @Ruling-0 in https://github.com/GTNewHorizons/BloodMagic/pull/64 (1.7.1)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/BloodMagic/pull/62 (1.7.0)
 
 # Updated - Botania - 1.11.7-GTNH --> 1.12.16-GTNH
-## *1.12.16-GTNH*
->## What's Changed
->* Fix achievement text typo by @koolkrafter5 in https://github.com/GTNewHorizons/Botania/pull/88
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Botania/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.12-GTNH...1.12.16-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.11.7-GTNH...1.12.16-GTNH
 
-## *1.12.12-GTNH*
->## What's Changed
->* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Botania/pull/83
->* Fix the rest of the lang file mistakes in Botania by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Botania/pull/84
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/Botania/pull/83
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.10-GTNH...1.12.12-GTNH
->
-
-## *1.12.10-GTNH*
->## What's Changed
->* Add configurable F3 Debug by @brandyyn in https://github.com/GTNewHorizons/Botania/pull/78
->
->## New Contributors
->* @brandyyn made their first contribution in https://github.com/GTNewHorizons/Botania/pull/78
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.8-GTNH...1.12.10-GTNH
->
-
-## *1.12.8-GTNH*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Botania/pull/81
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Botania/pull/81
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.6-GTNH...1.12.8-GTNH
->
-
-## *1.12.6-GTNH*
->## What's Changed
->* Update build by @miozune in https://github.com/GTNewHorizons/Botania/pull/76
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.5-GTNH...1.12.6-GTNH
->
-
-## *1.12.5-GTNH*
->## What's Changed
->* Small Cleanup by @glowredman in https://github.com/GTNewHorizons/Botania/pull/68
->* Reach ring rewrite by @Shadow1590 in https://github.com/GTNewHorizons/Botania/pull/67
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Botania/pull/68
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.3-GTNH...1.12.5-GTNH
->
-
-## *1.12.3-GTNH*
->## What's Changed
->* backported item filter for Rannuncarpus by @shadoxxhd in https://github.com/GTNewHorizons/Botania/pull/60
->
->## New Contributors
->* @shadoxxhd made their first contribution in https://github.com/GTNewHorizons/Botania/pull/60
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.2-GTNH...1.12.3-GTNH
->
-
-## *1.12.2-GTNH*
->## What's Changed
->* AgricarnationCompatibility by @Fabboz in https://github.com/GTNewHorizons/Botania/pull/62
->
->## New Contributors
->* @Fabboz made their first contribution in https://github.com/GTNewHorizons/Botania/pull/62
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.12.1-GTNH...1.12.2-GTNH
->
-
-## *1.12.1-GTNH*
->## What's Changed
->* Fix music disk use in the GT electric jukebox by adding metadata by @eigenraven in https://github.com/GTNewHorizons/Botania/pull/66
->
->## New Contributors
->* @eigenraven made their first contribution in https://github.com/GTNewHorizons/Botania/pull/66
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botania/compare/1.11.6-GTNH...1.12.1-GTNH
->
+## What's Changed:
+>* Fix achievement text typo by @koolkrafter5 in https://github.com/GTNewHorizons/Botania/pull/88 (1.12.16-GTNH)
+>* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Botania/pull/83 (1.12.12-GTNH)
+>* Fix the rest of the lang file mistakes in Botania by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Botania/pull/84 (1.12.12-GTNH)
+>* Add configurable F3 Debug by @brandyyn in https://github.com/GTNewHorizons/Botania/pull/78 (1.12.10-GTNH)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Botania/pull/81 (1.12.8-GTNH)
+>* Update build by @miozune in https://github.com/GTNewHorizons/Botania/pull/76 (1.12.6-GTNH)
+>* Small Cleanup by @glowredman in https://github.com/GTNewHorizons/Botania/pull/68 (1.12.5-GTNH)
+>* Reach ring rewrite by @Shadow1590 in https://github.com/GTNewHorizons/Botania/pull/67 (1.12.5-GTNH)
+>* backported item filter for Rannuncarpus by @shadoxxhd in https://github.com/GTNewHorizons/Botania/pull/60 (1.12.3-GTNH)
+>* AgricarnationCompatibility by @Fabboz in https://github.com/GTNewHorizons/Botania/pull/62 (1.12.2-GTNH)
+>* Fix music disk use in the GT electric jukebox by adding metadata by @eigenraven in https://github.com/GTNewHorizons/Botania/pull/66 (1.12.1-GTNH)
 
 # Updated - Botanic-horizons - 1.1.7-GTNH --> 1.11.16-GTNH
-## *1.11.16-GTNH*
->## What's Changed
->* Downtier Alfheim and Elementium to be mid EV instead of IV by @chrombread in https://github.com/GTNewHorizons/Botanic-horizons/pull/35
->
->## New Contributors
->* @chrombread made their first contribution in https://github.com/GTNewHorizons/Botanic-horizons/pull/35
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.11.14-GTNH...1.11.16-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.1.7-GTNH...1.11.16-GTNH
 
-## *1.11.14-GTNH*
->## What's Changed
->* Botania Multiblocks by @combusterf in https://github.com/GTNewHorizons/Botanic-horizons/pull/33
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.1.12-GTNH...1.11.14-GTNH
->
-
-## *1.1.12-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.1.11-GTNH...1.1.12-GTNH
->
-
-## *1.1.11-GTNH*
->## What's Changed
->* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/Botanic-horizons/pull/34
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/Botanic-horizons/pull/34
->
->**Full Changelog**: https://github.com/GTNewHorizons/Botanic-horizons/compare/1.1.7-GTNH...1.1.11-GTNH
->
+## What's Changed:
+>* Downtier Alfheim and Elementium to be mid EV instead of IV by @chrombread in https://github.com/GTNewHorizons/Botanic-horizons/pull/35 (1.11.16-GTNH)
+>* Botania Multiblocks by @combusterf in https://github.com/GTNewHorizons/Botanic-horizons/pull/33 (1.11.14-GTNH)
+>* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/Botanic-horizons/pull/34 (1.1.11-GTNH)
 
 # Updated - BuildCraft - 7.1.42 --> 7.1.44
-## *7.1.44*
->## What's Changed
->* [Memory-opti:static allocations] Fix 2 memory issues by @Alexdoru in https://github.com/GTNewHorizons/BuildCraft/pull/23
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/BuildCraft/compare/7.1.43...7.1.44
->
+**Full Changelog**: https://github.com/GTNewHorizons/BuildCraft/compare/7.1.42...7.1.44
 
-## *7.1.43*
->## What's Changed
->* Fix WorldServer leak by @Alexdoru in https://github.com/GTNewHorizons/BuildCraft/pull/22
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/BuildCraft/pull/22
->
->**Full Changelog**: https://github.com/GTNewHorizons/BuildCraft/compare/7.1.42...7.1.43
->
+## What's Changed:
+>* [Memory-opti:static allocations] Fix 2 memory issues by @Alexdoru in https://github.com/GTNewHorizons/BuildCraft/pull/23 (7.1.44)
+>* Fix WorldServer leak by @Alexdoru in https://github.com/GTNewHorizons/BuildCraft/pull/22 (7.1.43)
 
 # Updated - CarpentersBlocks - 3.6.4-GTNH --> 3.7.0-GTNH
-## *3.7.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/CarpentersBlocks/compare/3.6.4-GTNH...3.7.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/CarpentersBlocks/compare/3.6.4-GTNH...3.7.0-GTNH
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - Catwalks-2 - 2.3.2-GTNH --> 2.4.0-GTNH
-## *2.4.0-GTNH*
->## What's Changed
->* Fix some annoyances by @mitchej123 in https://github.com/GTNewHorizons/Catwalks-2/pull/16
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Catwalks-2/compare/2.3.4-GTNH...2.4.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Catwalks-2/compare/2.3.2-GTNH...2.4.0-GTNH
 
-## *2.3.4-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Catwalks-2/compare/2.3.2-GTNH...2.3.4-GTNH
->
+## What's Changed:
+>* Fix some annoyances by @mitchej123 in https://github.com/GTNewHorizons/Catwalks-2/pull/16 (2.4.0-GTNH)
 
 # Updated - Chisel - 2.15.5-GTNH --> 2.16.5-GTNH
-## *2.16.5-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Chisel/pull/60
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/60
->
->**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.16.4-GTNH...2.16.5-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.15.5-GTNH...2.16.5-GTNH
 
-## *2.16.4-GTNH*
->## What's Changed
->* Fix chisel slot voiding in some conditions by @serenibyss in https://github.com/GTNewHorizons/Chisel/pull/57
->* Fix CCRenderState reference by @serenibyss in https://github.com/GTNewHorizons/Chisel/pull/59
->* Fix rendering with LittleTiles by @DarkShadow44 in https://github.com/GTNewHorizons/Chisel/pull/58
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/58
->
->**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.16.2-GTNH...2.16.4-GTNH
->
-
-## *2.16.2-GTNH*
->## What's Changed
->* fix endstone oredict by @chochem in https://github.com/GTNewHorizons/Chisel/pull/56
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.16.1-GTNH...2.16.2-GTNH
->
-
-## *2.16.1-GTNH*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Chisel/pull/55
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.16.0-GTNH...2.16.1-GTNH
->
-
-## *2.16.0-GTNH*
->## What's Changed
->* Tooltip fix by @YannickMG in https://github.com/GTNewHorizons/Chisel/pull/54
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Chisel/pull/54
->
->**Full Changelog**: https://github.com/GTNewHorizons/Chisel/compare/2.15.3-GTNH...2.16.0-GTNH
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Chisel/pull/60 (2.16.5-GTNH)
+>* Fix chisel slot voiding in some conditions by @serenibyss in https://github.com/GTNewHorizons/Chisel/pull/57 (2.16.4-GTNH)
+>* Fix CCRenderState reference by @serenibyss in https://github.com/GTNewHorizons/Chisel/pull/59 (2.16.4-GTNH)
+>* Fix rendering with LittleTiles by @DarkShadow44 in https://github.com/GTNewHorizons/Chisel/pull/58 (2.16.4-GTNH)
+>* fix endstone oredict by @chochem in https://github.com/GTNewHorizons/Chisel/pull/56 (2.16.2-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Chisel/pull/55 (2.16.1-GTNH)
+>* Tooltip fix by @YannickMG in https://github.com/GTNewHorizons/Chisel/pull/54 (2.16.0-GTNH)
 
 # Updated - CodeChickenCore - 1.4.1 --> 1.4.3
-## *1.4.3*
->## What's Changed
->* modern java compat by @FalsePattern in https://github.com/GTNewHorizons/CodeChickenCore/pull/31
->
->## New Contributors
->* @FalsePattern made their first contribution in https://github.com/GTNewHorizons/CodeChickenCore/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenCore/compare/1.4.2...1.4.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenCore/compare/1.4.1...1.4.3
 
-## *1.4.2*
->## What's Changed
->* More thread safe, again. by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenCore/pull/30
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/CodeChickenCore/compare/1.4.1...1.4.2
->
+## What's Changed:
+>* modern java compat by @FalsePattern in https://github.com/GTNewHorizons/CodeChickenCore/pull/31 (1.4.3)
+>* More thread safe, again. by @mitchej123 in https://github.com/GTNewHorizons/CodeChickenCore/pull/30 (1.4.2)
 
 # Updated - Computronics - 1.8.5-GTNH --> 1.9.3-GTNH
-## *1.9.3-GTNH*
->## What's Changed
->* Add Driver for GregTech Circuit Configuration by @DeckerCHAN in https://github.com/GTNewHorizons/Computronics/pull/30
->
->## New Contributors
->* @DeckerCHAN made their first contribution in https://github.com/GTNewHorizons/Computronics/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/Computronics/compare/1.9.1-GTNH...1.9.3-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Computronics/compare/1.8.5-GTNH...1.9.3-GTNH
 
-## *1.9.1-GTNH*
->## What's Changed
->* Update dependencies.gradle by @Dream-Master in https://github.com/GTNewHorizons/Computronics/pull/31
->* Fix EnderIO weather obelisk driver by @serenibyss in https://github.com/GTNewHorizons/Computronics/pull/32
->* Remove deprecated capacitorbank integration by @dibbydoda in https://github.com/GTNewHorizons/Computronics/pull/33
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Computronics/pull/32
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/Computronics/pull/33
->
->**Full Changelog**: https://github.com/GTNewHorizons/Computronics/compare/1.9.0-GTNH...1.9.1-GTNH
->
-
-## *1.9.0-GTNH*
->## What's Changed
->* Adjust parameters with OC by @MeiTianyou in https://github.com/GTNewHorizons/Computronics/pull/28
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Computronics/compare/1.8.5-GTNH...1.9.0-GTNH
->
+## What's Changed:
+>* Add Driver for GregTech Circuit Configuration by @DeckerCHAN in https://github.com/GTNewHorizons/Computronics/pull/30 (1.9.3-GTNH)
+>* Update dependencies.gradle by @Dream-Master in https://github.com/GTNewHorizons/Computronics/pull/31 (1.9.1-GTNH)
+>* Fix EnderIO weather obelisk driver by @serenibyss in https://github.com/GTNewHorizons/Computronics/pull/32 (1.9.1-GTNH)
+>* Remove deprecated capacitorbank integration by @dibbydoda in https://github.com/GTNewHorizons/Computronics/pull/33 (1.9.1-GTNH)
+>* Adjust parameters with OC by @MeiTianyou in https://github.com/GTNewHorizons/Computronics/pull/28 (1.9.0-GTNH)
 
 # Updated - CookingForBlockheads - 1.3.8-GTNH --> 1.4.4-GTNH
-## *1.4.4-GTNH*
->## What's Changed
->* Tweak StorageDrawer Compat and add JABBA Compatibility by @dibbydoda in https://github.com/GTNewHorizons/CookingForBlockheads/pull/54
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/CookingForBlockheads/pull/54
->
->**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.4.3-GTNH...1.4.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.3.8-GTNH...1.4.4-GTNH
 
-## *1.4.3-GTNH*
->## What's Changed
->* Fix sink fluid drain bug by @C0bra5 in https://github.com/GTNewHorizons/CookingForBlockheads/pull/53
->
->## New Contributors
->* @C0bra5 made their first contribution in https://github.com/GTNewHorizons/CookingForBlockheads/pull/53
->
->**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.4.2-GTNH...1.4.3-GTNH
->
+## What's Changed:
+>* Tweak StorageDrawer Compat and add JABBA Compatibility by @dibbydoda in https://github.com/GTNewHorizons/CookingForBlockheads/pull/54 (1.4.4-GTNH)
+>* Fix sink fluid drain bug by @C0bra5 in https://github.com/GTNewHorizons/CookingForBlockheads/pull/53 (1.4.3-GTNH)
+>* Fixed hard coding item stacks to 64 by @Andthehand in https://github.com/GTNewHorizons/CookingForBlockheads/pull/51 (1.4.2-GTNH)
+>* Fixed baguette dough crafting by @Andthehand in https://github.com/GTNewHorizons/CookingForBlockheads/pull/52 (1.4.1-GTNH)
 
-## *1.4.2-GTNH*
->## What's Changed
->* Fixed hard coding item stacks to 64 by @Andthehand in https://github.com/GTNewHorizons/CookingForBlockheads/pull/51
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.4.1-GTNH...1.4.2-GTNH
->
-
-## *1.4.1-GTNH*
->## What's Changed
->* Fixed baguette dough crafting by @Andthehand in https://github.com/GTNewHorizons/CookingForBlockheads/pull/52
->
->## New Contributors
->* @Andthehand made their first contribution in https://github.com/GTNewHorizons/CookingForBlockheads/pull/52
->
->**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.4.0-GTNH...1.4.1-GTNH
->
-
-## *1.4.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/CookingForBlockheads/compare/1.3.8-GTNH...1.4.0-GTNH
->
-
+# Updated - Craft-Presence - 2.5.3 --> 2.6.1
+Mod is client-side only.
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - CraftTweaker - 3.4.0 --> 3.4.2
-## *3.4.2*
->**Full Changelog**: https://github.com/GTNewHorizons/CraftTweaker/compare/3.4.1...3.4.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/CraftTweaker/compare/3.4.0...3.4.2
 
-## *3.4.1*
->## What's Changed
->* Remove MT STUCK chat message by @brandyyn in https://github.com/GTNewHorizons/CraftTweaker/pull/23
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/CraftTweaker/compare/3.4.0...3.4.1
->
+## What's Changed:
+>* Remove MT STUCK chat message by @brandyyn in https://github.com/GTNewHorizons/CraftTweaker/pull/23 (3.4.1)
 
 # Updated - Crops-plus-plus - 1.7.14 --> 1.8.10
-## *1.8.10*
->## What's Changed
->* Localization of potions tooltip by @Discreater in https://github.com/GTNewHorizons/Crops-plus-plus/pull/94
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/94
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.9...1.8.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.7.14...1.8.10
 
-## *1.8.9*
->## What's Changed
->* Use formatNumbers instead of parseNumberToString by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/92
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.8...1.8.9
->
-
-## *1.8.8*
->## What's Changed
->* Cleanup deprecated / unused methods by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/91
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.7...1.8.8
->
-
-## *1.8.7*
->## What's Changed
->* Change recipes to the optimized version by @StaffiX in https://github.com/GTNewHorizons/Crops-plus-plus/pull/90
->
->## New Contributors
->* @StaffiX made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/90
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.6...1.8.7
->
-
-## *1.8.6*
->## What's Changed
->* Downscale crop textures to 16x16 by @serenibyss in https://github.com/GTNewHorizons/Crops-plus-plus/pull/86
->* Retexture Weed Picker by @serenibyss in https://github.com/GTNewHorizons/Crops-plus-plus/pull/87
->* Remove getTankPressure override by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/89
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/86
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.4...1.8.6
->
-
-## *1.8.4*
->## What's Changed
->* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/Crops-plus-plus/pull/88
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.2...1.8.4
->
-
-## *1.8.2*
->## What's Changed
->* Add custom textures for the Sugar Beet crop by @Juknum in https://github.com/GTNewHorizons/Crops-plus-plus/pull/85
->
->## New Contributors
->* @Juknum made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/85
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.8.0...1.8.2
->
-
-## *1.8.0*
->## What's Changed
->* Fix Typo for Natura Blueberry by @Yoshy2002 in https://github.com/GTNewHorizons/Crops-plus-plus/pull/84
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/Crops-plus-plus/pull/84
->
->**Full Changelog**: https://github.com/GTNewHorizons/Crops-plus-plus/compare/1.7.13...1.8.0
->
+## What's Changed:
+>* Localization of potions tooltip by @Discreater in https://github.com/GTNewHorizons/Crops-plus-plus/pull/94 (1.8.10)
+>* Use formatNumbers instead of parseNumberToString by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/92 (1.8.9)
+>* Cleanup deprecated / unused methods by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/91 (1.8.8)
+>* Change recipes to the optimized version by @StaffiX in https://github.com/GTNewHorizons/Crops-plus-plus/pull/90 (1.8.7)
+>* Downscale crop textures to 16x16 by @serenibyss in https://github.com/GTNewHorizons/Crops-plus-plus/pull/86 (1.8.6)
+>* Retexture Weed Picker by @serenibyss in https://github.com/GTNewHorizons/Crops-plus-plus/pull/87 (1.8.6)
+>* Remove getTankPressure override by @miozune in https://github.com/GTNewHorizons/Crops-plus-plus/pull/89 (1.8.6)
+>* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/Crops-plus-plus/pull/88 (1.8.4)
+>* Add custom textures for the Sugar Beet crop by @Juknum in https://github.com/GTNewHorizons/Crops-plus-plus/pull/85 (1.8.2)
+>* Fix Typo for Natura Blueberry by @Yoshy2002 in https://github.com/GTNewHorizons/Crops-plus-plus/pull/84 (1.8.0)
 
 # Updated - Custom-Main-Menu - 1.11.3 --> 1.12.1
 Mod is client-side only.
-## *1.12.1*
->**Full Changelog**: https://github.com/GTNewHorizons/Custom-Main-Menu/compare/1.12.0...1.12.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/Custom-Main-Menu/compare/1.11.3...1.12.1
 
-## *1.12.0*
->## What's Changed
->* Fix shuffled menus on Java 17 by @ah-OOG-ah in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/9
->
->## New Contributors
->* @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/Custom-Main-Menu/compare/1.11.2...1.12.0
->
+## What's Changed:
+>* Fix shuffled menus on Java 17 by @ah-OOG-ah in https://github.com/GTNewHorizons/Custom-Main-Menu/pull/9 (1.12.0)
 
 # New Mod - Darkerer:1.0.6
-## *1.0.6*
->## What's Changed
->* Fix Client/Server side handling by @glowredman in https://github.com/GTNewHorizons/Darkerer/pull/1
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Darkerer/pull/1
->
->**Full Changelog**: https://github.com/GTNewHorizons/Darkerer/compare/1.0.5...1.0.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/Darkerer/compare/1.0.3...1.0.6
 
-## *1.0.5*
->**Full Changelog**: https://github.com/GTNewHorizons/Darkerer/compare/1.0.4...1.0.5
->
-
-## *1.0.4*
->**Full Changelog**: https://github.com/GTNewHorizons/Darkerer/compare/1.0.3...1.0.4
->
-
-## *1.0.3*
->**Full Changelog**: https://github.com/GTNewHorizons/Darkerer/compare/1.0.2...1.0.3
->
+## What's Changed:
+>* Fix Client/Server side handling by @glowredman in https://github.com/GTNewHorizons/Darkerer/pull/1 (1.0.6)
 
 # Updated - DefaultServerList - 1.5.0 --> 1.6.4
 Mod is client-side only.
-## *1.6.4*
->## What's Changed
->* Use Forge configs instead of JSON by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/10
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.6.2...1.6.4
->
+**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.5.0...1.6.4
 
-## *1.6.2*
->## What's Changed
->* Fix Mixin Loading by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/9
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.6.1...1.6.2
->
-
-## *1.6.1*
->**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.6.0...1.6.1
->
-
-## *1.6.0*
->**Full Changelog**: https://github.com/GTNewHorizons/DefaultServerList/compare/1.5.0...1.6.0
->
+## What's Changed:
+>* Use Forge configs instead of JSON by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/10 (1.6.4)
+>* Fix Mixin Loading by @glowredman in https://github.com/GTNewHorizons/DefaultServerList/pull/9 (1.6.2)
 
 # Updated - DefaultWorldGenerator - 0.3.0 --> 0.4.0
 Mod is client-side only.
-## *0.4.0*
->## What's Changed
->* Added Unlock Key for GuiCreateWorld by @Taskeren in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/4
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/4
->
->**Full Changelog**: https://github.com/GTNewHorizons/DefaultWorldGenerator/compare/0.3.0...0.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/DefaultWorldGenerator/compare/0.3.0...0.4.0
+
+## What's Changed:
+>* Added Unlock Key for GuiCreateWorld by @Taskeren in https://github.com/GTNewHorizons/DefaultWorldGenerator/pull/4 (0.4.0)
 
 # Updated - Draconic-Evolution - 1.3.18-GTNH --> 1.4.23-GTNH
-## *1.4.23-GTNH*
->## What's Changed
->* Magnet improvements by @Alexdoru in https://github.com/GTNewHorizons/Draconic-Evolution/pull/72
->* Magnet attracts only if closest player, and toggleable self-drop pickup with Hodgepodge loaded by @Ruling-0 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/70
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.21-GTNH...1.4.23-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.3.18-GTNH...1.4.23-GTNH
 
-## *1.4.21-GTNH*
->## What's Changed
->* Inhibitor improvements by @Shadow1590 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/64
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.18-GTNH...1.4.21-GTNH
->
-
-## *1.4.18-GTNH*
->## What's Changed
->* Add more Draconic Reactor configuration, and allow fuel automation by @StaffiX in https://github.com/GTNewHorizons/Draconic-Evolution/pull/61
->
->## New Contributors
->* @StaffiX made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/61
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.16-GTNH...1.4.18-GTNH
->
-
-## *1.4.16-GTNH*
->## What's Changed
->* Fix GT Loader checks without touching Optional decorator for now by @felixfour in https://github.com/GTNewHorizons/Draconic-Evolution/pull/69
->* Fix gregtech loader checks, and change Optional hazmat decorators to check if gtnh's gt5 is loaded by @felixfour in https://github.com/GTNewHorizons/Draconic-Evolution/pull/68
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.14-GTNH...1.4.16-GTNH
->
-
-## *1.4.14-GTNH*
->## What's Changed
->* add config options to weighting ore gen by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/67
->
->## New Contributors
->* @48a3efa65c881ef567345b17f3910e06 made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/67
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.12-GTNH...1.4.14-GTNH
->
-
-## *1.4.12-GTNH*
->## What's Changed
->* nicer German translations by @2ndDerivative in https://github.com/GTNewHorizons/Draconic-Evolution/pull/66
->* Move Draconic/Wyvern armor to new GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Draconic-Evolution/pull/65
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/66
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.6-GTNH...1.4.12-GTNH
->
-
-## *1.4.6-GTNH*
->## What's Changed
->* Fix OpenComputers component not properly loaded for Particle Generator (and probably other components) by @YamiKami-Sama in https://github.com/GTNewHorizons/Draconic-Evolution/pull/63
->
->## New Contributors
->* @YamiKami-Sama made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/63
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.5-GTNH...1.4.6-GTNH
->
-
-## *1.4.5-GTNH*
->## What's Changed
->* Add Dislocator Inhibitor by @Shadow1590 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/60
->
->## New Contributors
->* @Shadow1590 made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/60
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.3-GTNH...1.4.5-GTNH
->
-
-## *1.4.3-GTNH*
->## What's Changed
->* Fix Magnet pulling fake item entities by @Ruling-0 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/59
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/59
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.2-GTNH...1.4.3-GTNH
->
-
-## *1.4.2-GTNH*
->## What's Changed
->* More configurable Magnet by @Kogepan229 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/57
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/57
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.1-GTNH...1.4.2-GTNH
->
-
-## *1.4.1-GTNH*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Draconic-Evolution/pull/58
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.4.0-GTNH...1.4.1-GTNH
->
-
-## *1.4.0-GTNH*
->## What's Changed
->* Broaden support for mouse button keybinds by @wlhlm in https://github.com/GTNewHorizons/Draconic-Evolution/pull/56
->
->## New Contributors
->* @wlhlm made their first contribution in https://github.com/GTNewHorizons/Draconic-Evolution/pull/56
->
->**Full Changelog**: https://github.com/GTNewHorizons/Draconic-Evolution/compare/1.3.14-GTNH...1.4.0-GTNH
->
+## What's Changed:
+>* Magnet improvements by @Alexdoru in https://github.com/GTNewHorizons/Draconic-Evolution/pull/72 (1.4.23-GTNH)
+>* Magnet attracts only if closest player, and toggleable self-drop pickup with Hodgepodge loaded by @Ruling-0 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/70 (1.4.23-GTNH)
+>* Inhibitor improvements by @Shadow1590 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/64 (1.4.21-GTNH)
+>* Add more Draconic Reactor configuration, and allow fuel automation by @StaffiX in https://github.com/GTNewHorizons/Draconic-Evolution/pull/61 (1.4.18-GTNH)
+>* Fix GT Loader checks without touching Optional decorator for now by @felixfour in https://github.com/GTNewHorizons/Draconic-Evolution/pull/69 (1.4.16-GTNH)
+>* Fix gregtech loader checks, and change Optional hazmat decorators to check if gtnh's gt5 is loaded by @felixfour in https://github.com/GTNewHorizons/Draconic-Evolution/pull/68 (1.4.16-GTNH)
+>* add config options to weighting ore gen by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/67 (1.4.14-GTNH)
+>* nicer German translations by @2ndDerivative in https://github.com/GTNewHorizons/Draconic-Evolution/pull/66 (1.4.12-GTNH)
+>* Move Draconic/Wyvern armor to new GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Draconic-Evolution/pull/65 (1.4.12-GTNH)
+>* Fix OpenComputers component not properly loaded for Particle Generator (and probably other components) by @YamiKami-Sama in https://github.com/GTNewHorizons/Draconic-Evolution/pull/63 (1.4.6-GTNH)
+>* Add Dislocator Inhibitor by @Shadow1590 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/60 (1.4.5-GTNH)
+>* Fix Magnet pulling fake item entities by @Ruling-0 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/59 (1.4.3-GTNH)
+>* More configurable Magnet by @Kogepan229 in https://github.com/GTNewHorizons/Draconic-Evolution/pull/57 (1.4.2-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Draconic-Evolution/pull/58 (1.4.1-GTNH)
+>* Broaden support for mouse button keybinds by @wlhlm in https://github.com/GTNewHorizons/Draconic-Evolution/pull/56 (1.4.0-GTNH)
 
 # Updated - Electro-Magic-Tools - 1.5.17 --> 1.6.10
-## *1.6.10*
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.9...1.6.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.5.17...1.6.10
 
-## *1.6.9*
->## What's Changed
->* Fix ConcurrentModificationException in ItemShieldFocus by @cargocats in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/95
->* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/96
->
->## New Contributors
->* @cargocats made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/95
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/96
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.7...1.6.9
->
-
-## *1.6.7*
->## What's Changed
->* Essentia Generator Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/93
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/94
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.5...1.6.7
->
-
-## *1.6.5*
->## What's Changed
->* Change optional decorator modid from `gregtech` to `gregtech_nh` for gt6 compat by @felixfour in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/92
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/92
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.4...1.6.5
->
-
-## *1.6.4*
->## What's Changed
->* Move Nano/Quantum armor pieces to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/91
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/91
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.3...1.6.4
->
-
-## *1.6.3*
->## What's Changed
->* EMT Foci Bugfixes/Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/90
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/90
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.2...1.6.3
->
-
-## *1.6.2*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/89
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.1...1.6.2
->
-
-## *1.6.1*
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.6.0...1.6.1
->
-
-## *1.6.0*
->## What's Changed
->* Migrate Research Completer to GT5u by @serenibyss in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/88
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/Electro-Magic-Tools/compare/1.5.16...1.6.0
->
+## What's Changed:
+>* Fix ConcurrentModificationException in ItemShieldFocus by @cargocats in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/95 (1.6.9)
+>* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/96 (1.6.9)
+>* Essentia Generator Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/93 (1.6.7)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/94 (1.6.7)
+>* Change optional decorator modid from `gregtech` to `gregtech_nh` for gt6 compat by @felixfour in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/92 (1.6.5)
+>* Move Nano/Quantum armor pieces to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/91 (1.6.4)
+>* EMT Foci Bugfixes/Cleanup by @koolkrafter5 in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/90 (1.6.3)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/89 (1.6.2)
+>* Migrate Research Completer to GT5u by @serenibyss in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/88 (1.6.0)
 
 # Updated - EnderCore - 0.4.6 --> 0.4.8
-## *0.4.8*
->## What's Changed
->* Remove EnderCoreTransformerClient   by @0hwx in https://github.com/GTNewHorizons/EnderCore/pull/26
->
->## New Contributors
->* @0hwx made their first contribution in https://github.com/GTNewHorizons/EnderCore/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderCore/compare/0.4.6...0.4.8
->
+**Full Changelog**: https://github.com/GTNewHorizons/EnderCore/compare/0.4.6...0.4.8
+
+## What's Changed:
+>* Remove EnderCoreTransformerClient   by @0hwx in https://github.com/GTNewHorizons/EnderCore/pull/26 (0.4.8)
 
 # Updated - EnderIO - 2.8.24 --> 2.9.18
-## *2.9.18*
->## What's Changed
->* Update NEI Handlers by @slprime in https://github.com/GTNewHorizons/EnderIO/pull/198
->
->## New Contributors
->* @slprime made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/198
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.16...2.9.18
->
+**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.8.24...2.9.18
 
-## *2.9.16*
->## What's Changed
->* Remove deprecated CapacitorBank by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/197
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.14...2.9.16
->
-
-## *2.9.14*
->## What's Changed
->* Comparator refactor and Vacuum Chest logic by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/196
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.13...2.9.14
->
-
-## *2.9.13*
->## What's Changed
->* Small Cleanup by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/195
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.12...2.9.13
->
-
-## *2.9.12*
->## What's Changed
->* Feature: Automatable weather obelisk by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/193
->* Make Fused Quartz blast resistance configurable by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/194
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/193
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.8...2.9.12
->
-
-## *2.9.8*
->## What's Changed
->* Change hazmat Optional decorators' modid from `gregtech` to `gregtech_nh` to add gt6 compat by @felixfour in https://github.com/GTNewHorizons/EnderIO/pull/191
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/191
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.7...2.9.8
->
-
-## *2.9.7*
->## What's Changed
->* Move End Steel/ Stellar Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/189
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.6...2.9.7
->
-
-## *2.9.6*
->## What's Changed
->* fix trackman's goggles config by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/188
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.5...2.9.6
->
-
-## *2.9.5*
->## What's Changed
->* Fix naturalist's eyes by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/187
->* Add trackman's goggles upgrade support to the Dark Helm by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/186
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/187
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.4...2.9.5
->
-
-## *2.9.4*
->## What's Changed
->* Mark EnderCore as a required dependency by @serenibyss in https://github.com/GTNewHorizons/EnderIO/pull/185
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/185
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.3...2.9.4
->
-
-## *2.9.3*
->## What's Changed
->* Adding "show range" button to multiple machines by @Dioxop in https://github.com/GTNewHorizons/EnderIO/pull/184
->
->## New Contributors
->* @Dioxop made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/184
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.2...2.9.3
->
-
-## *2.9.2*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/183
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.1...2.9.2
->
-
-## *2.9.1*
->## What's Changed
->* Remove left-over code and textures for ultra dense ME conduits by @szuend in https://github.com/GTNewHorizons/EnderIO/pull/182
->
->## New Contributors
->* @szuend made their first contribution in https://github.com/GTNewHorizons/EnderIO/pull/182
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.9.0...2.9.1
->
-
-## *2.9.0*
->## What's Changed
->* ensure `TileLightNode` instance at `breakBlock` by @Pilzinsel64 in https://github.com/GTNewHorizons/EnderIO/pull/181
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderIO/compare/2.8.22...2.9.0
->
+## What's Changed:
+>* Update NEI Handlers by @slprime in https://github.com/GTNewHorizons/EnderIO/pull/198 (2.9.18)
+>* Remove deprecated CapacitorBank by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/197 (2.9.16)
+>* Comparator refactor and Vacuum Chest logic by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/196 (2.9.14)
+>* Small Cleanup by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/195 (2.9.13)
+>* Feature: Automatable weather obelisk by @dibbydoda in https://github.com/GTNewHorizons/EnderIO/pull/193 (2.9.12)
+>* Make Fused Quartz blast resistance configurable by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/194 (2.9.12)
+>* Change hazmat Optional decorators' modid from `gregtech` to `gregtech_nh` to add gt6 compat by @felixfour in https://github.com/GTNewHorizons/EnderIO/pull/191 (2.9.8)
+>* Move End Steel/ Stellar Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/189 (2.9.7)
+>* fix trackman's goggles config by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/188 (2.9.6)
+>* Fix naturalist's eyes by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/187 (2.9.5)
+>* Add trackman's goggles upgrade support to the Dark Helm by @2ndDerivative in https://github.com/GTNewHorizons/EnderIO/pull/186 (2.9.5)
+>* Mark EnderCore as a required dependency by @serenibyss in https://github.com/GTNewHorizons/EnderIO/pull/185 (2.9.4)
+>* Adding "show range" button to multiple machines by @Dioxop in https://github.com/GTNewHorizons/EnderIO/pull/184 (2.9.3)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/EnderIO/pull/183 (2.9.2)
+>* Remove left-over code and textures for ultra dense ME conduits by @szuend in https://github.com/GTNewHorizons/EnderIO/pull/182 (2.9.1)
+>* ensure `TileLightNode` instance at `breakBlock` by @Pilzinsel64 in https://github.com/GTNewHorizons/EnderIO/pull/181 (2.9.0)
 
 # Updated - EnderStorage - 1.7.2 --> 1.7.3
-## *1.7.3*
->## What's Changed
->* Re-encode `sv_SV.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/EnderStorage/pull/17
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/EnderStorage/pull/17
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderStorage/compare/1.7.2...1.7.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/EnderStorage/compare/1.7.2...1.7.3
+
+## What's Changed:
+>* Re-encode `sv_SV.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/EnderStorage/pull/17 (1.7.3)
 
 # Updated - EnderZoo - 1.3.1 --> 1.3.2
-## *1.3.2*
->## What's Changed
->* remove concussion creeper from tainted lands by @giantcavespider in https://github.com/GTNewHorizons/EnderZoo/pull/12
->
->## New Contributors
->* @giantcavespider made their first contribution in https://github.com/GTNewHorizons/EnderZoo/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnderZoo/compare/1.3.1...1.3.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/EnderZoo/compare/1.3.1...1.3.2
+
+## What's Changed:
+>* remove concussion creeper from tainted lands by @giantcavespider in https://github.com/GTNewHorizons/EnderZoo/pull/12 (1.3.2)
 
 # Updated - EnhancedLootBags - 1.1.2 --> 1.2.8
-## *1.2.8*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/EnhancedLootBags/pull/15
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/EnhancedLootBags/pull/15
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.2.7...1.2.8
->
+**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.1.2...1.2.8
 
-## *1.2.7*
->## What's Changed
->* Tell GTNH players how to enchant their lootbags by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/14
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.2.5...1.2.7
->
-
-## *1.2.5*
->## What's Changed
->* Better communicate the purpose of enchanting lootbags by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/13
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.2.3...1.2.5
->
-
-## *1.2.3*
->## What's Changed
->* Less trashy loot by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.2.1...1.2.3
->
-
-## *1.2.1*
->## What's Changed
->* Localizable group name & tooltips by @ChromaPIE in https://github.com/GTNewHorizons/EnhancedLootBags/pull/11
->
->## New Contributors
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/EnhancedLootBags/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.2.0...1.2.1
->
-
-## *1.2.0*
->## What's Changed
->* Customizable Lootbag icons by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/10
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/EnhancedLootBags/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/EnhancedLootBags/compare/1.1.1...1.2.0
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/EnhancedLootBags/pull/15 (1.2.8)
+>* Tell GTNH players how to enchant their lootbags by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/14 (1.2.7)
+>* Better communicate the purpose of enchanting lootbags by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/13 (1.2.5)
+>* Less trashy loot by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/12 (1.2.3)
+>* Localizable group name & tooltips by @ChromaPIE in https://github.com/GTNewHorizons/EnhancedLootBags/pull/11 (1.2.1)
+>* Customizable Lootbag icons by @YannickMG in https://github.com/GTNewHorizons/EnhancedLootBags/pull/10 (1.2.0)
 
 # New Mod - Et-Futurum-Requiem:2.6.2.18-GTNH-daily
-## *2.6.2.18-GTNH-daily*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.17-GTNH-daily...2.6.2.18-GTNH-daily
->
+**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.1-GTNH-pre...2.6.2.18-GTNH-daily
 
-## *2.6.2.17-GTNH-daily*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.16-GTNH-pre...2.6.2.17-GTNH-daily
->
-
-## *2.6.2.9-GTNH*
->## What's Changed
->* Update build.gradle by @Dream-Master in https://github.com/GTNewHorizons/Et-Futurum-Requiem/pull/12
->
->## New Contributors
->* @Dream-Master made their first contribution in https://github.com/GTNewHorizons/Et-Futurum-Requiem/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/commits/2.6.2.9-GTNH
->
-
-## *2.6.2.8-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.7-GTNH...2.6.2.8-GTNH
->
-
-## *2.6.2.7-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.6-GTNH...2.6.2.7-GTNH
->
-
-## *2.6.2.6-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.5-GTNH...2.6.2.6-GTNH
->
-
-## *2.6.2.5-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.4-GTNH...2.6.2.5-GTNH
->
-
-## *2.6.2.4-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.3-GTNH...2.6.2.4-GTNH
->
-
-## *2.6.2.3-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.2-GTNH...2.6.2.3-GTNH
->
-
-## *2.6.2.2-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Et-Futurum-Requiem/compare/2.6.2.1-GTNH-pre...2.6.2.2-GTNH
->
+## What's Changed:
+>* Update build.gradle by @Dream-Master in https://github.com/GTNewHorizons/Et-Futurum-Requiem/pull/12 (2.6.2.9-GTNH)
 
 # Updated - FindIt - 1.3.10 --> 1.4.0
-## *1.4.0*
->## What's Changed
->* fix loader check by @felixfour in https://github.com/GTNewHorizons/FindIt/pull/27
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/FindIt/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/FindIt/compare/1.3.10...1.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/FindIt/compare/1.3.10...1.4.0
+
+## What's Changed:
+>* fix loader check by @felixfour in https://github.com/GTNewHorizons/FindIt/pull/27 (1.4.0)
 
 # Updated - FloodLights - 1.4.6 --> 1.5.4
-## *1.5.4*
->## What's Changed
->* Preverse NBT data when block is broken by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/14
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.5.3...1.5.4
->
+**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.4.6...1.5.4
 
-## *1.5.3*
->## What's Changed
->* add missing override for grow light by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/13
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.5.2...1.5.3
->
-
-## *1.5.2*
->## What's Changed
->* Set `isBlockContainer` to true in all blocks spawning tile entities by @DCNick3 in https://github.com/GTNewHorizons/FloodLights/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.4.5...1.5.2
->
-
-## *1.5.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/FloodLights/pull/9
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.5.0...1.5.1
->
-
-## *1.5.0*
->## What's Changed
->* Fix cascade chunkloading by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/8
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/FloodLights/compare/1.4.2...1.5.0
->
+## What's Changed:
+>* Preverse NBT data when block is broken by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/14 (1.5.4)
+>* add missing override for grow light by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/13 (1.5.3)
+>* Set `isBlockContainer` to true in all blocks spawning tile entities by @DCNick3 in https://github.com/GTNewHorizons/FloodLights/pull/12 (1.5.2)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/FloodLights/pull/9 (1.5.1)
+>* Fix cascade chunkloading by @Pilzinsel64 in https://github.com/GTNewHorizons/FloodLights/pull/8 (1.5.0)
 
 # Updated - ForbiddenMagic - 0.7.1-GTNH --> 0.8.0-GTNH
-## *0.8.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/ForbiddenMagic/compare/0.7.1-GTNH...0.8.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/ForbiddenMagic/compare/0.7.1-GTNH...0.8.0-GTNH
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - ForestryMC - 4.9.22 --> 4.10.14
-## *4.10.14*
->## What's Changed
->* Add missing = in Localisation by @Yoshy2002 in https://github.com/GTNewHorizons/ForestryMC/pull/97
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/97
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.13...4.10.14
->
+**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.9.22...4.10.14
 
-## *4.10.13*
->## What's Changed
->* Change NEIHandler Tooltip Position by @slprime in https://github.com/GTNewHorizons/ForestryMC/pull/96
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.11...4.10.13
->
-
-## *4.10.11*
->## What's Changed
->* Protect some calls that lead to loadChunk with blockExists by @Georggi in https://github.com/GTNewHorizons/ForestryMC/pull/91
->
->## New Contributors
->* @Georggi made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/91
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.10...4.10.11
->
-
-## *4.10.10*
->## What's Changed
->* Disable flowers that cannot be planted by @DrParadox7 in https://github.com/GTNewHorizons/ForestryMC/pull/94
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.8...4.10.10
->
-
-## *4.10.8*
->## What's Changed
->* Add thunder substrate for rainmaker by @dibbydoda in https://github.com/GTNewHorizons/ForestryMC/pull/95
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.7...4.10.8
->
-
-## *4.10.7*
->## What's Changed
->* Fix multiblock components to drop inventory contents when broken by @thedarkcolour in https://github.com/GTNewHorizons/ForestryMC/pull/93
->
->## New Contributors
->* @thedarkcolour made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/93
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.6...4.10.7
->
-
-## *4.10.6*
->## What's Changed
->* Habitat locator mouse hover shows Hellish temperature in the Nether  by @dibbydoda in https://github.com/GTNewHorizons/ForestryMC/pull/92
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/92
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.5...4.10.6
->
-
-## *4.10.5*
->## What's Changed
->* Fix alveary climate logic by @Demiu in https://github.com/GTNewHorizons/ForestryMC/pull/90
->
->## New Contributors
->* @Demiu made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/90
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.3...4.10.5
->
-
-## *4.10.3*
->## What's Changed
->* Add missing localization by @Discreater in https://github.com/GTNewHorizons/ForestryMC/pull/89
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/89
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.2...4.10.3
->
-
-## *4.10.2*
->## What's Changed
->* Don't crash if someone tries to color number values stored in lang files by @YannickMG in https://github.com/GTNewHorizons/ForestryMC/pull/88
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.1...4.10.2
->
-
-## *4.10.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ForestryMC/pull/87
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.10.0...4.10.1
->
-
-## *4.10.0*
->## What's Changed
->* fix: Use GT ash instead of letting unification screw everything up. by @combusterf in https://github.com/GTNewHorizons/ForestryMC/pull/86
->
->## New Contributors
->* @combusterf made their first contribution in https://github.com/GTNewHorizons/ForestryMC/pull/86
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForestryMC/compare/4.9.19...4.10.0
->
+## What's Changed:
+>* Add missing = in Localisation by @Yoshy2002 in https://github.com/GTNewHorizons/ForestryMC/pull/97 (4.10.14)
+>* Change NEIHandler Tooltip Position by @slprime in https://github.com/GTNewHorizons/ForestryMC/pull/96 (4.10.13)
+>* Protect some calls that lead to loadChunk with blockExists by @Georggi in https://github.com/GTNewHorizons/ForestryMC/pull/91 (4.10.11)
+>* Disable flowers that cannot be planted by @DrParadox7 in https://github.com/GTNewHorizons/ForestryMC/pull/94 (4.10.10)
+>* Add thunder substrate for rainmaker by @dibbydoda in https://github.com/GTNewHorizons/ForestryMC/pull/95 (4.10.8)
+>* Fix multiblock components to drop inventory contents when broken by @thedarkcolour in https://github.com/GTNewHorizons/ForestryMC/pull/93 (4.10.7)
+>* Habitat locator mouse hover shows Hellish temperature in the Nether  by @dibbydoda in https://github.com/GTNewHorizons/ForestryMC/pull/92 (4.10.6)
+>* Fix alveary climate logic by @Demiu in https://github.com/GTNewHorizons/ForestryMC/pull/90 (4.10.5)
+>* Add missing localization by @Discreater in https://github.com/GTNewHorizons/ForestryMC/pull/89 (4.10.3)
+>* Don't crash if someone tries to color number values stored in lang files by @YannickMG in https://github.com/GTNewHorizons/ForestryMC/pull/88 (4.10.2)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ForestryMC/pull/87 (4.10.1)
+>* fix: Use GT ash instead of letting unification screw everything up. by @combusterf in https://github.com/GTNewHorizons/ForestryMC/pull/86 (4.10.0)
 
 # Updated - ForgeMultipart - 1.6.2 --> 1.6.7
-## *1.6.7*
->## What's Changed
->* Force render return type to Unit by @Caedis in https://github.com/GTNewHorizons/ForgeMultipart/pull/30
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/ForgeMultipart/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.6.6...1.6.7
->
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.6.2...1.6.7
 
-## *1.6.6*
->## What's Changed
->* Fix crash introduced by memory leak fix by @Alexdoru in https://github.com/GTNewHorizons/ForgeMultipart/pull/29
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.6.4...1.6.6
->
-
-## *1.6.4*
->## What's Changed
->* Fix WorldClient leak by @Alexdoru in https://github.com/GTNewHorizons/ForgeMultipart/pull/28
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.6.3...1.6.4
->
-
-## *1.6.3*
->## What's Changed
->* Forward material to shader by @dvdmandt in https://github.com/GTNewHorizons/ForgeMultipart/pull/27
->
->## New Contributors
->* @dvdmandt made their first contribution in https://github.com/GTNewHorizons/ForgeMultipart/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeMultipart/compare/1.6.2...1.6.3
->
+## What's Changed:
+>* Force render return type to Unit by @Caedis in https://github.com/GTNewHorizons/ForgeMultipart/pull/30 (1.6.7)
+>* Fix crash introduced by memory leak fix by @Alexdoru in https://github.com/GTNewHorizons/ForgeMultipart/pull/29 (1.6.6)
+>* Fix WorldClient leak by @Alexdoru in https://github.com/GTNewHorizons/ForgeMultipart/pull/28 (1.6.4)
+>* Forward material to shader by @dvdmandt in https://github.com/GTNewHorizons/ForgeMultipart/pull/27 (1.6.3)
 
 # Updated - ForgeRelocation - 0.2.1 --> 0.3.3
-## *0.3.3*
->## What's Changed
->* Fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/ForgeRelocation/pull/9
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.3.2...0.3.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.2.1...0.3.3
 
-## *0.3.2*
->## What's Changed
->* use one local variable for the Tesselator, so it can be transformed properly by @Alexdoru in https://github.com/GTNewHorizons/ForgeRelocation/pull/8
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/ForgeRelocation/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.3.1...0.3.2
->
-
-## *0.3.1*
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.3.0...0.3.1
->
-
-## *0.3.0*
->**Full Changelog**: https://github.com/GTNewHorizons/ForgeRelocation/compare/0.2.1...0.3.0
->
+## What's Changed:
+>* Fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/ForgeRelocation/pull/9 (0.3.3)
+>* use one local variable for the Tesselator, so it can be transformed properly by @Alexdoru in https://github.com/GTNewHorizons/ForgeRelocation/pull/8 (0.3.2)
 
 # Updated - Forgelin - 1.10.0-GTNH --> 2.0.1-GTNH
-## *2.0.1-GTNH*
->## What's Changed
->* Shade Kotlin sources by @ah-OOG-ah in https://github.com/GTNewHorizons/Forgelin/pull/12
->
->## New Contributors
->* @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Forgelin/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/Forgelin/compare/2.0.0-GTNH...2.0.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Forgelin/compare/1.10.0-GTNH...2.0.1-GTNH
 
-## *2.0.0-GTNH*
->## What's Changed
->* Updates by @Taskeren in https://github.com/GTNewHorizons/Forgelin/pull/11
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/Forgelin/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/Forgelin/compare/1.10.0-GTNH...2.0.0-GTNH
->
+## What's Changed:
+>* Shade Kotlin sources by @ah-OOG-ah in https://github.com/GTNewHorizons/Forgelin/pull/12 (2.0.1-GTNH)
+>* Updates by @Taskeren in https://github.com/GTNewHorizons/Forgelin/pull/11 (2.0.0-GTNH)
 
 # Updated - GT5-Unofficial - 5.09.50.119 --> 5.09.51.388
-## *5.09.51.388*
->## What's Changed
->* Fix overclock calculator speed overflow by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4598
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.387...5.09.51.388
->
-
-## *5.09.51.387*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4597
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.386...5.09.51.387
->
-
-## *5.09.51.386*
->## What's Changed
->* CAL imprinting recipes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4512
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.385...5.09.51.386
->
-
-## *5.09.51.385*
->## What's Changed
->* Don't schedule ~5-15k structure checks every time a forge of the gods starts or stops by @dvdmandt in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4585
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.384...5.09.51.385
->
-
-## *5.09.51.384*
->## What's Changed
->* Move server event registration to `FMLServerAboutToStartEvent` by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4577
->* unbind power google keybind by default by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4580
->* Add Cherry Plank Item (For EFR Recipes) by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4579
->* Move tool mode switch to its own keybind by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4545
->* fix crafting sound not playing anymore by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4584
->* Fix Maceration stack tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4593
->* Split hasContainerItem and getContainerItem of MetaGeneratedTool by @slprime in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4583
->* More Multiblock Abbreviations by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4587
->* Improve wording of godforge power panel by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4596
->* add config for color and line width of the GT Tool block overlay by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4578
->* Mirror texture of SpaceTime Screwdriver Head by @Worive in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4594
->* Delete gt++ PlayerUtils class by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4576
->
->## New Contributors
->* @Worive made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4594
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.382...5.09.51.384
->
-
-## *5.09.51.382*
->## What's Changed
->* AAL NEI Data Access Hatch Bugfix by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4567
->* Add nano forge t4 by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3630
->* Fixes for Nanoforge t4 pr by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4575
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.379...5.09.51.382
->
-
-## *5.09.51.379*
->## What's Changed
->* Correctly use Server and Client proxy classes by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4541
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.377...5.09.51.379
->
-
-## *5.09.51.377*
->## What's Changed
->* Add ability to disable play sound when crafting with tools by @slprime in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4570
->* Remove mention of wallsharing from Maintenance Hatch tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4566
->* Dragon Essence Altar Bee Mutation Bugfix by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4572
->* EUs -> EU by @koolkrafter5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4573
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.374...5.09.51.377
->
-
-## *5.09.51.374*
->## What's Changed
->* Expose playSound so that NEI autocrafting can toggle it by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4569
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.372...5.09.51.374
->
-
-## *5.09.51.372*
->## What's Changed
->* Add translation support for GT5U recipes by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4555
->* Add LMA Machine Type by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4562
->* Delete usages of `SideReference$EffectiveSide` by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4560
->* Removes Crib, Cribus, & Proxy Restriction on Molecular Transformer by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4563
->* Bump postea version by @Cleptomania in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4559
->* Fix NPE when unregistering server events by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4564
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.370...5.09.51.372
->
-
-## *5.09.51.370*
->## What's Changed
->* Add Missing Units to NEI for Steam Machines by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4553
->* Remove Chemical Plant Manual by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4554
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.369...5.09.51.370
->
-
-## *5.09.51.369*
->## What's Changed
->* Rework LNR tooltip to be more visually pleasing by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4537
->* Partial Revert of #4120 by @ChibiChoko in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4535
->* Ur-Ghast, Platinum, Firestone, & Sulfur Bee Changes by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4533
->* Implement 'Batch Mode' for EEC and VM's to increase performance by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4534
->* Extract commonly used methods from Commands to new parent class GTBaseCommand by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4538
->* Add a `Map<UUID,EntityPlayerMP>` in GTProxy by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4542
->* Fix typo in localization key. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4547
->* fix incorrect glass tier registered to structurelib by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4546
->* Unrefined Desh OreDict, Salt LCR Recipe, Thorns Recipe for TGS by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4540
->* Added Perfect OC and Conditional Perfect OC to Tooltip builder by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4544
->* added a toggle for the input hatch filter  by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4543
->* Use ArrayProximityChecks for maglev and mob reppellors by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4549
->* Show Steam Flowrate Instead of EU/t in NEI for Steam Machines by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4552
->
->## New Contributors
->* @ChibiChoko made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4535
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.368...5.09.51.369
->
-
-## *5.09.51.368*
->## What's Changed
->* Clarify miner tooltip that fortune only works on small ores by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4539
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.365...5.09.51.368
->
-
-## *5.09.51.365*
->## What's Changed
->* Add BHC to Machine Type by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4532
->* Added Wrench Precise Mode by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4447
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.362...5.09.51.365
->
-
-## *5.09.51.362*
->## What's Changed
->* Add Nullity Annotations to GalactiGreg API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4500
->* Add Nullity Annotations to GoodGenerator API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4501
->* Add Nullity Annotations to GTPlusPlus API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4503
->* Add Nullity Annotations to KubaTech API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4505
->* Add Null Annotations in `RecipeMapBackend` for Recipe Checks by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4498
->* "Zeron-100 Reactor Shielding" Name-Change & Assembler Recipe Addition  by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4526
->* Improve cape renderer + use UUID map by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4460
->* Reduce allocations from GTRecipe#mChances by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4519
->* Large Naq Reactor No EU Explosion, Fix CME by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4493
->* Various minor ArrayList / array / boxed collections improvements by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4521
->* Neutral Ferrocene Chain by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4492
->* Add Nullity Annotations to Bartworks API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4499
->* Fix mapiary crash on removing bees by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4528
->* Fix LSC structure preview crash by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4529
->* Refactor `gregtech.api.enums.Dyes` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4524
->* add backhand to mods enum by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4530
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.359...5.09.51.362
->
-
-## *5.09.51.359*
->## What's Changed
->* Added Netherite Bee and Prismarine Bee by @AdityaVG13 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4448
->* Bring Steam Alloy Smelter from Steam Age update by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4415
->* Rare Earth Bee Changes by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4522
->
->## New Contributors
->* @AdityaVG13 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4448
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.358...5.09.51.359
->
-
-## *5.09.51.358*
->## What's Changed
->* Fix text overlap in NEI handler for space mining by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4523
->* ui: improve Fusion Reactor tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4525
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.357...5.09.51.358
->
-
-## *5.09.51.357*
->## What's Changed
->* added Data Orb copying for ME Output Bus by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4470
->* Fixed misaligned entries in MaterialsInit1.java by @apia46 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4495
->* [Memory-opti:static allocations:16 MB] Only allocate owner/ stacktrace ArrayLists in GTRecipes when config is ON by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4513
->* Add laser & energy hatches to Large Naquadah Reactor by @JuanICasareski in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4510
->* [Memory-opti:static allocations:5 MB] Stop allocating zero length arrays in GTRecipes by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4514
->* delete unused class FlowerSet.java by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4515
->* [Memory-opti:runtime allocations] Reduce allocations by using the same zero length array singletons by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4516
->* fix output hatch partition by @lc-1337 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4518
->* Deprecate `GTUtility.signum` in Favor of `Integer.signum` and `Long.signum` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4517
->
->## New Contributors
->* @apia46 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4495
->* @JuanICasareski made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4510
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.355...5.09.51.357
->
-
-## *5.09.51.355*
->## What's Changed
->* Fix file name casing of custom tc4 aspects by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4507
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.353...5.09.51.355
->
-
-## *5.09.51.353*
->## What's Changed
->* [Temp Fix] Dont hash null stacks by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4497
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.351...5.09.51.353
->
-
-## *5.09.51.351*
->## What's Changed
->* Fix EU Detection Covers for LSCs with UHV+ caps by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4496
->* Buffer Block Event Packets by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4491
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.349...5.09.51.351
->
-
-## *5.09.51.349*
->## What's Changed
->* Add recipe for ceramic plate in compressor by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4465
->* Fix  Mass Fabricator Scrapbox Recipe by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4494
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.347...5.09.51.349
->
-
-## *5.09.51.347*
->## What's Changed
->* Remove broken TileEvent subscription by @zyf051520 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4484
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.346...5.09.51.347
->
-
-## *5.09.51.346*
->## What's Changed
->* Fix EOH Scanner Stab Field by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4486
->* Introduce `cacheMap` for Recipe Search Optimization by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4469
->* fix drone centre hatch textures by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4483
->* Improved a text of Drone Center by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4485
->* Milling Machine Recipe Changes  by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4482
->
->## New Contributors
->* @UltraProdigy made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4482
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.345...5.09.51.346
->
-
-## *5.09.51.345*
->## What's Changed
->* only checks if flower is loaded if there is a flower by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4471
->* Replace `Math.pow` with new `GTUtility.powInt` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4475
->* Replace `Math.pow` with Shift by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4474
->* Remove second separator line from LINAC tooltip by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4467
->* Small Performance Improvement in `setMufflers` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4478
->* Replace `Math.pow` with `GTUtility.powInt` where Possible by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4477
->* Implement `GTUtility.log2` and `GTUtility.log4` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4479
->* Improve WA Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4480
->* Standardise Custom1-5 Aspect creation by @OmdaCZ in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4473
->* Fix Linked Input Bus data stick interaction. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4463
->* localization gui 250419 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4212
->* Refactor MegLev Code by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4488
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.344...5.09.51.345
->
-
-## *5.09.51.344*
->## What's Changed
->* implemented DEFC POC over recipe time division. by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4468
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.343...5.09.51.344
->
-
-## *5.09.51.343*
->## What's Changed
->* Add throughput in WAILA to laser source hatch by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4461
->* Implement ISurvivalConstructable in MTEVoidMinerBase by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4462
->* Optimize monster repellent performance by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4451
->* Implement MagLev Pylon by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4289
->* Add Naquarite Insulator Line by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4281
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.339...5.09.51.343
->
-
-## *5.09.51.339*
->## What's Changed
->* Fix Large Fluid Extractor not using any power by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4456
->* Make Electric Air Filter use turbine durability by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4455
->* Remove pollution fluid mentions from Advanced Muffler by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4454
->* Add BlockCasings13 by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4453
->* AL and AAL Fixes by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4458
->* Correct IsaMill Ball Hatch name by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4449
->* Improve performance of registering EEC events by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4457
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.336...5.09.51.339
->
-
-## *5.09.51.336*
->## What's Changed
->* Added back the Energy Hatch ctor with inventory size by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4446
->* LHE Fixes by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4450
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.332...5.09.51.336
->
-
-## *5.09.51.332*
->## What's Changed
->* Add missing number formatting to some godforge ui elements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4431
->* Fix imprint recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4432
->* Make cribs cache keep order of recipes by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4430
->* Protect some calls that lead to loadChunk with blockExists by @Georggi in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4196
->* Draconium/Awakened Draconium Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4421
->* Remove all redundant method override by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4419
->* Fluid link covers adjustments by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4433
->* Fix large fluid extractor having a missing front overlay by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4435
->* Fix ME output bus/hatch not getting formed textures by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4436
->* Tweak Vajra Right Click by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4413
->* Suppress missing warnings for removed gt++ items by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4434
->* Fix Boldarnator Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4437
->* Void Miners Rebrand by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3881
->* Large Molecular Assembler sets idle EUt to the wrong variable by @Simolater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4440
->* Rename A/t to A by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4445
->* Soft Mallet Maintenance by @koolkrafter5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4443
->* Fix Tooltip of Coolant Tower by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4442
->* Change the time for Salt Water in Chem Plant by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4444
->* Add ctm compatibility to gt casings by @kuba6000 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4439
->
->## New Contributors
->* @Simolater made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4440
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4443
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.330...5.09.51.332
->
-
-## *5.09.51.330*
->## What's Changed
->* Fix bwMetaGeneratedItem0 shifting mod id by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4420
->* Fix Infuser not Charging with All Available Amps by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4409
->* [MUI2] Microwave Energy Transmitter by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4376
->* Add a steam pressure gauge to single and multiblocks by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4292
->* Removal of ItemUtils by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4402
->* Minor strings fix by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4426
->* Fix some fluids having the wrong tooltips by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4388
->* fix crash on invalid pattern replace by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4423
->* Fix electric prospector crash by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4382
->* Fix GT++ pipes not having solidifier recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4394
->* Fix XL turbines blocking fluid input after switching fitting mode by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4393
->* Fix TT multi hatch adders not setting interface terminal name by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4392
->* Fix godforge item consumption issue by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4429
->* Fix tool container item issues by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4383
->* Add more info to scanner for Tesla Tower by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4391
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.328...5.09.51.330
->
-
-## *5.09.51.328*
->## What's Changed
->* More consistent Batch Mode Activation with WireCutter by @Xeno-Ra in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4411
->* ME Hatch capacity syncing for MM by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4414
->* Add LFE-controllerFaces by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4412
->
->## New Contributors
->* @Xeno-Ra made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4411
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.326...5.09.51.328
->
-
-## *5.09.51.326*
->## What's Changed
->* Allowed Electric Implosion Compressor to have Hatches on the top. by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4408
->
->## New Contributors
->* @chrombread made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4408
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.324...5.09.51.326
->
-
-## *5.09.51.324*
->## What's Changed
->* fix voltage not using gt formatter for battery buffers by @Spicierspace153 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4404
->* Seperate ME busses and hatches by color by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4403
->* Restore WirelessCharger charging speed by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4410
->* Memory improvements in WirelessChargerManager by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4406
->
->## New Contributors
->* @Spicierspace153 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4404
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.319...5.09.51.324
->
-
-## *5.09.51.319*
->## What's Changed
->* Make Lens Indicator in T6 Water Plant optional by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4396
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.318...5.09.51.319
->
-
-## *5.09.51.318*
->## What's Changed
->* Make some controllers use unique front overlay textures by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4381
->* Remove the large processing factory by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4384
->* Remove Large Essentia Generator by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4387
->* Remove Processing Array by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4385
->* Remove Low Power Lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4386
->* Fix lava boiler dropping wrong cell item on right click by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4390
->* Fix antimatter glass failing to apply umv glass oredict by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4389
->* Fix fuel values for rocket fuel by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4397
->* Show YottaHatch online status in waila by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4395
->* Fix steam machines not connecting to pipes and not filling by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4398
->* Cleanup by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4399
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.314...5.09.51.318
->
-
-## *5.09.51.314*
->## What's Changed
->* Delete replaceDeprecatedCoils by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4377
->* Fix GT++ normal pipes not being craftable by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4379
->* [MUI2] EU Meter Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4372
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.312...5.09.51.314
->
-
-## *5.09.51.312*
->## What's Changed
->* [MUI2] Overflow Valve Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4368
->* Some migration from GTLanguageManager to StatCollector by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4155
->* Fix Needs Maintenance cover UI by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4375
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.310...5.09.51.312
->
-
-## *5.09.51.310*
->## What's Changed
->* [MUI2] Fluid Regulator Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4369
->* [MUI2] Neutron Sensor Hatch by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4374
->* Remove Bartworks EBF hack by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4215
->* Fix Crib voiding their inventory by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4236
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.309...5.09.51.310
->
-
-## *5.09.51.309*
->## What's Changed
->* Refactor Fluids and Fluid Units by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4279
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.308...5.09.51.309
->
-
-## *5.09.51.308*
->## What's Changed
->* Change to MultiBlockBase drainEnergy by @WaterOtter86 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3872
->* Make tierskipping an actual mechanic by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4318
->* add Data Orb item copying functionality for Research Station Scanner by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4267
->* PR to fix void protection for multi smelters by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4195
->
->## New Contributors
->* @WaterOtter86 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3872
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.307...5.09.51.308
->
-
-## *5.09.51.307*
->## What's Changed
->* Implementing Proper Keybind to replace the hardcodded ctrl key. by @PantACRO4life in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4363
->* Add the Decay Warehouse by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4185
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.306...5.09.51.307
->
-
-## *5.09.51.306*
->## What's Changed
->* Fix Single Use Tool Oredictionary and Incorrect IDs by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4342
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.305...5.09.51.306
->
-
-## *5.09.51.305*
->## What's Changed
->* Mte base gui cleanup by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4356
->* Fix some bugs with the Machine Controller cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4347
->* Fix enderium skip by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4373
->* Add correction for even more accurate subticking by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4346
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.302...5.09.51.305
->
-
-## *5.09.51.302*
->## What's Changed
->* Add singlestep Eglin steel and enderium by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4364
->* [MUI2] Liquid Meter Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4366
->* Sunset the Steam Engine Upgrade by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4361
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.300...5.09.51.302
->
-
-## *5.09.51.300*
->## What's Changed
->* Add MUI2 support for Cover Tabs by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4291
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.299...5.09.51.300
->
-
-## *5.09.51.299*
->## What's Changed
->* Remove Construction Foam Cable Logic by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4359
->* Add Custom Renderers for MetaGeneratedItems by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4254
->* Fix Cover Text field text color by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4365
->* Correct grammar on the bee overflow error by @YoungOnionMC in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4367
->
->## New Contributors
->* @YoungOnionMC made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4367
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.298...5.09.51.299
->
-
-## *5.09.51.298*
->## What's Changed
->* Create a few ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4295
->* Fix EoH NPE by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4335
->* Fix Yotta Hatch NPE by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4334
->* Fix `survivalBuildPiece` typo by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4305
->* Unify Thorium Tetrafluoride usages by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4340
->* Allow flocculation unit to have 3 hatches of each type by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4341
->* Remove the Large Advanced Gas Turbine by @ah-OOG-ah in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4339
->* Adapting to breaking changes of GenericListSyncHandler constructor by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4343
->* Mega Apiary Enhancements by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4332
->* Change subtick calculator from duration to a multiplier calculator by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4146
->* fix turbine overlay not changing when machine activity changes by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4344
->* Fix Barnarda C saplings AGAIN. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4349
->* Allow the Solidifier Hatch to store Programmed Circuits. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4348
->* Glass tube machine recipes by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4352
->* Minor MUI2 Cover theme update by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4353
->* Ender IO Texture Set Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4250
->* Adapt to MUI2 changes by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4358
->* Don't filter rocket engine hatches by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4357
->* Fix Multis Missing Recipe Duration for Chance Based Recipes by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4360
->* Fixed GT++ Ores missing recipes by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4362
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.291...5.09.51.298
->
-
-## *5.09.51.291*
->## What's Changed
->* Fix Industrial Apiaries Stackable Upgrades Always Using Max Values by @Ghostipedia in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4337
->* Fix T7 water quadratic parallel bonus by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4338
->* Add in recycling recipes for NewHorizonsCoreMod bars by @cargocats in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4331
->
->## New Contributors
->* @Ghostipedia made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4337
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.289...5.09.51.291
->
-
-## *5.09.51.289*
->## What's Changed
->* Fix MUI2 phantom circuit slot by @zyf051520 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4330
->* Fix ME outputs trying to push when offline by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4316
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4330
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.287...5.09.51.289
->
-
-## *5.09.51.287*
->## What's Changed
->* Removed a redundant block from ForgeOfGods by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4328
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.285...5.09.51.287
->
-
-## *5.09.51.285*
->## What's Changed
->* Remove Tiny Ashes from BBF outputs by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4178
->* Various emissive coils fixes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4248
->* Add EoH pity by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4303
->* Remove redundant circuit for Samaric Residue Dust by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4304
->* Make covers use global tick counter by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4301
->* Fix DOB bee breed condition by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4312
->* Godforge fixes again by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4311
->* Fix issue where Advanced Muffler Hatch does not consume Air Filters from ME Input Bus by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4308
->* Fix godforge graviton shard world reload issue by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4313
->* Separate Pattern Recipe Caching from Dual Inputs by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4228
->* Fix Cyclotron Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4314
->* Remove Redundant Methods in MTEMultiBlockBase by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4315
->* Replace Baubles with Baubles-Expanded by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4307
->* Remove my author tag by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4320
->* Improve Un-coloured Material Block Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4321
->* Adapt code to MUI2 updates by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4325
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.282...5.09.51.285
->
-
-## *5.09.51.282*
->## What's Changed
->* Ichorium Block/Framebox Texture Update by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4274
->* Consistent Component Texture by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4271
->* Port vajra  by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4204
->* Add sticky mode functionality to Yotta Hatch by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4272
->* MTEMultiblockBase MUI2 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4287
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.279...5.09.51.282
->
-
-## *5.09.51.279*
->## What's Changed
->* Move Source/Target Chambers to RA2 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4137
->* Fix overflow when charging RF items with Wireless Charger by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4298
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.277...5.09.51.279
->
-
-## *5.09.51.277*
->## What's Changed
->* THTR Tooltip and Default WA Mode by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4290
->* Specify DTPF discount decay in its tooltip by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4293
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.275...5.09.51.277
->
-
-## *5.09.51.275*
->## What's Changed
->* Fix crash when the Heat Exchanger causes a world save corruption after exploding with MTEHatchInputME by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4286
->* Create ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4239
->* Fix basic redstone cover nullification on version migration by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4288
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.273...5.09.51.275
->
-
-## *5.09.51.273*
->## What's Changed
->* Add to available SIO2 reaction with Mg by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4280
->* Add power monitoring goggles by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4123
->* Make High Density Fission Fuels Cheaper by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4278
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.270...5.09.51.273
->
-
-## *5.09.51.270*
->## What's Changed
->* Deleting a dot at the end of a line by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4268
->* Fix bad XL turbine muffler logic by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4270
->* Let reinforced glass be harvested by silk touch by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4251
->* Add Water pump base draw by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4245
->* Add missing chemical formulas; Fix sub/superscript display by @redspah in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4156
->* Improve Plasma Forge GetInfoData with additional catalyst usage and convergence advancements by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4264
->* Make drones not consumed again by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4260
->* Use StructureUtility's ofAnyWater in multiblock structures wherever relevant. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4255
->* Assorted Godforge fixes/enhancements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4253
->* Fix pipe indicators by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4244
->* Fix rich fortune logic to be 2x instead of min 2 drops by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4242
->* Add advanced network switch by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4070
->* Refactor Single Use Tools by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4263
->* Don't use experimental EFR features by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4273
->* Fix centrifuges overlay on world joining by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4249
->* Support up to 8 energy hatches on Alloy Blast Smelter by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4276
->* resolve access to logistic pipes UI with wrench by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4277
->* MHDCSM Block by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4283
->* Improve multiblock tooltip by @evgengoldwar in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4122
->* Super Glue Graphene recipes buff by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4284
->* Enable MetaTileEntity with custom TileEntities (via sub-classes of BasicMachines) by @szuend in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4078
->* Reduce Excessive AL/Assembler Recipe Times, Make Regular AL Used More Often by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4259
->
->## New Contributors
->* @redspah made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4156
->* @NeOzay made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4264
->* @szuend made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4078
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.266...5.09.51.270
->
-
-## *5.09.51.266*
->## What's Changed
->* Improve SSASS and SLAM tooltips so they are more understandable by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4229
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.263...5.09.51.266
->
-
-## *5.09.51.263*
->## What's Changed
->* Fixed tooltip for Primitive Water Pump (Dim: 3x3x5 -> 3x3x4) by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4246
->* Refactor hatch background texture code by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4173
->* Remove BDM from SLAM, add MagMatter to and rebalance SSASS Magnetic Stab by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4252
->* Capitalize several fluid names by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4258
->* Add color-based input separation by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4183
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.261...5.09.51.263
->
-
-## *5.09.51.261*
->## What's Changed
->* Port some initial cover UIs to MUI2 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4191
->* add structure channel desc and indicator item by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4148
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.259...5.09.51.261
->
-
-## *5.09.51.259*
->## What's Changed
->* Netherite: Let the Hell be with us by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4074
->* Fix intergalactic blocks registration order by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4238
->* Fix Fortune Rich Ores Yielding Less Than Expected by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4240
->* Buff HDP by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4243
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.256...5.09.51.259
->
-
-## *5.09.51.256*
->## What's Changed
->* Fix synchronization for wireless computation/data by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4213
->* Readding the sheen to cosmic neutronium by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4197
->* Coal tar recipes for Cactus and sugar charcoal/coke by @lucythebean in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4232
->* Fix laser mirror loop stack overflow & Add debug generator mirror support by @YueLengM in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4167
->* Fusion Recipe Threshold Changes by @Impos913 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4055
->* Minor refactor to multi item outputting by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4112
->* Fix XLT Muffler Preview & Hologram Dots by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4235
->* Fix XLT / LT Fluid Dupe + Voiding by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4237
->
->## New Contributors
->* @YueLengM made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4167
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.254...5.09.51.256
->
-
-## *5.09.51.254*
->## What's Changed
->* Intergalactic post merge cleanup by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4234
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.253...5.09.51.254
->
-
-## *5.09.51.253*
->## What's Changed
->* Don't show maintenance readout on unformed multis by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4231
->* Widen Modifiers to `protected` in ParallelHelper and OverclockCalculator by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4226
->* Plasma Texture Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4220
->* Rework Wireless Charger by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4192
->* Improve forbidden isModLoaded and getModItem scripts by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4208
->* Merge GTNH Intergalactic into GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4205
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.251...5.09.51.253
->
-
-## *5.09.51.251*
->## What's Changed
->* add Biodiesel as RC boiler fuel by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4200
->* Add output hatch check to MTEBioVat by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4221
->* GoodGenerators' Naquadah recipe map should be RecipeMap<FuelBackend> by @Apeiria01 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4222
->* Describe UCFE mechanics in the machine tooltip. by @Sopel97 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4223
->* Add mod with "gregtechNH" modid for easier GT6 differentiation by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4225
->* Use lowercase modid for gregtech_nh by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4227
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.248...5.09.51.251
->
-
-## *5.09.51.248*
->## What's Changed
->* fix ichorium plasma by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4218
->* Fix Incorrect Colour for Molten and Plasma Ichorium by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4219
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.244...5.09.51.248
->
-
-## *5.09.51.244*
->## What's Changed
->* Add missing spaces to Drone Center display text in Waila (Attempt 2) by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4216
->* Remove deprecated onToolRightClick methods by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4181
->* More Ore Texture Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4198
->* New Ichorium Texture Set by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4217
->* Remove unused biofuel material by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4214
->
->## New Contributors
->* @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4216
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.242...5.09.51.244
->
-
-## *5.09.51.242*
->## What's Changed
->* Remove GT plankWood recipes in ore recipe generator by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4179
->* Expose vanilla TE data packet system to MTEs by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4172
->* We're Going Fishing Son by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4014
->* Fix turbine efficiency in electric air filter by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4170
->* Spirally Infinity Coil Texture by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4164
->* Fix kerogen not having LCR recipe, and add cells for fulvic acid and kerogen by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4207
->* fix global_energy_join by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4189
->* make neutron accelerator hatch not an energy hatch by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4201
->* Improve Precise Assembler tooltip by @Sopel97 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4211
->* Misc decayable gt++ dust QoL improvements by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4184
->* Add text to precise assembler ui displaying the casing voltage limit by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4166
->* Fixed Electric Implosion Compressor tier checking by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4193
->* Remove hard limit on slot 0 for (adv) assline stocking busses by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4190
->* Fix distillation tower voiding with multiple output hatches per layer by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4180
->* Adjust infinite spray can keybind controls by @PantACRO4life in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4128
->* Add MUI2 support for the Radio Hatch by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4186
->* Add firestone burn effect to GT items by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4154
->* Move Large Molecular Assembler to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4115
->* Fix industrial apiary upgrades overflow by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4199
->* Remove hasSidedRedstoneOutputBehavior by @paulzzh in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4210
->
->## New Contributors
->* @Sopel97 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4211
->* @ABKQPO made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4193
->* @PantACRO4life made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4128
->* @paulzzh made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4210
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.240...5.09.51.242
->
-
-## *5.09.51.240*
->## What's Changed
->* Add the Redstone Sniffer by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4025
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.238...5.09.51.240
->
-
-## *5.09.51.238*
->## What's Changed
->* fix fusion casing CTM issue when using angelica by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4118
->* Add extruder recipe for pasta by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4187
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.234...5.09.51.238
->
-
-## *5.09.51.234*
->## What's Changed
->* Add IronTankMinecarts to mod enums by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4182
->* Add % full and Time Until Full to YOTTank by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4119
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.233...5.09.51.234
->
-
-## *5.09.51.233*
->## What's Changed
->* Advanced Assembly Line Improvements by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4158
->* Don't initialize covers as null by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4165
->* buff railcraft bending recipes down to LV/MV by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4162
->* Smoothen overclocks for fractional ticks by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4163
->* fix and add QoL to infinite tank from gt++ by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4141
->* Change superstable seed texture by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4169
->* Fix ME Hatch Output Filtering by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4168
->* Allow MTEs to dynamically modify the item dropped when broken by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4174
->* Clean up some TTMultiblockBase fields by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4159
->* Fix Buck Converter UI client desync by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4161
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.230...5.09.51.233
->
-
-## *5.09.51.230*
->## What's Changed
->* Remove abandoned item Behavior classes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4140
->* Structure wrapper system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4068
->* Support Custom Glyphs via Private Use Area Unicode + New Element Symbols by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4056
->* Complete the Cover refactor by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4072
->* Fix NPE in getWailaNBTData by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4149
->* Add methods to register GT++ catalysts and milling balls by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4144
->* Text de-hardcoding by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4145
->* Waila change for multiblock locked recipe  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4150
->* Allow DualInputInventory fallback to non-cached processing procedure by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4134
->* Chanced outputs amount consistency by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4136
->* Move all the Armors' Hazmat features to Interface implementations by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4142
->* Add cell for Raw Radox by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4152
->* Remove dead file by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4153
->* Fix some core GT achievements by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4157
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.227...5.09.51.230
->
-
-## *5.09.51.227*
->## What's Changed
->* Mitigate merge conflicts by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4138
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.220...5.09.51.227
->
-
-## *5.09.51.220*
->## What's Changed
->* Fix ActiveGTMachineMutationCondition by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4130
->* Add more info to MTE collision exception by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4129
->* Add a config option to invert scrolling direction for Ghost Circuits by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4103
->* Synchrotron is not symmetrical by @guid118 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4100
->* Better Dynamic Heating Coil Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4096
->* Comet helium ions by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4098
->* Localization of scanner's information data by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4124
->* Fix spelling of "Appliances" in GT++ by @Zorbatron in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4131
->* Fix PrAss NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4132
->* Beamline Refactor/Cleanup by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4133
->* Fix t1 water not forming with distilled or cofhcore water by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4135
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4130
->* @guid118 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4100
->* @Zorbatron made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4131
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.216...5.09.51.220
->
-
-## *5.09.51.216*
->## What's Changed
->* Fix Synchrotron NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4127
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.211...5.09.51.216
->
-
-## *5.09.51.211*
->## What's Changed
->* Fix Cleanroom NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4125
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.205...5.09.51.211
->
-
-## *5.09.51.205*
->## What's Changed
->* Remove Aluminium Oreberry fluid extraction by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4120
->* Fix EIC NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4121
->* Disable any automation of BBF by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4113
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.203...5.09.51.205
->
-
-## *5.09.51.203*
->## What's Changed
->* Enable power panel functionality for godforge modules by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4114
->* Fix merge conflicts by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4116
->* Fix BlockRenderer6343 hatch face culling by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4095
->* Fix/hazard api by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4107
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.200...5.09.51.203
->
-
-## *5.09.51.200*
->## What's Changed
->* Casing system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4067
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.199...5.09.51.200
->
-
-## *5.09.51.199*
->## What's Changed
->* Some CommonBaseMetaTileEntity refactors by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4105
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.198...5.09.51.199
->
-
-## *5.09.51.198*
->## What's Changed
->* MUI2 port part2: Widget Theme by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4066
->* fix rendering issues introduced by #3973 by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4111
->* Glass Refactor and other assorted minor structure check/tooltip fixes by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4032
->* Refactoring GT++ 2025-03-03 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4020
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.197...5.09.51.198
->
-
-## *5.09.51.197*
->## What's Changed
->* Fix pipe collisions by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4108
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.196...5.09.51.197
->
-
-## *5.09.51.196*
->## What's Changed
->* Fix Leftover wafers from beamline durability calculation by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4109
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.195...5.09.51.196
->
-
-## *5.09.51.195*
->## What's Changed
->* Fix Antimatter Sequencer Tricoder info showing wrong information. by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4101
->* Require sneaking to place cover on pipes, wires and frame boxes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4104
->* Hazard protection API by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4102
->* Fix Degasser Scanner Info Bug by @ReignOfFROZE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4106
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.192...5.09.51.195
->
-
-## *5.09.51.192*
->## What's Changed
->* Allow SLAM to be built faster with Hologram Projector by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4090
->* Localization of additional tooltips by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4093
->* Stop ME input bus from pushing/allowing pulling by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4082
->* Fix efficiency not going down after disabling the multiblock by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4086
->* Adding Proper Batch, Mask Parallel & Adjusting Focus Bus on Beamline by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4036
->* New Later Recipe for Rhugnor by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4091
->* Fix AL recipe packet NPE on world load by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4094
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.189...5.09.51.192
->
-
-## *5.09.51.189*
->## What's Changed
->* Change aqua regia to follow real life composition by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3982
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.188...5.09.51.189
->
-
-## *5.09.51.188*
->## What's Changed
->* Modern Ore Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4085
->* Dynamic heating coils by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3951
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.187...5.09.51.188
->
-
-## *5.09.51.187*
->## What's Changed
->* Change double plate max stack size to 64 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4088
->* Fix waila for steam machine parallel by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4089
->* Lower large boiler pollution config defaults by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4092
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.185...5.09.51.187
->
-
-## *5.09.51.185*
->## What's Changed
->* add half mode to power transformers by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4080
->* Remove BW Pair class by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4071
->* Fix Flask Configurator not allowing values above 32767 by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4087
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.183...5.09.51.185
->
-
-## *5.09.51.183*
->## What's Changed
->* Fix pipe dupe by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4083
->* Fix tectech EnderFluidLink cover ghost loading by @Georggi in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4084
->
->## New Contributors
->* @Georggi made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4084
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.181...5.09.51.183
->
-
-## *5.09.51.181*
->## What's Changed
->* Fix PA parallels being locked to 1 by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4077
->* Decrement single-use screwdriver on circuit change by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4081
->* fix crowbar train reversing/boosting compatibility by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4079
->
->## New Contributors
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4081
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4079
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.178...5.09.51.181
->
-
-## *5.09.51.178*
->## What's Changed
->* Add missing Hot Ingot texture for Manasteel Texture Set by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4069
->* Creon & mellion mini rework by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4064
->* backport max number of sounds playing by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4059
->* Allow searching for Random Access Memory using "RAM" by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4051
->* Allow distilled water in algae pond structure by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4073
->* zfighting free block overlay by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3973
->* Ender Io, Gaia Spirit and Mana Diamond Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4001
->* Stocking hatch & bus disabling by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4013
->* Re-add multi-step californium recipe and make it faster by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4052
->* Fix output slot of quantum chest etc. not being recognized by AE by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4042
->* Refactor OverclockCalculator by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4038
->* Add MTESolarFactory by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3703
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.176...5.09.51.178
->
-
-## *5.09.51.176*
->## What's Changed
->* Fix Synchotron and Source Chamber block rendering issue by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4054
->* Godforge graviton shard related fixes by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4048
->* Add rotation support to the Bacterial Vat by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4012
->* Fix texture orientation for some machine controllers by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4033
->* AL Refactor Fixes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4057
->* Revert spacetime texture change by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4063
->* Manasteel, Terrasteel and Elementium Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4062
->* Typo: "ignot" -> "ingot" by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4061
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.173...5.09.51.176
->
-
-## *5.09.51.173*
->## What's Changed
->* Fix ZPM Hull Recycling by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4050
->* migrate fusion recipe startup energy thresholds to use long by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4047
->* Implement survival autoplace for tectech machines by @OmdaCZ in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4053
->* Refactor pipe registration & move item pipes from coremod by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4022
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.169...5.09.51.173
->
-
-## *5.09.51.169*
->## What's Changed
->* Add recipes for tiny GTPP pipes by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4044
->* Fix non gt item covers not working when sneaking by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4045
->* Localization of item tooltips by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4040
->* Added the ability to filter outputs to ME Output Bus and Hatch by @Diamantino-Op in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3828
->
->## New Contributors
->* @Diamantino-Op made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3828
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.167...5.09.51.169
->
-
-## *5.09.51.167*
->## What's Changed
->* Cleanup by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4023
->* Merge itemstacks in some assline recipes 1/3 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4008
->* Conceptually merge cover info and cover behavior. by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3995
->* Fix cover GUI by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4026
->* Fix Cover refactor mistakes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4027
->* Merge MTEBrickedBlastFurnace and MTEPrimitiveBlastFurnace by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4028
->* Require sneaking to place cover by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4031
->* fix catalyst for crude rhodium in QFT by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4030
->* Supplement locale by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4024
->* Fix Fluid Regulator covers pipe connection by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4034
->* Fix Shutter cover crash by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4035
->* Simplify parallel calculations and tooltip for multi smelter by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4029
->* Fix black hole utility hatch gui not opening by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4041
->
->## New Contributors
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4024
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.162...5.09.51.167
->
-
-## *5.09.51.162*
->## What's Changed
->* Localization 250303 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4019
->* Re-enable wire up and down crafting for lategame wires by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3997
->* Fix level8 Purification Unit not consume ME inputs on successful catalyst insertion by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4010
->* Better handle capacityless fluid containers by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4015
->* Take DTPF catalyst discount into account on recipecheck by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4006
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.160...5.09.51.162
->
-
-## *5.09.51.160*
->## What's Changed
->* MUI2 MTE base by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3975
->* Remove Hatch Placement Restriction on Large Thermal Refinery by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4017
->* Add rotation + some fixes for Lead Lined Box by @mM4ri in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4018
->* Replace turbine casing textures by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4021
->* Fix rotation + flipping for GT textures by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4016
->
->## New Contributors
->* @mM4ri made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4018
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.157...5.09.51.160
->
-
-## *5.09.51.157*
->## What's Changed
->* Specify heat overclocks in Zyngen tooltip by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4009
->* Fix integer division in LINAC energy calculation by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4011
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.155...5.09.51.157
->
-
-## *5.09.51.155*
->## What's Changed
->* Allow toggling Antimatter hatch front face insertion with a screwdriver by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3988
->* add a config to run EEC in peaceful mode by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3990
->* fix localization of Fish Trap Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3992
->* Fix bowl dupe by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3981
->* Localization 250223 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3986
->* Generate recycling recipes for nuclear gt++ mats by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3993
->* CoAL recipe changes by @Impos913 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3936
->* Fix QFT not consuming fluids with stocking hatches by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3994
->* Localization of structure hints by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3987
->* Fix Incorrect Tooltip in Compact Fusion Mk1, Mk4 and Mk5 Autoplace Popups by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3996
->* Restore MTEHatchEnergy inventory size + description constructor by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4000
->* Distinguish wireless multiamp and wireless laser by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4002
->* Rename MTE pipes to be more descriptive & cleanup bounding box by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3983
->* Fixed aDismantleable being Ignored in GTShapelessRecipe by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4007
->* Localization of fluid chemical formula tooltips in NEI overlay by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3989
->* Refactor AL recipe system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3903
->* Fix BW forms of capsules + refractory capsules having no container item by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3980
->* Godforge Rehab by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3712
->* Random deprecations cleanup by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3984
->* Refactoring GT++ 2025-02-19 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3970
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.153...5.09.51.155
->
-
-## *5.09.51.153*
->## What's Changed
->* Refactor recipemap backend modification callbacks by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3950
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.152...5.09.51.153
->
-
-## *5.09.51.152*
->## What's Changed
->* if shift click on select item mui, then close after callback by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3977
->* Improve structure error feedback by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3884
->* Add missing localization-2 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3976
->* Localization 250222 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3979
->* Unique Plasma and Molten Textures for Cosmic Neutronium by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3946
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.150...5.09.51.152
->
-
-## *5.09.51.150*
->## What's Changed
->* Add Dynamo Hatches to Naqfuel Refinery by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3972
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.148...5.09.51.150
->
-
-## *5.09.51.148*
->## What's Changed
->* Refactoring GT++ 2025-02-17 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3967
->* Add missing localization by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3954
->* Add general missing mappings handler by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3971
->* Remove autogen obsidian recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3969
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3954
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.146...5.09.51.148
->
-
-## *5.09.51.146*
->## What's Changed
->* Add Matter Manipulator to GT Mods enum by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3968
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.142...5.09.51.146
->
-
-## *5.09.51.142*
->## What's Changed
->* Cleanups around singleblock by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3961
->* Refactoring GT++ 2025-02-13 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3948
->* Refactoring GT++ 2025-02-14 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3949
->* Reduce volcanus minimum casing to 6 by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3964
->* Remove functionality to set capacity of ME hatches to max long by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3960
->* Waila multiblock improvement  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3965
->* Adds new tool: Decorator's Trowel by @querns in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3963
->* Register blocking mode ignore items by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3962
->* Fix mistake with cactus coke and sugar charcoal by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3966
->* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3953
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.140...5.09.51.142
->
-
-## *5.09.51.140*
->## What's Changed
->* Implement Capability system by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3898
->* Remove Sonictron by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3957
->* Fix position of chest cover gui to be to the left of the machine gui by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3958
->* Prevent crash from formatting machine items by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3956
->* Use capability for SoundP2P and CraftingIconProvider by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3959
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.138...5.09.51.140
->
-
-## *5.09.51.138*
->## What's Changed
->* Fix NBT tag for "always use maximum" parallel setting by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3955
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.136...5.09.51.138
->
-
-## *5.09.51.136*
->## What's Changed
->* Introduce Power Control Panel (Part 1) by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3952
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.134...5.09.51.136
->
-
-## *5.09.51.134*
->## What's Changed
->* Refactoring GT++ 2025-02-12 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3937
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.132...5.09.51.134
->
-
-## *5.09.51.132*
->## What's Changed
->* Cosmic Neutronium TextureSet +  Molten Infinity and Infinity Plasma Texture Cleaning by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3943
->* Fix broken cosmic neutronium plasma by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3944
->* Add missing residue output to waterline catalyst recipes by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3945
->* Make circuit names more consistent by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3947
->* Ring of Loki support for Cover Copy/Paste Tool by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3941
->
->## New Contributors
->* @jude123412 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3943
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.128...5.09.51.132
->
-
-## *5.09.51.128*
->## What's Changed
->* Add item output slot to fluid heater by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3932
->* Refactor MTECable to update MTE without block swap  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3826
->* Fix excessive catalyst usage in DTPF while using convergence and batch mode by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3929
->* Rock breaker by @EnderProyects in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3883
->* Remove Bio and Breakthrough circuits from the modpack by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3389
->* Fix Ztones Having craftingTank OreDict by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3940
->* Fix Alchemical Furnace Polluting Without Burning by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3938
->* Improve state transitions for Machine Controller Cover by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3939
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.126...5.09.51.128
->
-
-## *5.09.51.126*
->## What's Changed
->* Remove GT Empty Crate by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3933
->* Fix multi smelter adding an empty output stack by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3928
->* Set extreme air intake hatch tier to ZPM by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3930
->* Fix HIP not voiding by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3934
->* Add fake recipes for quantum computer components by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3924
->* Add missing super.invalidate() by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3931
->* Fix an LCR collision by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3935
->* Normalizing gtpp recipes 2025-02-09 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3922
->* Improve sources of Cryotheum by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3918
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.124...5.09.51.126
->
-
-## *5.09.51.121*
->## What's Changed
->* Change a few tooltips by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3909
->* Add sugar and cactus coke/charcoal to pyrolyse oven per issue #18969 by @lucythebean in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3907
->* Kill parametrizer hatch by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3905
->* Add `getInfoMap` method to `IGregTechDeviceInformation` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3897
->* Fix typo by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3910
->* Skip TGS recipes with null sapling by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3912
->
->## New Contributors
->* @lucythebean made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3907
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.119...5.09.51.121
->
-
-## *5.09.51.119*
->## What's Changed
->* Was broke, Fix. by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3895
->* Fix super tank fluid locking by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3899
->* Fix tesla tower ignoring primary winding  by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3896
->* Parametrizer memory card enhancement by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3902
->* Introduce the Black Hole Utility Hatch by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3901
->* Rebalance Americium and Europium Comb by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3894
->* Fix placing covers by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3904
->* Fix BHC Parallels by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3906
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.117...5.09.51.119
->
-
-## *5.09.51.117*
->## What's Changed
->* Add `expediteRecipeCheck` to copy-paste for data sticks and data orbs by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3892
->* Remove invalid CRIBs before use by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3893
->* Add gunpowder centrifuging by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3886
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.115...5.09.51.117
->
-
-## *5.09.51.115*
->## What's Changed
->* Refactor/covers part 2 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3891
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.114...5.09.51.115
->
-
-## *5.09.51.114*
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.113...5.09.51.114
->
-
-## *5.09.51.113*
->## What's Changed
->* Update OreMixes.java by @POPlol333 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3887
->* Remove broken ICoverable implementation by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3888
->* UV Pump and Field Generator recipe correction in CoAL by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3889
->
->## New Contributors
->* @FrostyFire1 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3889
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.110...5.09.51.113
->
-
-## *5.09.51.110*
->## What's Changed
->* Some refactor around MTE structure & random cleanups by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3878
->* EFR Tree simulator by @EnderProyects in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3879
->* Change liquid temperature by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3880
->* Remove metal foils recipes to make cable by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3713
->* Add basalt to rock breaker by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3875
->* Replace old 32x/64x/png/gradiented circuitry textures with better 16x ones by @bluhbipo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3509
->* Correct Steam Grinder and Squsher multi tooltips to note structures are hollow. by @Eraldoe in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3882
->* Cover refactor, part 1 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3874
->* Include locked recipe information in WAILA tooltip  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3855
->* Fix line endings by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3885
->
->## New Contributors
->* @EnderProyects made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3879
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.108...5.09.51.110
->
-
-## *5.09.51.108*
->## What's Changed
->* Replace Rhugnor with Radox in Compact MK4 Fusion Controller by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3876
->* Add Pipe Swapping functionality by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3836
->* Change computation formula in Research Station for scanner mode by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3877
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.105...5.09.51.108
->
-
-## *5.09.51.105*
->## What's Changed
->* Cover UI crash fixes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3873
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.103...5.09.51.105
->
-
-## *5.09.51.103*
->## What's Changed
->* This was supposed to be tea, not lemon juice/milk by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3865
->* Remove Precious Metal Alloy recipe in ABS by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3866
->* UV Motor Recipe Correction by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3869
->* Add throughput info for Multi-Amp and Laser hatches to scanner and Waila by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3867
->* Multiblock Replicator Hatch Refactor by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3868
->* Correct recipe input order for UV motor CoAL recipe by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3870
->* Fix ME hatches voiding by @CookieBrigade in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3871
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.101...5.09.51.103
->
-
-## *5.09.51.101*
->## What's Changed
->* Better Assline checkresult by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3863
->* Fix confusing black hole exploit by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3864
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.99...5.09.51.101
->
-
-## *5.09.51.99*
->## What's Changed
->* Fix cribs in fluid shaper by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3862
->* Replace Aluminum Gravel Ore with Zinc Gravel Ore, and deal with the consequences by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3852
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.97...5.09.51.99
->
-
-## *5.09.51.97*
->## What's Changed
->* Fix cribusses dupe 2.8 by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3859
->* Rewrite CoAL recipe loader by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3837
->* Remove deprecated render classes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3773
->* Fix `TTUtility.toExponentForm()` throws with smaller inputs by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3861
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.95...5.09.51.97
->
-
-## *5.09.51.95*
->## What's Changed
->* Fix Large HP Steam Turbine ignoring loose flow setting by @C-Remilian in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3857
->* Capitalize "Station" in Research Station by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3858
->
->## New Contributors
->* @C-Remilian made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3857
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.93...5.09.51.95
->
-
-## *5.09.51.93*
->## What's Changed
->* Deprecate GTLanguageManager by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3853
->* Consolidate GoodGenerator MTE IDs enum by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3854
->* Fix: tectech AL recipe adder does not reinit datasticks correctly by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3856
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.91...5.09.51.93
->
-
-## *5.09.51.91*
->## What's Changed
->* Change biolab recipes to be able to use any circuit o the tier and not just the item any circuit of the tier by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3849
->* Add multi_plate subtag to materials that are used to make gc and dreamcore compressed plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3851
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.89...5.09.51.91
->
-
-## *5.09.51.89*
->## What's Changed
->* Consolidate IC2 item sourcing via existing ItemList entries in recipes by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3834
->* Add Waila Pipe info by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3839
->* BHC Energy Hatch Limit and Parallel Calculations, Green TecTech Hatch Tooltip by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3843
->* Add blank casings page 12 by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3846
->* Fix black hole circuits by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3845
->* More accurate Waila status line for steam machines with obstructed vents by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3848
->* Remove double plates from multiplate subtag by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3850
->
->## New Contributors
->* @mak8427 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3839
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.87...5.09.51.89
->
-
-## *5.09.51.87*
->## What's Changed
->* Add proper support for dense steam to steam valve and regulator by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3835
->* Lock dust > tiny/small dust recipe to the top row by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3838
->* Fix: PreciseAssembler accepts Bronze Plated Bricks as high tier machine blocks by @Apeiria01 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3840
->* Add multiplate tag for Bartworks materials by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3841
->* Add total and usage back to Bacterial Vat by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3842
->
->## New Contributors
->* @Apeiria01 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3840
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.85...5.09.51.87
->
-
-## *5.09.51.85*
->## What's Changed
->* Buff HILE speed slightly by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3831
->* Expose ME hatch additionalConnections for MM by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3829
->* Disable CRIB pattern pushing when working disabled by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3830
->* Allow limited multiamp on HILE by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3832
->* Add missed materials to multi-plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3833
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.83...5.09.51.85
->
-
-## *5.09.51.83*
->## What's Changed
->* Change QFT hatch requirements by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3813
->* Improve gt solars by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3827
->* Add subtag for generating multi-plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3821
->* Retexture RTG, Charcoal Pile Igniter, Seismic Prospector by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3788
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.81...5.09.51.83
->
-
-## *5.09.51.79*
->## What's Changed
->* Remove Old GT++ UI from some multiblocks by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3819
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.77...5.09.51.79
->
-
-## *5.09.51.77*
->## What's Changed
->* Remove multi-ingot by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3815
->* Correct tengam for magnetic upgrade in Antimatter forge by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3818
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.75...5.09.51.77
->
-
-## *5.09.51.75*
->## What's Changed
->* fix error in tooltip by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3816
->* Lsc wireless mode improvements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3814
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.73...5.09.51.75
->
-
-## *5.09.51.73*
->## What's Changed
->* Change Neutronium Recipe Cost to properly behave in compact mk4 by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3812
->* Factory pipe system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3621
->* Cleaned up Throwable try catches by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3280
->* Change block autogen to use material mass for duration by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3804
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.72...5.09.51.73
->
-
-## *5.09.51.72*
->## What's Changed
->* Add supercritical steams to steam valve and regulator by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3809
->* Add ways to modify ingredients shown on NEI by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3805
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.71...5.09.51.72
->
-
-## *5.09.51.71*
->## What's Changed
->* Retier CRIB, proxy, adv stocking hatch by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3766
->* Remove beamline mask repairing by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3798
->* Allow screwdriver in toolbox for programmed circuit by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3775
->* Fix 1 tick research completer recipes not draining vis by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3806
->* change busses to buses in Tooltips etc by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3807
->* Restore stability waila info for black hole by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3803
->* Add superstable black hole seed by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3808
->* Rotating machines break adjacent enets by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3810
->* Update recipes to gt solar panels by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3811
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.70...5.09.51.71
->
-
-## *5.09.51.70*
->## What's Changed
->* Change tier textures for Auto-Taping, Uncertanty Resolver, and Wireless Data Hatches by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3795
->* Remove Teflon by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3801
->* Allow GT++ apiary frames to be repaired by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3799
->* Allow GT++ charge pack to charge RF items by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3800
->* Order DTPF Recipes by Catalyst Tier by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3796
->* Make multiblocks able to better modify their NEI preview by @Lyfts in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3792
->
->## New Contributors
->* @Bjdufre1 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3795
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.69...5.09.51.70
->
-
-## *5.09.51.69*
->## What's Changed
->* Cribs super recipe check by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3608
->* Update super chests description by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3794
->* fix end dust bee by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3793
->* fix bw fluid names by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3797
->* Remove MuTE leftover & minor refactor around ProcessingLogic by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3802
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.67...5.09.51.69
->
-
-## *5.09.51.67*
->## What's Changed
->* Ender tank voiding fluids in gt tank input slot fix by @Shadow1590 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3790
->* Add NC hatches for PCB Factory and QFT  by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3737
->
->## New Contributors
->* @Shadow1590 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3790
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.65...5.09.51.67
->
-
-## *5.09.51.65*
->## What's Changed
->* remove ic2 valuable ore compat, ic2 miner, and ic2 scanners by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3785
->* Rebalance scanning times by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3761
->* Fix multiblock extruder playing bender sound by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3777
->* Add cells for missing coremod fluids by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3774
->* Allow plunger to drain all fluid when sneaking by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3779
->* Show "Working Disabled" instead of "Idle" when machine is soft malleted by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3780
->* Add tooltip to parameter copy paste card by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3781
->* Allow setting amperage with screwdriver on wireless lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3782
->* Renaming MEBF to MBF by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3772
->* Remove more naqfuels by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3786
->* remove weak turbine cutoff by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3739
->* Widen Modifiers to `protected` in MTEHatchInputBusME and MTEHatchOutputBusME by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3787
->* Add casing minimum to Chemical Plant tooltip by @Breviel in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3770
->* Show EEC current mob in WAILA and tricorder by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3776
->* Refactor Biovat and Radio Hatches by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3728
->* Fix traversal order of `RecipeMap`. by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3764
->
->## New Contributors
->* @Breviel made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3770
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.63...5.09.51.65
->
-
-## *5.09.51.63*
->## What's Changed
->* remove over 1000 recipes that were pure bloat by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3771
->* Allow name remover to remove muffler upgrades by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3778
->* Remove GT++ naq fuels by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3783
->* Combine duplicate Titansteel fluids in UHV charge pack recipe by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3784
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.61...5.09.51.63
->
-
-## *5.09.51.61*
->## What's Changed
->* Add perfect Isolation to CRIB Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3768
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.60...5.09.51.61
->
-
-## *5.09.51.60*
->## What's Changed
->* Remove pollution fluid mechanic from ebf by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3677
->* Added Assembler Recipe for the Distillation Tower by @SafariXiu in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3758
->* Allow pulling from the auto workbench's first byproduct slot (slot 9). by @nshepperd in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3759
->* Disable redstone control on the superchest/quantumchest itself by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3762
->* Let QFT recognize programmed circuits in input buses. by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3763
->* Fixed GT++ Logs Missing Recipes by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3752
->* More gt recipe cleanup by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3765
->* Remove metadata casts to byte by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3706
->* Migrate coremod machines to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3767
->* Revert "Changing name of MBF to MEBF" by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3760
->
->## New Contributors
->* @SafariXiu made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3758
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.58...5.09.51.60
->
-
-## *5.09.51.58*
->## What's Changed
->* add MBF abbreviation in Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3755
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.56...5.09.51.58
->
-
-## *5.09.51.56*
->## What's Changed
->* More batch mode by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3751
->* remove froth recycling Circuits by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3757
->* fix HV tank recipes by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3753
->* Changing name of MBF to MEBF by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3756
->* Migrate coremod casings to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3732
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.54...5.09.51.56
->
-
-## *5.09.51.54*
->## What's Changed
->* Make degasser not form without control hatch by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3750
->* Enhance Wireless Detectors with toggle-able sided redstone manipulation by @Sanduhr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3617
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.52...5.09.51.54
->
-
-## *5.09.51.52*
->## What's Changed
->* some Multiblock Tooltip fixes by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3748
->* Clean up some deprecation usages by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3698
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.50...5.09.51.52
->
-
-## *5.09.51.50*
->## What's Changed
->* Don't ignore Tinker's Construct blocks in ore registration. by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3709
->* fix chem formulas for a few lanth materials by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3744
->* No Free Computation by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3745
->* Update structure size tooltips for Large Electric Compressor / HIP by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3746
->* fix Tooltip of Molecular Transformer by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3747
->* Simplified Multiblock Lathe by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3724
->* Fix AL output amount by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3749
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.48...5.09.51.50
->
-
-## *5.09.51.48*
->## What's Changed
->* Cache last recipe done by Target Chamber by @Elisis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3738
->* Cap waterline T3 success to avoid cheese by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3741
->* Material chem balance fixes by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3743
->* Reduce CAL recipe time by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3742
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.46...5.09.51.48
->
-
-## *5.09.51.46*
->## What's Changed
->* fix ptfe melting temp by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3740
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.40...5.09.51.46
->
-
-## *5.09.51.40*
->## What's Changed
->* Fix plasma arc recipes by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3736
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.38...5.09.51.40
->
-
-## *5.09.51.38*
->## What's Changed
->* Symetrize mapiary bottom by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3727
->* Add Hafnium Output to QFT by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3729
->* Fix PrAss not working with stocking bus notifications by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3730
->* remove unnecessary recipes by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3731
->* fix hazmat-protection tooltip hard code to help localize by @miaowwwwww in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3734
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3735
->
->## New Contributors
->* @miaowwwwww made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3734
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.36...5.09.51.38
->
-
-## *5.09.51.36*
->## What's Changed
->* Fix goodgen controller textures missing by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3723
->* Move MTE IDs around by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3725
->* Fix crash on serializing space teams by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3726
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.33...5.09.51.36
->
-
-## *5.09.51.33*
->## What's Changed
->* Updates Structure checks to add error hinting by @kstvr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3254
->* Add separate minimum & default tick rates for covers by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3722
->* Disable wirecutter interaction on EOH when it's working by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3710
->* Matter manipulator compat by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3222
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.31...5.09.51.33
->
-
-## *5.09.51.31*
->## What's Changed
->* re enable Multi Tool by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3711
->* Boldarnator (industrial rock breaker) GPL by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3668
->* Change Strontium Processing Recipe  by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3720
->* Restore gem implosion by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3714
->* Clean up no longer needed galaxyspace isModLoaded check by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3705
->* Change Semifluid generator EBF gating by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3719
->* Remove MuTE code from master branch by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3716
->* Selenium processing tweak by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3721
->* Gt tools removal by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3717
->* GT++ multiblock glow texture support by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3704
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.29...5.09.51.31
->
-
-## *5.09.51.29*
->## What's Changed
->* Prospector scanner recipe fix by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3708
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.27...5.09.51.29
->
-
-## *5.09.51.27*
->## What's Changed
->* Wireless energy covers by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3701
->* Fixes for dyson galaxyspace to intergalactic migration by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3700
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.24...5.09.51.27
->
-
-## *5.09.51.22*
->## What's Changed
->* Fix fluid extractor and solidifier overdraw by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3691
->* Add steam fill bars to steam machines by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3690
->* Add tiered solar generators to gt by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3689
->* LES UI update by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3694
->* Add some plasma recipes to Mk4 Fusion by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3695
->* Refactor Sparge Tower by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3693
->* Widen the Voltage enum in ItemComb by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3697
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.20...5.09.51.22
->
-
-## *5.09.51.20*
->## What's Changed
->* Buff godforge conversion milestone scaling by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3688
->* Introducing the Klein bottle! An "Infinite" "Volumetric" "Flask" by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3490
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.18...5.09.51.20
->
-
-## *5.09.51.18*
->## What's Changed
->* Add Chemical Bath + Thermal Centrifuge mode to IOF by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3539
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.16...5.09.51.18
->
-
-## *5.09.51.16*
->## What's Changed
->* fix Space Project NEI GUI by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3687
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.15...5.09.51.16
->
-
-## *5.09.51.15*
->## What's Changed
->* Add onPlayerDestroyItem event when using a tool on a machine by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3686
->* Add extra null checks for waila outputs data by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3682
->* double patterns cribs by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3461
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.14...5.09.51.15
->
-
-## *5.09.51.14*
->## What's Changed
->* Remove transitional platinum concentrate recipe by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3676
->* Fix flipped bolt/screwdriver image encoding issues by @kumquat-ir in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3678
->* Fix circuit 9 Heavy Oil by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3680
->* Remove duplicate stone dust recipe by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3681
->* Fix lsc crash at full capacity by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3679
->* Fix fluid shaper glass amount range tooltip by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3683
->* Swap Draconic and Wyvern DEFC textures by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3684
->* Fix the Sound of Saplings from GT++ by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3685
->* Fix multiblock tooltips by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3674
->
->## New Contributors
->* @kumquat-ir made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3678
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3685
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.13...5.09.51.14
->
-
-## *5.09.51.13*
->## What's Changed
->* Fix autobuild of first godforge ring by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3675
->* Prevent fill by hand reservoir/air intake hatch with incorrect fluid by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3673
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.12...5.09.51.13
->
-
-## *5.09.51.12*
->## What's Changed
->* Alternate lsc info fix by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3669
->* Fix Bio Lab recipe voltages that uses transform module by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3671
->* Fix structure of mapiary by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3670
->* Fix SLAM structure and Antimatter Multi Tooltips by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3672
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.11...5.09.51.12
->
-
-## *5.09.51.11*
->## What's Changed
->* Add Oredict Tag to Beamline Masks by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3663
->* Move ingot macerating and ingot/dust fluid extracting out of recycling by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3664
->* Set an owner in force load chunk NBT for opis by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3666
->* Spotless apply for branch chunkloader-add-type-information for #3666 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3667
->* Updated Maintenance texts to become easier to identify by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3541
->* Fix multi ui text position by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3665
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.10...5.09.51.11
->
-
-## *5.09.51.10*
->## What's Changed
->* Remove priest tier skip by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3660
->* change: fix symmetry of decontaminant degasser by @combusterf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3661
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.09...5.09.51.10
->
-
-## *5.09.51.09*
->## What's Changed
->* Reallow dynamo hatches on Data Bank for power pass by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3653
->* Migrate Research Completer to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3620
->* Fix Zircaloy-4 dust recipe conflict by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3654
->* Add a small bonus applied to fuels with large burntime to GT large boilers.   by @spacebuilder2020 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3418
->* Align multiblock text to left by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3553
->* Refactoring LES code for better readability by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3569
->* Fix lag probably caused by crib by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3655
->* LES Tricorder Parallel count info by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3656
->* Change scanner to respect fake recipe item count by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3657
->* HIP Unit mini rework  by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3658
->* Reduce Naquadria plasma amount in stellar catalyst by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3659
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.08...5.09.51.09
->
-
-## *5.09.51.08*
->## What's Changed
->* Single-block boilers accept empty containers again by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3651
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.07...5.09.51.08
->
-
-## *5.09.51.07*
->## What's Changed
->* Revisiting Neutron Accelerators by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3538
->* fix bug in werkstoff recipe autogen by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3652
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.06...5.09.51.07
->
-
-## *5.09.51.06*
->## What's Changed
->* Add some more missing solidifier recipes by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3649
->* PArt 1 of Wire/cable rebalance, take 2 by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3510
->* Make Uncertain Resolver X the default version by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3408
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.05...5.09.51.06
->
-
-## *5.09.51.05*
->## What's Changed
->* fix reservoir hatch crash by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3646
->* Add Research Station to NEI Scanner List by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3647
->* Refactor Steam Input Bus to extend MTEHatchInputBus by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3642
->* Making Plasma Arc Furnace more useful by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3357
->* Adds Tin Alloy mixer recipe by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3542
->* Fix a few Glass Tooltips by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3648
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.04...5.09.51.05
->
-
-## *5.09.51.04*
->## What's Changed
->* Rotate Screwdriver 90° From File by @benjamin-kirkbride in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3640
->
->## New Contributors
->* @benjamin-kirkbride made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3640
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.03...5.09.51.04
->
-
-## *5.09.51.03*
->## What's Changed
->* Fix Wrong Nether/Fluix Quartz Seed Amount in Autoclave by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3636
->* Fix LSC wireless rebalance push wrong info. by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3638
->* Fix Rocket engine pollution by @zhehedream in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3635
->* Remove a few more commands the shouldn't be in use. by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3634
->* Allow I/O Hatches to be placed on all Steel Casings in the Industrial Lathe  by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3637
->* Fix UUA time multiplier by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3641
->* remove outdated compat code by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3307
->* Separate tool crafting sound from getContainerItem by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3639
->* Remove some GT tools by @Connor-Colenso in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3203
->* Add missing goodgenerator solidifier recipes by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3645
->* Deprecate BW low power lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3644
->* Migrate GalaxySpace materials to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3520
->* Add Signalium, Lumiium and Enderium ABS recipes by @BlueHero233 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3355
->
->## New Contributors
->* @zhehedream made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3635
->* @purebluez made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3637
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.02...5.09.51.03
->
-
-## *5.09.51.02*
->## What's Changed
->* Fix DTPF convergence item consumption by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3629
->* Fix fusion hatch textures by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3632
->* Delete the RunGC command by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3631
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.01...5.09.51.02
->
-
-## *5.09.51.01*
->## What's Changed
->* fix NPE in MTEMultiAutoclave.getWailaNBTData by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3624
->* bandaid fix for rotated turbine overlay by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3622
->* localize research station mode for waila by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3623
->* Fix modded music disk playback in the electric jukebox using the new GTNHLib api by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3628
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.51.00...5.09.51.01
->
-
-## *5.09.51.00*
->## What's Changed
->* Remove second Description Line of Network Switch by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3615
->* Add efficiency to cleanroom gui by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3616
->* Decrease TF-specific vein max height spawn by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3590
->* Downtier Transformation Module by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3527
->* Consistent recipe check order for ME crafting buses. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3555
->* Add WAILA info displaying recipe outputs to multiblocks by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3586
->* Fix NEI fuel recipes for large boilers by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3565
->* Unifying multi-mode multis tooltips, adds "shortnames" to some multis by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3560
->* Add an upgradable hand pump by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3485
->* Remove Compact Fusion force chunk loading by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3618
->* Remove DTPF force chunk loading by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3619
->* Refactored BioLab and Radio Hatch Recipes by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3515
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3615
->
->**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.50.103...5.09.51.00
->
+**Full Changelog**: https://github.com/GTNewHorizons/GT5-Unofficial/compare/5.09.50.119...5.09.51.388
+
+## What's Changed:
+>* Fix overclock calculator speed overflow by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4598 (5.09.51.388)
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4597 (5.09.51.387)
+>* CAL imprinting recipes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4512 (5.09.51.386)
+>* Don't schedule ~5-15k structure checks every time a forge of the gods starts or stops by @dvdmandt in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4585 (5.09.51.385)
+>* Move server event registration to `FMLServerAboutToStartEvent` by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4577 (5.09.51.384)
+>* unbind power google keybind by default by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4580 (5.09.51.384)
+>* Add Cherry Plank Item (For EFR Recipes) by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4579 (5.09.51.384)
+>* Move tool mode switch to its own keybind by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4545 (5.09.51.384)
+>* fix crafting sound not playing anymore by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4584 (5.09.51.384)
+>* Fix Maceration stack tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4593 (5.09.51.384)
+>* Split hasContainerItem and getContainerItem of MetaGeneratedTool by @slprime in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4583 (5.09.51.384)
+>* More Multiblock Abbreviations by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4587 (5.09.51.384)
+>* Improve wording of godforge power panel by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4596 (5.09.51.384)
+>* add config for color and line width of the GT Tool block overlay by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4578 (5.09.51.384)
+>* Mirror texture of SpaceTime Screwdriver Head by @Worive in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4594 (5.09.51.384)
+>* Delete gt++ PlayerUtils class by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4576 (5.09.51.384)
+>* AAL NEI Data Access Hatch Bugfix by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4567 (5.09.51.382)
+>* Add nano forge t4 by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3630 (5.09.51.382)
+>* Fixes for Nanoforge t4 pr by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4575 (5.09.51.382)
+>* Correctly use Server and Client proxy classes by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4541 (5.09.51.379)
+>* Add ability to disable play sound when crafting with tools by @slprime in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4570 (5.09.51.377)
+>* Remove mention of wallsharing from Maintenance Hatch tooltip. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4566 (5.09.51.377)
+>* Dragon Essence Altar Bee Mutation Bugfix by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4572 (5.09.51.377)
+>* EUs -> EU by @koolkrafter5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4573 (5.09.51.377)
+>* Expose playSound so that NEI autocrafting can toggle it by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4569 (5.09.51.374)
+>* Add translation support for GT5U recipes by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4555 (5.09.51.372)
+>* Add LMA Machine Type by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4562 (5.09.51.372)
+>* Delete usages of `SideReference$EffectiveSide` by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4560 (5.09.51.372)
+>* Removes Crib, Cribus, & Proxy Restriction on Molecular Transformer by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4563 (5.09.51.372)
+>* Bump postea version by @Cleptomania in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4559 (5.09.51.372)
+>* Fix NPE when unregistering server events by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4564 (5.09.51.372)
+>* Add Missing Units to NEI for Steam Machines by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4553 (5.09.51.370)
+>* Remove Chemical Plant Manual by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4554 (5.09.51.370)
+>* Rework LNR tooltip to be more visually pleasing by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4537 (5.09.51.369)
+>* Partial Revert of #4120 by @ChibiChoko in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4535 (5.09.51.369)
+>* Ur-Ghast, Platinum, Firestone, & Sulfur Bee Changes by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4533 (5.09.51.369)
+>* Implement 'Batch Mode' for EEC and VM's to increase performance by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4534 (5.09.51.369)
+>* Extract commonly used methods from Commands to new parent class GTBaseCommand by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4538 (5.09.51.369)
+>* Add a `Map<UUID,EntityPlayerMP>` in GTProxy by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4542 (5.09.51.369)
+>* Fix typo in localization key. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4547 (5.09.51.369)
+>* fix incorrect glass tier registered to structurelib by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4546 (5.09.51.369)
+>* Unrefined Desh OreDict, Salt LCR Recipe, Thorns Recipe for TGS by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4540 (5.09.51.369)
+>* Added Perfect OC and Conditional Perfect OC to Tooltip builder by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4544 (5.09.51.369)
+>* added a toggle for the input hatch filter  by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4543 (5.09.51.369)
+>* Use ArrayProximityChecks for maglev and mob reppellors by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4549 (5.09.51.369)
+>* Show Steam Flowrate Instead of EU/t in NEI for Steam Machines by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4552 (5.09.51.369)
+>* Clarify miner tooltip that fortune only works on small ores by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4539 (5.09.51.368)
+>* Add BHC to Machine Type by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4532 (5.09.51.365)
+>* Added Wrench Precise Mode by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4447 (5.09.51.365)
+>* Add Nullity Annotations to GalactiGreg API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4500 (5.09.51.362)
+>* Add Nullity Annotations to GoodGenerator API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4501 (5.09.51.362)
+>* Add Nullity Annotations to GTPlusPlus API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4503 (5.09.51.362)
+>* Add Nullity Annotations to KubaTech API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4505 (5.09.51.362)
+>* Add Null Annotations in `RecipeMapBackend` for Recipe Checks by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4498 (5.09.51.362)
+>* "Zeron-100 Reactor Shielding" Name-Change & Assembler Recipe Addition  by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4526 (5.09.51.362)
+>* Improve cape renderer + use UUID map by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4460 (5.09.51.362)
+>* Reduce allocations from GTRecipe#mChances by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4519 (5.09.51.362)
+>* Large Naq Reactor No EU Explosion, Fix CME by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4493 (5.09.51.362)
+>* Various minor ArrayList / array / boxed collections improvements by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4521 (5.09.51.362)
+>* Neutral Ferrocene Chain by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4492 (5.09.51.362)
+>* Add Nullity Annotations to Bartworks API by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4499 (5.09.51.362)
+>* Fix mapiary crash on removing bees by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4528 (5.09.51.362)
+>* Fix LSC structure preview crash by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4529 (5.09.51.362)
+>* Refactor `gregtech.api.enums.Dyes` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4524 (5.09.51.362)
+>* add backhand to mods enum by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4530 (5.09.51.362)
+>* Added Netherite Bee and Prismarine Bee by @AdityaVG13 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4448 (5.09.51.359)
+>* Bring Steam Alloy Smelter from Steam Age update by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4415 (5.09.51.359)
+>* Rare Earth Bee Changes by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4522 (5.09.51.359)
+>* Fix text overlap in NEI handler for space mining by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4523 (5.09.51.358)
+>* ui: improve Fusion Reactor tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4525 (5.09.51.358)
+>* added Data Orb copying for ME Output Bus by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4470 (5.09.51.357)
+>* Fixed misaligned entries in MaterialsInit1.java by @apia46 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4495 (5.09.51.357)
+>* [Memory-opti:static allocations:16 MB] Only allocate owner/ stacktrace ArrayLists in GTRecipes when config is ON by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4513 (5.09.51.357)
+>* Add laser & energy hatches to Large Naquadah Reactor by @JuanICasareski in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4510 (5.09.51.357)
+>* [Memory-opti:static allocations:5 MB] Stop allocating zero length arrays in GTRecipes by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4514 (5.09.51.357)
+>* delete unused class FlowerSet.java by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4515 (5.09.51.357)
+>* [Memory-opti:runtime allocations] Reduce allocations by using the same zero length array singletons by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4516 (5.09.51.357)
+>* fix output hatch partition by @lc-1337 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4518 (5.09.51.357)
+>* Deprecate `GTUtility.signum` in Favor of `Integer.signum` and `Long.signum` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4517 (5.09.51.357)
+>* Fix file name casing of custom tc4 aspects by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4507 (5.09.51.355)
+>* [Temp Fix] Dont hash null stacks by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4497 (5.09.51.353)
+>* Fix EU Detection Covers for LSCs with UHV+ caps by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4496 (5.09.51.351)
+>* Buffer Block Event Packets by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4491 (5.09.51.351)
+>* Add recipe for ceramic plate in compressor by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4465 (5.09.51.349)
+>* Fix  Mass Fabricator Scrapbox Recipe by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4494 (5.09.51.349)
+>* Remove broken TileEvent subscription by @zyf051520 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4484 (5.09.51.347)
+>* Fix EOH Scanner Stab Field by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4486 (5.09.51.346)
+>* Introduce `cacheMap` for Recipe Search Optimization by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4469 (5.09.51.346)
+>* fix drone centre hatch textures by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4483 (5.09.51.346)
+>* Improved a text of Drone Center by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4485 (5.09.51.346)
+>* Milling Machine Recipe Changes  by @UltraProdigy in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4482 (5.09.51.346)
+>* only checks if flower is loaded if there is a flower by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4471 (5.09.51.345)
+>* Replace `Math.pow` with new `GTUtility.powInt` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4475 (5.09.51.345)
+>* Replace `Math.pow` with Shift by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4474 (5.09.51.345)
+>* Remove second separator line from LINAC tooltip by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4467 (5.09.51.345)
+>* Small Performance Improvement in `setMufflers` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4478 (5.09.51.345)
+>* Replace `Math.pow` with `GTUtility.powInt` where Possible by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4477 (5.09.51.345)
+>* Implement `GTUtility.log2` and `GTUtility.log4` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4479 (5.09.51.345)
+>* Improve WA Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4480 (5.09.51.345)
+>* Standardise Custom1-5 Aspect creation by @OmdaCZ in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4473 (5.09.51.345)
+>* Fix Linked Input Bus data stick interaction. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4463 (5.09.51.345)
+>* localization gui 250419 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4212 (5.09.51.345)
+>* Refactor MegLev Code by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4488 (5.09.51.345)
+>* implemented DEFC POC over recipe time division. by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4468 (5.09.51.344)
+>* Add throughput in WAILA to laser source hatch by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4461 (5.09.51.343)
+>* Implement ISurvivalConstructable in MTEVoidMinerBase by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4462 (5.09.51.343)
+>* Optimize monster repellent performance by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4451 (5.09.51.343)
+>* Implement MagLev Pylon by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4289 (5.09.51.343)
+>* Add Naquarite Insulator Line by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4281 (5.09.51.343)
+>* Fix Large Fluid Extractor not using any power by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4456 (5.09.51.339)
+>* Make Electric Air Filter use turbine durability by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4455 (5.09.51.339)
+>* Remove pollution fluid mentions from Advanced Muffler by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4454 (5.09.51.339)
+>* Add BlockCasings13 by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4453 (5.09.51.339)
+>* AL and AAL Fixes by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4458 (5.09.51.339)
+>* Correct IsaMill Ball Hatch name by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4449 (5.09.51.339)
+>* Improve performance of registering EEC events by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4457 (5.09.51.339)
+>* Added back the Energy Hatch ctor with inventory size by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4446 (5.09.51.336)
+>* LHE Fixes by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4450 (5.09.51.336)
+>* Add missing number formatting to some godforge ui elements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4431 (5.09.51.332)
+>* Fix imprint recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4432 (5.09.51.332)
+>* Make cribs cache keep order of recipes by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4430 (5.09.51.332)
+>* Protect some calls that lead to loadChunk with blockExists by @Georggi in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4196 (5.09.51.332)
+>* Draconium/Awakened Draconium Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4421 (5.09.51.332)
+>* Remove all redundant method override by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4419 (5.09.51.332)
+>* Fluid link covers adjustments by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4433 (5.09.51.332)
+>* Fix large fluid extractor having a missing front overlay by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4435 (5.09.51.332)
+>* Fix ME output bus/hatch not getting formed textures by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4436 (5.09.51.332)
+>* Tweak Vajra Right Click by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4413 (5.09.51.332)
+>* Suppress missing warnings for removed gt++ items by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4434 (5.09.51.332)
+>* Fix Boldarnator Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4437 (5.09.51.332)
+>* Void Miners Rebrand by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3881 (5.09.51.332)
+>* Large Molecular Assembler sets idle EUt to the wrong variable by @Simolater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4440 (5.09.51.332)
+>* Rename A/t to A by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4445 (5.09.51.332)
+>* Soft Mallet Maintenance by @koolkrafter5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4443 (5.09.51.332)
+>* Fix Tooltip of Coolant Tower by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4442 (5.09.51.332)
+>* Change the time for Salt Water in Chem Plant by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4444 (5.09.51.332)
+>* Add ctm compatibility to gt casings by @kuba6000 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4439 (5.09.51.332)
+>* Fix bwMetaGeneratedItem0 shifting mod id by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4420 (5.09.51.330)
+>* Fix Infuser not Charging with All Available Amps by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4409 (5.09.51.330)
+>* [MUI2] Microwave Energy Transmitter by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4376 (5.09.51.330)
+>* Add a steam pressure gauge to single and multiblocks by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4292 (5.09.51.330)
+>* Removal of ItemUtils by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4402 (5.09.51.330)
+>* Minor strings fix by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4426 (5.09.51.330)
+>* Fix some fluids having the wrong tooltips by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4388 (5.09.51.330)
+>* fix crash on invalid pattern replace by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4423 (5.09.51.330)
+>* Fix electric prospector crash by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4382 (5.09.51.330)
+>* Fix GT++ pipes not having solidifier recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4394 (5.09.51.330)
+>* Fix XL turbines blocking fluid input after switching fitting mode by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4393 (5.09.51.330)
+>* Fix TT multi hatch adders not setting interface terminal name by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4392 (5.09.51.330)
+>* Fix godforge item consumption issue by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4429 (5.09.51.330)
+>* Fix tool container item issues by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4383 (5.09.51.330)
+>* Add more info to scanner for Tesla Tower by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4391 (5.09.51.330)
+>* More consistent Batch Mode Activation with WireCutter by @Xeno-Ra in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4411 (5.09.51.328)
+>* ME Hatch capacity syncing for MM by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4414 (5.09.51.328)
+>* Add LFE-controllerFaces by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4412 (5.09.51.328)
+>* Allowed Electric Implosion Compressor to have Hatches on the top. by @chrombread in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4408 (5.09.51.326)
+>* fix voltage not using gt formatter for battery buffers by @Spicierspace153 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4404 (5.09.51.324)
+>* Seperate ME busses and hatches by color by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4403 (5.09.51.324)
+>* Restore WirelessCharger charging speed by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4410 (5.09.51.324)
+>* Memory improvements in WirelessChargerManager by @Alexdoru in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4406 (5.09.51.324)
+>* Make Lens Indicator in T6 Water Plant optional by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4396 (5.09.51.319)
+>* Make some controllers use unique front overlay textures by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4381 (5.09.51.318)
+>* Remove the large processing factory by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4384 (5.09.51.318)
+>* Remove Large Essentia Generator by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4387 (5.09.51.318)
+>* Remove Processing Array by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4385 (5.09.51.318)
+>* Remove Low Power Lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4386 (5.09.51.318)
+>* Fix lava boiler dropping wrong cell item on right click by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4390 (5.09.51.318)
+>* Fix antimatter glass failing to apply umv glass oredict by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4389 (5.09.51.318)
+>* Fix fuel values for rocket fuel by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4397 (5.09.51.318)
+>* Show YottaHatch online status in waila by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4395 (5.09.51.318)
+>* Fix steam machines not connecting to pipes and not filling by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4398 (5.09.51.318)
+>* Cleanup by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4399 (5.09.51.318)
+>* Delete replaceDeprecatedCoils by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4377 (5.09.51.314)
+>* Fix GT++ normal pipes not being craftable by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4379 (5.09.51.314)
+>* [MUI2] EU Meter Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4372 (5.09.51.314)
+>* [MUI2] Overflow Valve Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4368 (5.09.51.312)
+>* Some migration from GTLanguageManager to StatCollector by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4155 (5.09.51.312)
+>* Fix Needs Maintenance cover UI by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4375 (5.09.51.312)
+>* [MUI2] Fluid Regulator Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4369 (5.09.51.310)
+>* [MUI2] Neutron Sensor Hatch by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4374 (5.09.51.310)
+>* Remove Bartworks EBF hack by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4215 (5.09.51.310)
+>* Fix Crib voiding their inventory by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4236 (5.09.51.310)
+>* Refactor Fluids and Fluid Units by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4279 (5.09.51.309)
+>* Change to MultiBlockBase drainEnergy by @WaterOtter86 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3872 (5.09.51.308)
+>* Make tierskipping an actual mechanic by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4318 (5.09.51.308)
+>* add Data Orb item copying functionality for Research Station Scanner by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4267 (5.09.51.308)
+>* PR to fix void protection for multi smelters by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4195 (5.09.51.308)
+>* Implementing Proper Keybind to replace the hardcodded ctrl key. by @PantACRO4life in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4363 (5.09.51.307)
+>* Add the Decay Warehouse by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4185 (5.09.51.307)
+>* Fix Single Use Tool Oredictionary and Incorrect IDs by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4342 (5.09.51.306)
+>* Mte base gui cleanup by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4356 (5.09.51.305)
+>* Fix some bugs with the Machine Controller cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4347 (5.09.51.305)
+>* Fix enderium skip by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4373 (5.09.51.305)
+>* Add correction for even more accurate subticking by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4346 (5.09.51.305)
+>* Add singlestep Eglin steel and enderium by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4364 (5.09.51.302)
+>* [MUI2] Liquid Meter Cover by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4366 (5.09.51.302)
+>* Sunset the Steam Engine Upgrade by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4361 (5.09.51.302)
+>* Add MUI2 support for Cover Tabs by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4291 (5.09.51.300)
+>* Remove Construction Foam Cable Logic by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4359 (5.09.51.299)
+>* Add Custom Renderers for MetaGeneratedItems by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4254 (5.09.51.299)
+>* Fix Cover Text field text color by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4365 (5.09.51.299)
+>* Correct grammar on the bee overflow error by @YoungOnionMC in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4367 (5.09.51.299)
+>* Create a few ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4295 (5.09.51.298)
+>* Fix EoH NPE by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4335 (5.09.51.298)
+>* Fix Yotta Hatch NPE by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4334 (5.09.51.298)
+>* Fix `survivalBuildPiece` typo by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4305 (5.09.51.298)
+>* Unify Thorium Tetrafluoride usages by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4340 (5.09.51.298)
+>* Allow flocculation unit to have 3 hatches of each type by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4341 (5.09.51.298)
+>* Remove the Large Advanced Gas Turbine by @ah-OOG-ah in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4339 (5.09.51.298)
+>* Adapting to breaking changes of GenericListSyncHandler constructor by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4343 (5.09.51.298)
+>* Mega Apiary Enhancements by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4332 (5.09.51.298)
+>* Change subtick calculator from duration to a multiplier calculator by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4146 (5.09.51.298)
+>* fix turbine overlay not changing when machine activity changes by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4344 (5.09.51.298)
+>* Fix Barnarda C saplings AGAIN. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4349 (5.09.51.298)
+>* Allow the Solidifier Hatch to store Programmed Circuits. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4348 (5.09.51.298)
+>* Glass tube machine recipes by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4352 (5.09.51.298)
+>* Minor MUI2 Cover theme update by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4353 (5.09.51.298)
+>* Ender IO Texture Set Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4250 (5.09.51.298)
+>* Adapt to MUI2 changes by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4358 (5.09.51.298)
+>* Don't filter rocket engine hatches by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4357 (5.09.51.298)
+>* Fix Multis Missing Recipe Duration for Chance Based Recipes by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4360 (5.09.51.298)
+>* Fixed GT++ Ores missing recipes by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4362 (5.09.51.298)
+>* Fix Industrial Apiaries Stackable Upgrades Always Using Max Values by @Ghostipedia in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4337 (5.09.51.291)
+>* Fix T7 water quadratic parallel bonus by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4338 (5.09.51.291)
+>* Add in recycling recipes for NewHorizonsCoreMod bars by @cargocats in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4331 (5.09.51.291)
+>* Fix MUI2 phantom circuit slot by @zyf051520 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4330 (5.09.51.289)
+>* Fix ME outputs trying to push when offline by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4316 (5.09.51.289)
+>* Removed a redundant block from ForgeOfGods by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4328 (5.09.51.287)
+>* Remove Tiny Ashes from BBF outputs by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4178 (5.09.51.285)
+>* Various emissive coils fixes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4248 (5.09.51.285)
+>* Add EoH pity by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4303 (5.09.51.285)
+>* Remove redundant circuit for Samaric Residue Dust by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4304 (5.09.51.285)
+>* Make covers use global tick counter by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4301 (5.09.51.285)
+>* Fix DOB bee breed condition by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4312 (5.09.51.285)
+>* Godforge fixes again by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4311 (5.09.51.285)
+>* Fix issue where Advanced Muffler Hatch does not consume Air Filters from ME Input Bus by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4308 (5.09.51.285)
+>* Fix godforge graviton shard world reload issue by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4313 (5.09.51.285)
+>* Separate Pattern Recipe Caching from Dual Inputs by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4228 (5.09.51.285)
+>* Fix Cyclotron Tooltip by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4314 (5.09.51.285)
+>* Remove Redundant Methods in MTEMultiBlockBase by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4315 (5.09.51.285)
+>* Replace Baubles with Baubles-Expanded by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4307 (5.09.51.285)
+>* Remove my author tag by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4320 (5.09.51.285)
+>* Improve Un-coloured Material Block Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4321 (5.09.51.285)
+>* Adapt code to MUI2 updates by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4325 (5.09.51.285)
+>* Ichorium Block/Framebox Texture Update by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4274 (5.09.51.282)
+>* Consistent Component Texture by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4271 (5.09.51.282)
+>* Port vajra  by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4204 (5.09.51.282)
+>* Add sticky mode functionality to Yotta Hatch by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4272 (5.09.51.282)
+>* MTEMultiblockBase MUI2 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4287 (5.09.51.282)
+>* Move Source/Target Chambers to RA2 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4137 (5.09.51.279)
+>* Fix overflow when charging RF items with Wireless Charger by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4298 (5.09.51.279)
+>* THTR Tooltip and Default WA Mode by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4290 (5.09.51.277)
+>* Specify DTPF discount decay in its tooltip by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4293 (5.09.51.277)
+>* Fix crash when the Heat Exchanger causes a world save corruption after exploding with MTEHatchInputME by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4286 (5.09.51.275)
+>* Create ru_RU.lang by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4239 (5.09.51.275)
+>* Fix basic redstone cover nullification on version migration by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4288 (5.09.51.275)
+>* Add to available SIO2 reaction with Mg by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4280 (5.09.51.273)
+>* Add power monitoring goggles by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4123 (5.09.51.273)
+>* Make High Density Fission Fuels Cheaper by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4278 (5.09.51.273)
+>* Deleting a dot at the end of a line by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4268 (5.09.51.270)
+>* Fix bad XL turbine muffler logic by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4270 (5.09.51.270)
+>* Let reinforced glass be harvested by silk touch by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4251 (5.09.51.270)
+>* Add Water pump base draw by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4245 (5.09.51.270)
+>* Add missing chemical formulas; Fix sub/superscript display by @redspah in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4156 (5.09.51.270)
+>* Improve Plasma Forge GetInfoData with additional catalyst usage and convergence advancements by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4264 (5.09.51.270)
+>* Make drones not consumed again by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4260 (5.09.51.270)
+>* Use StructureUtility's ofAnyWater in multiblock structures wherever relevant. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4255 (5.09.51.270)
+>* Assorted Godforge fixes/enhancements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4253 (5.09.51.270)
+>* Fix pipe indicators by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4244 (5.09.51.270)
+>* Fix rich fortune logic to be 2x instead of min 2 drops by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4242 (5.09.51.270)
+>* Add advanced network switch by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4070 (5.09.51.270)
+>* Refactor Single Use Tools by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4263 (5.09.51.270)
+>* Don't use experimental EFR features by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4273 (5.09.51.270)
+>* Fix centrifuges overlay on world joining by @SKProCH in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4249 (5.09.51.270)
+>* Support up to 8 energy hatches on Alloy Blast Smelter by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4276 (5.09.51.270)
+>* resolve access to logistic pipes UI with wrench by @NeOzay in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4277 (5.09.51.270)
+>* MHDCSM Block by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4283 (5.09.51.270)
+>* Improve multiblock tooltip by @evgengoldwar in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4122 (5.09.51.270)
+>* Super Glue Graphene recipes buff by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4284 (5.09.51.270)
+>* Enable MetaTileEntity with custom TileEntities (via sub-classes of BasicMachines) by @szuend in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4078 (5.09.51.270)
+>* Reduce Excessive AL/Assembler Recipe Times, Make Regular AL Used More Often by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4259 (5.09.51.270)
+>* Improve SSASS and SLAM tooltips so they are more understandable by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4229 (5.09.51.266)
+>* Fixed tooltip for Primitive Water Pump (Dim: 3x3x5 -> 3x3x4) by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4246 (5.09.51.263)
+>* Refactor hatch background texture code by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4173 (5.09.51.263)
+>* Remove BDM from SLAM, add MagMatter to and rebalance SSASS Magnetic Stab by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4252 (5.09.51.263)
+>* Capitalize several fluid names by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4258 (5.09.51.263)
+>* Add color-based input separation by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4183 (5.09.51.263)
+>* Port some initial cover UIs to MUI2 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4191 (5.09.51.261)
+>* add structure channel desc and indicator item by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4148 (5.09.51.261)
+>* Netherite: Let the Hell be with us by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4074 (5.09.51.259)
+>* Fix intergalactic blocks registration order by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4238 (5.09.51.259)
+>* Fix Fortune Rich Ores Yielding Less Than Expected by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4240 (5.09.51.259)
+>* Buff HDP by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4243 (5.09.51.259)
+>* Fix synchronization for wireless computation/data by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4213 (5.09.51.256)
+>* Readding the sheen to cosmic neutronium by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4197 (5.09.51.256)
+>* Coal tar recipes for Cactus and sugar charcoal/coke by @lucythebean in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4232 (5.09.51.256)
+>* Fix laser mirror loop stack overflow & Add debug generator mirror support by @YueLengM in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4167 (5.09.51.256)
+>* Fusion Recipe Threshold Changes by @Impos913 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4055 (5.09.51.256)
+>* Minor refactor to multi item outputting by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4112 (5.09.51.256)
+>* Fix XLT Muffler Preview & Hologram Dots by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4235 (5.09.51.256)
+>* Fix XLT / LT Fluid Dupe + Voiding by @54M44R in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4237 (5.09.51.256)
+>* Intergalactic post merge cleanup by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4234 (5.09.51.254)
+>* Don't show maintenance readout on unformed multis by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4231 (5.09.51.253)
+>* Widen Modifiers to `protected` in ParallelHelper and OverclockCalculator by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4226 (5.09.51.253)
+>* Plasma Texture Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4220 (5.09.51.253)
+>* Rework Wireless Charger by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4192 (5.09.51.253)
+>* Improve forbidden isModLoaded and getModItem scripts by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4208 (5.09.51.253)
+>* Merge GTNH Intergalactic into GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4205 (5.09.51.253)
+>* add Biodiesel as RC boiler fuel by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4200 (5.09.51.251)
+>* Add output hatch check to MTEBioVat by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4221 (5.09.51.251)
+>* GoodGenerators' Naquadah recipe map should be RecipeMap<FuelBackend> by @Apeiria01 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4222 (5.09.51.251)
+>* Describe UCFE mechanics in the machine tooltip. by @Sopel97 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4223 (5.09.51.251)
+>* Add mod with "gregtechNH" modid for easier GT6 differentiation by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4225 (5.09.51.251)
+>* Use lowercase modid for gregtech_nh by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4227 (5.09.51.251)
+>* fix ichorium plasma by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4218 (5.09.51.248)
+>* Fix Incorrect Colour for Molten and Plasma Ichorium by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4219 (5.09.51.248)
+>* Add missing spaces to Drone Center display text in Waila (Attempt 2) by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4216 (5.09.51.244)
+>* Remove deprecated onToolRightClick methods by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4181 (5.09.51.244)
+>* More Ore Texture Improvements by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4198 (5.09.51.244)
+>* New Ichorium Texture Set by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4217 (5.09.51.244)
+>* Remove unused biofuel material by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4214 (5.09.51.244)
+>* Remove GT plankWood recipes in ore recipe generator by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4179 (5.09.51.242)
+>* Expose vanilla TE data packet system to MTEs by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4172 (5.09.51.242)
+>* We're Going Fishing Son by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4014 (5.09.51.242)
+>* Fix turbine efficiency in electric air filter by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4170 (5.09.51.242)
+>* Spirally Infinity Coil Texture by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4164 (5.09.51.242)
+>* Fix kerogen not having LCR recipe, and add cells for fulvic acid and kerogen by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4207 (5.09.51.242)
+>* fix global_energy_join by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4189 (5.09.51.242)
+>* make neutron accelerator hatch not an energy hatch by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4201 (5.09.51.242)
+>* Improve Precise Assembler tooltip by @Sopel97 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4211 (5.09.51.242)
+>* Misc decayable gt++ dust QoL improvements by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4184 (5.09.51.242)
+>* Add text to precise assembler ui displaying the casing voltage limit by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4166 (5.09.51.242)
+>* Fixed Electric Implosion Compressor tier checking by @ABKQPO in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4193 (5.09.51.242)
+>* Remove hard limit on slot 0 for (adv) assline stocking busses by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4190 (5.09.51.242)
+>* Fix distillation tower voiding with multiple output hatches per layer by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4180 (5.09.51.242)
+>* Adjust infinite spray can keybind controls by @PantACRO4life in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4128 (5.09.51.242)
+>* Add MUI2 support for the Radio Hatch by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4186 (5.09.51.242)
+>* Add firestone burn effect to GT items by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4154 (5.09.51.242)
+>* Move Large Molecular Assembler to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4115 (5.09.51.242)
+>* Fix industrial apiary upgrades overflow by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4199 (5.09.51.242)
+>* Remove hasSidedRedstoneOutputBehavior by @paulzzh in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4210 (5.09.51.242)
+>* Add the Redstone Sniffer by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4025 (5.09.51.240)
+>* fix fusion casing CTM issue when using angelica by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4118 (5.09.51.238)
+>* Add extruder recipe for pasta by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4187 (5.09.51.238)
+>* Add IronTankMinecarts to mod enums by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4182 (5.09.51.234)
+>* Add % full and Time Until Full to YOTTank by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4119 (5.09.51.234)
+>* Advanced Assembly Line Improvements by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4158 (5.09.51.233)
+>* Don't initialize covers as null by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4165 (5.09.51.233)
+>* buff railcraft bending recipes down to LV/MV by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4162 (5.09.51.233)
+>* Smoothen overclocks for fractional ticks by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4163 (5.09.51.233)
+>* fix and add QoL to infinite tank from gt++ by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4141 (5.09.51.233)
+>* Change superstable seed texture by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4169 (5.09.51.233)
+>* Fix ME Hatch Output Filtering by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4168 (5.09.51.233)
+>* Allow MTEs to dynamically modify the item dropped when broken by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4174 (5.09.51.233)
+>* Clean up some TTMultiblockBase fields by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4159 (5.09.51.233)
+>* Fix Buck Converter UI client desync by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4161 (5.09.51.233)
+>* Remove abandoned item Behavior classes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4140 (5.09.51.230)
+>* Structure wrapper system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4068 (5.09.51.230)
+>* Support Custom Glyphs via Private Use Area Unicode + New Element Symbols by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4056 (5.09.51.230)
+>* Complete the Cover refactor by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4072 (5.09.51.230)
+>* Fix NPE in getWailaNBTData by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4149 (5.09.51.230)
+>* Add methods to register GT++ catalysts and milling balls by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4144 (5.09.51.230)
+>* Text de-hardcoding by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4145 (5.09.51.230)
+>* Waila change for multiblock locked recipe  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4150 (5.09.51.230)
+>* Allow DualInputInventory fallback to non-cached processing procedure by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4134 (5.09.51.230)
+>* Chanced outputs amount consistency by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4136 (5.09.51.230)
+>* Move all the Armors' Hazmat features to Interface implementations by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4142 (5.09.51.230)
+>* Add cell for Raw Radox by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4152 (5.09.51.230)
+>* Remove dead file by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4153 (5.09.51.230)
+>* Fix some core GT achievements by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4157 (5.09.51.230)
+>* Mitigate merge conflicts by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4138 (5.09.51.227)
+>* Fix ActiveGTMachineMutationCondition by @dibbydoda in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4130 (5.09.51.220)
+>* Add more info to MTE collision exception by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4129 (5.09.51.220)
+>* Add a config option to invert scrolling direction for Ghost Circuits by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4103 (5.09.51.220)
+>* Synchrotron is not symmetrical by @guid118 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4100 (5.09.51.220)
+>* Better Dynamic Heating Coil Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4096 (5.09.51.220)
+>* Comet helium ions by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4098 (5.09.51.220)
+>* Localization of scanner's information data by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4124 (5.09.51.220)
+>* Fix spelling of "Appliances" in GT++ by @Zorbatron in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4131 (5.09.51.220)
+>* Fix PrAss NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4132 (5.09.51.220)
+>* Beamline Refactor/Cleanup by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4133 (5.09.51.220)
+>* Fix t1 water not forming with distilled or cofhcore water by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4135 (5.09.51.220)
+>* Fix Synchrotron NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4127 (5.09.51.216)
+>* Fix Cleanroom NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4125 (5.09.51.211)
+>* Remove Aluminium Oreberry fluid extraction by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4120 (5.09.51.205)
+>* Fix EIC NPE by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4121 (5.09.51.205)
+>* Disable any automation of BBF by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4113 (5.09.51.205)
+>* Enable power panel functionality for godforge modules by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4114 (5.09.51.203)
+>* Fix merge conflicts by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4116 (5.09.51.203)
+>* Fix BlockRenderer6343 hatch face culling by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4095 (5.09.51.203)
+>* Fix/hazard api by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4107 (5.09.51.203)
+>* Casing system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4067 (5.09.51.200)
+>* Some CommonBaseMetaTileEntity refactors by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4105 (5.09.51.199)
+>* MUI2 port part2: Widget Theme by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4066 (5.09.51.198)
+>* fix rendering issues introduced by #3973 by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4111 (5.09.51.198)
+>* Glass Refactor and other assorted minor structure check/tooltip fixes by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4032 (5.09.51.198)
+>* Refactoring GT++ 2025-03-03 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4020 (5.09.51.198)
+>* Fix pipe collisions by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4108 (5.09.51.197)
+>* Fix Leftover wafers from beamline durability calculation by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4109 (5.09.51.196)
+>* Fix Antimatter Sequencer Tricoder info showing wrong information. by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4101 (5.09.51.195)
+>* Require sneaking to place cover on pipes, wires and frame boxes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4104 (5.09.51.195)
+>* Hazard protection API by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4102 (5.09.51.195)
+>* Fix Degasser Scanner Info Bug by @ReignOfFROZE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4106 (5.09.51.195)
+>* Allow SLAM to be built faster with Hologram Projector by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4090 (5.09.51.192)
+>* Localization of additional tooltips by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4093 (5.09.51.192)
+>* Stop ME input bus from pushing/allowing pulling by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4082 (5.09.51.192)
+>* Fix efficiency not going down after disabling the multiblock by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4086 (5.09.51.192)
+>* Adding Proper Batch, Mask Parallel & Adjusting Focus Bus on Beamline by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4036 (5.09.51.192)
+>* New Later Recipe for Rhugnor by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4091 (5.09.51.192)
+>* Fix AL recipe packet NPE on world load by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4094 (5.09.51.192)
+>* Change aqua regia to follow real life composition by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3982 (5.09.51.189)
+>* Modern Ore Textures by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4085 (5.09.51.188)
+>* Dynamic heating coils by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3951 (5.09.51.188)
+>* Change double plate max stack size to 64 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4088 (5.09.51.187)
+>* Fix waila for steam machine parallel by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4089 (5.09.51.187)
+>* Lower large boiler pollution config defaults by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4092 (5.09.51.187)
+>* add half mode to power transformers by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4080 (5.09.51.185)
+>* Remove BW Pair class by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4071 (5.09.51.185)
+>* Fix Flask Configurator not allowing values above 32767 by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4087 (5.09.51.185)
+>* Fix pipe dupe by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4083 (5.09.51.183)
+>* Fix tectech EnderFluidLink cover ghost loading by @Georggi in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4084 (5.09.51.183)
+>* Fix PA parallels being locked to 1 by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4077 (5.09.51.181)
+>* Decrement single-use screwdriver on circuit change by @jurrejelle in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4081 (5.09.51.181)
+>* fix crowbar train reversing/boosting compatibility by @2ndDerivative in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4079 (5.09.51.181)
+>* Add missing Hot Ingot texture for Manasteel Texture Set by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4069 (5.09.51.178)
+>* Creon & mellion mini rework by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4064 (5.09.51.178)
+>* backport max number of sounds playing by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4059 (5.09.51.178)
+>* Allow searching for Random Access Memory using "RAM" by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4051 (5.09.51.178)
+>* Allow distilled water in algae pond structure by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4073 (5.09.51.178)
+>* zfighting free block overlay by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3973 (5.09.51.178)
+>* Ender Io, Gaia Spirit and Mana Diamond Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4001 (5.09.51.178)
+>* Stocking hatch & bus disabling by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4013 (5.09.51.178)
+>* Re-add multi-step californium recipe and make it faster by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4052 (5.09.51.178)
+>* Fix output slot of quantum chest etc. not being recognized by AE by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4042 (5.09.51.178)
+>* Refactor OverclockCalculator by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4038 (5.09.51.178)
+>* Add MTESolarFactory by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3703 (5.09.51.178)
+>* Fix Synchotron and Source Chamber block rendering issue by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4054 (5.09.51.176)
+>* Godforge graviton shard related fixes by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4048 (5.09.51.176)
+>* Add rotation support to the Bacterial Vat by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4012 (5.09.51.176)
+>* Fix texture orientation for some machine controllers by @Kogepan229 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4033 (5.09.51.176)
+>* AL Refactor Fixes by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4057 (5.09.51.176)
+>* Revert spacetime texture change by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4063 (5.09.51.176)
+>* Manasteel, Terrasteel and Elementium Texture Sets by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4062 (5.09.51.176)
+>* Typo: "ignot" -> "ingot" by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4061 (5.09.51.176)
+>* Fix ZPM Hull Recycling by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4050 (5.09.51.173)
+>* migrate fusion recipe startup energy thresholds to use long by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4047 (5.09.51.173)
+>* Implement survival autoplace for tectech machines by @OmdaCZ in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4053 (5.09.51.173)
+>* Refactor pipe registration & move item pipes from coremod by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4022 (5.09.51.173)
+>* Add recipes for tiny GTPP pipes by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4044 (5.09.51.169)
+>* Fix non gt item covers not working when sneaking by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4045 (5.09.51.169)
+>* Localization of item tooltips by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4040 (5.09.51.169)
+>* Added the ability to filter outputs to ME Output Bus and Hatch by @Diamantino-Op in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3828 (5.09.51.169)
+>* Cleanup by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4023 (5.09.51.167)
+>* Merge itemstacks in some assline recipes 1/3 by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4008 (5.09.51.167)
+>* Conceptually merge cover info and cover behavior. by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3995 (5.09.51.167)
+>* Fix cover GUI by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4026 (5.09.51.167)
+>* Fix Cover refactor mistakes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4027 (5.09.51.167)
+>* Merge MTEBrickedBlastFurnace and MTEPrimitiveBlastFurnace by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4028 (5.09.51.167)
+>* Require sneaking to place cover by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4031 (5.09.51.167)
+>* fix catalyst for crude rhodium in QFT by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4030 (5.09.51.167)
+>* Supplement locale by @ChromaPIE in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4024 (5.09.51.167)
+>* Fix Fluid Regulator covers pipe connection by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4034 (5.09.51.167)
+>* Fix Shutter cover crash by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4035 (5.09.51.167)
+>* Simplify parallel calculations and tooltip for multi smelter by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4029 (5.09.51.167)
+>* Fix black hole utility hatch gui not opening by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4041 (5.09.51.167)
+>* Localization 250303 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4019 (5.09.51.162)
+>* Re-enable wire up and down crafting for lategame wires by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3997 (5.09.51.162)
+>* Fix level8 Purification Unit not consume ME inputs on successful catalyst insertion by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4010 (5.09.51.162)
+>* Better handle capacityless fluid containers by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4015 (5.09.51.162)
+>* Take DTPF catalyst discount into account on recipecheck by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4006 (5.09.51.162)
+>* MUI2 MTE base by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3975 (5.09.51.160)
+>* Remove Hatch Placement Restriction on Large Thermal Refinery by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4017 (5.09.51.160)
+>* Add rotation + some fixes for Lead Lined Box by @mM4ri in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4018 (5.09.51.160)
+>* Replace turbine casing textures by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4021 (5.09.51.160)
+>* Fix rotation + flipping for GT textures by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4016 (5.09.51.160)
+>* Specify heat overclocks in Zyngen tooltip by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4009 (5.09.51.157)
+>* Fix integer division in LINAC energy calculation by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4011 (5.09.51.157)
+>* Allow toggling Antimatter hatch front face insertion with a screwdriver by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3988 (5.09.51.155)
+>* add a config to run EEC in peaceful mode by @boubou19 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3990 (5.09.51.155)
+>* fix localization of Fish Trap Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3992 (5.09.51.155)
+>* Fix bowl dupe by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3981 (5.09.51.155)
+>* Localization 250223 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3986 (5.09.51.155)
+>* Generate recycling recipes for nuclear gt++ mats by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3993 (5.09.51.155)
+>* CoAL recipe changes by @Impos913 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3936 (5.09.51.155)
+>* Fix QFT not consuming fluids with stocking hatches by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3994 (5.09.51.155)
+>* Localization of structure hints by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3987 (5.09.51.155)
+>* Fix Incorrect Tooltip in Compact Fusion Mk1, Mk4 and Mk5 Autoplace Popups by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3996 (5.09.51.155)
+>* Restore MTEHatchEnergy inventory size + description constructor by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4000 (5.09.51.155)
+>* Distinguish wireless multiamp and wireless laser by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4002 (5.09.51.155)
+>* Rename MTE pipes to be more descriptive & cleanup bounding box by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3983 (5.09.51.155)
+>* Fixed aDismantleable being Ignored in GTShapelessRecipe by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4007 (5.09.51.155)
+>* Localization of fluid chemical formula tooltips in NEI overlay by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3989 (5.09.51.155)
+>* Refactor AL recipe system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3903 (5.09.51.155)
+>* Fix BW forms of capsules + refractory capsules having no container item by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3980 (5.09.51.155)
+>* Godforge Rehab by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3712 (5.09.51.155)
+>* Random deprecations cleanup by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3984 (5.09.51.155)
+>* Refactoring GT++ 2025-02-19 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3970 (5.09.51.155)
+>* Refactor recipemap backend modification callbacks by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3950 (5.09.51.153)
+>* if shift click on select item mui, then close after callback by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3977 (5.09.51.152)
+>* Improve structure error feedback by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3884 (5.09.51.152)
+>* Add missing localization-2 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3976 (5.09.51.152)
+>* Localization 250222 by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3979 (5.09.51.152)
+>* Unique Plasma and Molten Textures for Cosmic Neutronium by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3946 (5.09.51.152)
+>* Add Dynamo Hatches to Naqfuel Refinery by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3972 (5.09.51.150)
+>* Refactoring GT++ 2025-02-17 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3967 (5.09.51.148)
+>* Add missing localization by @Discreater in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3954 (5.09.51.148)
+>* Add general missing mappings handler by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3971 (5.09.51.148)
+>* Remove autogen obsidian recipes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3969 (5.09.51.148)
+>* Add Matter Manipulator to GT Mods enum by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3968 (5.09.51.146)
+>* Cleanups around singleblock by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3961 (5.09.51.142)
+>* Refactoring GT++ 2025-02-13 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3948 (5.09.51.142)
+>* Refactoring GT++ 2025-02-14 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3949 (5.09.51.142)
+>* Reduce volcanus minimum casing to 6 by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3964 (5.09.51.142)
+>* Remove functionality to set capacity of ME hatches to max long by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3960 (5.09.51.142)
+>* Waila multiblock improvement  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3965 (5.09.51.142)
+>* Adds new tool: Decorator's Trowel by @querns in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3963 (5.09.51.142)
+>* Register blocking mode ignore items by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3962 (5.09.51.142)
+>* Fix mistake with cactus coke and sugar charcoal by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3966 (5.09.51.142)
+>* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3953 (5.09.51.142)
+>* Implement Capability system by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3898 (5.09.51.140)
+>* Remove Sonictron by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3957 (5.09.51.140)
+>* Fix position of chest cover gui to be to the left of the machine gui by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3958 (5.09.51.140)
+>* Prevent crash from formatting machine items by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3956 (5.09.51.140)
+>* Use capability for SoundP2P and CraftingIconProvider by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3959 (5.09.51.140)
+>* Fix NBT tag for "always use maximum" parallel setting by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3955 (5.09.51.138)
+>* Introduce Power Control Panel (Part 1) by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3952 (5.09.51.136)
+>* Refactoring GT++ 2025-02-12 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3937 (5.09.51.134)
+>* Cosmic Neutronium TextureSet +  Molten Infinity and Infinity Plasma Texture Cleaning by @jude123412 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3943 (5.09.51.132)
+>* Fix broken cosmic neutronium plasma by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3944 (5.09.51.132)
+>* Add missing residue output to waterline catalyst recipes by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3945 (5.09.51.132)
+>* Make circuit names more consistent by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3947 (5.09.51.132)
+>* Ring of Loki support for Cover Copy/Paste Tool by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3941 (5.09.51.132)
+>* Add item output slot to fluid heater by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3932 (5.09.51.128)
+>* Refactor MTECable to update MTE without block swap  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3826 (5.09.51.128)
+>* Fix excessive catalyst usage in DTPF while using convergence and batch mode by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3929 (5.09.51.128)
+>* Rock breaker by @EnderProyects in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3883 (5.09.51.128)
+>* Remove Bio and Breakthrough circuits from the modpack by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3389 (5.09.51.128)
+>* Fix Ztones Having craftingTank OreDict by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3940 (5.09.51.128)
+>* Fix Alchemical Furnace Polluting Without Burning by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3938 (5.09.51.128)
+>* Improve state transitions for Machine Controller Cover by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3939 (5.09.51.128)
+>* Remove GT Empty Crate by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3933 (5.09.51.126)
+>* Fix multi smelter adding an empty output stack by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3928 (5.09.51.126)
+>* Set extreme air intake hatch tier to ZPM by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3930 (5.09.51.126)
+>* Fix HIP not voiding by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3934 (5.09.51.126)
+>* Add fake recipes for quantum computer components by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3924 (5.09.51.126)
+>* Add missing super.invalidate() by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3931 (5.09.51.126)
+>* Fix an LCR collision by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3935 (5.09.51.126)
+>* Normalizing gtpp recipes 2025-02-09 by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3922 (5.09.51.126)
+>* Improve sources of Cryotheum by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3918 (5.09.51.126)
+>* Change a few tooltips by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3909 (5.09.51.121)
+>* Add sugar and cactus coke/charcoal to pyrolyse oven per issue #18969 by @lucythebean in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3907 (5.09.51.121)
+>* Kill parametrizer hatch by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3905 (5.09.51.121)
+>* Add `getInfoMap` method to `IGregTechDeviceInformation` by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3897 (5.09.51.121)
+>* Fix typo by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3910 (5.09.51.121)
+>* Skip TGS recipes with null sapling by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3912 (5.09.51.121)
+>* Was broke, Fix. by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3895 (5.09.51.119)
+>* Fix super tank fluid locking by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3899 (5.09.51.119)
+>* Fix tesla tower ignoring primary winding  by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3896 (5.09.51.119)
+>* Parametrizer memory card enhancement by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3902 (5.09.51.119)
+>* Introduce the Black Hole Utility Hatch by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3901 (5.09.51.119)
+>* Rebalance Americium and Europium Comb by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3894 (5.09.51.119)
+>* Fix placing covers by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3904 (5.09.51.119)
+>* Fix BHC Parallels by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3906 (5.09.51.119)
+>* Add `expediteRecipeCheck` to copy-paste for data sticks and data orbs by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3892 (5.09.51.117)
+>* Remove invalid CRIBs before use by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3893 (5.09.51.117)
+>* Add gunpowder centrifuging by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3886 (5.09.51.117)
+>* Refactor/covers part 2 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3891 (5.09.51.115)
+>* Update OreMixes.java by @POPlol333 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3887 (5.09.51.113)
+>* Remove broken ICoverable implementation by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3888 (5.09.51.113)
+>* UV Pump and Field Generator recipe correction in CoAL by @FrostyFire1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3889 (5.09.51.113)
+>* Some refactor around MTE structure & random cleanups by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3878 (5.09.51.110)
+>* EFR Tree simulator by @EnderProyects in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3879 (5.09.51.110)
+>* Change liquid temperature by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3880 (5.09.51.110)
+>* Remove metal foils recipes to make cable by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3713 (5.09.51.110)
+>* Add basalt to rock breaker by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3875 (5.09.51.110)
+>* Replace old 32x/64x/png/gradiented circuitry textures with better 16x ones by @bluhbipo in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3509 (5.09.51.110)
+>* Correct Steam Grinder and Squsher multi tooltips to note structures are hollow. by @Eraldoe in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3882 (5.09.51.110)
+>* Cover refactor, part 1 by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3874 (5.09.51.110)
+>* Include locked recipe information in WAILA tooltip  by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3855 (5.09.51.110)
+>* Fix line endings by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3885 (5.09.51.110)
+>* Replace Rhugnor with Radox in Compact MK4 Fusion Controller by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3876 (5.09.51.108)
+>* Add Pipe Swapping functionality by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3836 (5.09.51.108)
+>* Change computation formula in Research Station for scanner mode by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3877 (5.09.51.108)
+>* Cover UI crash fixes by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3873 (5.09.51.105)
+>* This was supposed to be tea, not lemon juice/milk by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3865 (5.09.51.103)
+>* Remove Precious Metal Alloy recipe in ABS by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3866 (5.09.51.103)
+>* UV Motor Recipe Correction by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3869 (5.09.51.103)
+>* Add throughput info for Multi-Amp and Laser hatches to scanner and Waila by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3867 (5.09.51.103)
+>* Multiblock Replicator Hatch Refactor by @TheEpicGamer274 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3868 (5.09.51.103)
+>* Correct recipe input order for UV motor CoAL recipe by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3870 (5.09.51.103)
+>* Fix ME hatches voiding by @CookieBrigade in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3871 (5.09.51.103)
+>* Better Assline checkresult by @reobf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3863 (5.09.51.101)
+>* Fix confusing black hole exploit by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3864 (5.09.51.101)
+>* Fix cribs in fluid shaper by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3862 (5.09.51.99)
+>* Replace Aluminum Gravel Ore with Zinc Gravel Ore, and deal with the consequences by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3852 (5.09.51.99)
+>* Fix cribusses dupe 2.8 by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3859 (5.09.51.97)
+>* Rewrite CoAL recipe loader by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3837 (5.09.51.97)
+>* Remove deprecated render classes by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3773 (5.09.51.97)
+>* Fix `TTUtility.toExponentForm()` throws with smaller inputs by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3861 (5.09.51.97)
+>* Fix Large HP Steam Turbine ignoring loose flow setting by @C-Remilian in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3857 (5.09.51.95)
+>* Capitalize "Station" in Research Station by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3858 (5.09.51.95)
+>* Deprecate GTLanguageManager by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3853 (5.09.51.93)
+>* Consolidate GoodGenerator MTE IDs enum by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3854 (5.09.51.93)
+>* Fix: tectech AL recipe adder does not reinit datasticks correctly by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3856 (5.09.51.93)
+>* Change biolab recipes to be able to use any circuit o the tier and not just the item any circuit of the tier by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3849 (5.09.51.91)
+>* Add multi_plate subtag to materials that are used to make gc and dreamcore compressed plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3851 (5.09.51.91)
+>* Consolidate IC2 item sourcing via existing ItemList entries in recipes by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3834 (5.09.51.89)
+>* Add Waila Pipe info by @mak8427 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3839 (5.09.51.89)
+>* BHC Energy Hatch Limit and Parallel Calculations, Green TecTech Hatch Tooltip by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3843 (5.09.51.89)
+>* Add blank casings page 12 by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3846 (5.09.51.89)
+>* Fix black hole circuits by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3845 (5.09.51.89)
+>* More accurate Waila status line for steam machines with obstructed vents by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3848 (5.09.51.89)
+>* Remove double plates from multiplate subtag by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3850 (5.09.51.89)
+>* Add proper support for dense steam to steam valve and regulator by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3835 (5.09.51.87)
+>* Lock dust > tiny/small dust recipe to the top row by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3838 (5.09.51.87)
+>* Fix: PreciseAssembler accepts Bronze Plated Bricks as high tier machine blocks by @Apeiria01 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3840 (5.09.51.87)
+>* Add multiplate tag for Bartworks materials by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3841 (5.09.51.87)
+>* Add total and usage back to Bacterial Vat by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3842 (5.09.51.87)
+>* Buff HILE speed slightly by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3831 (5.09.51.85)
+>* Expose ME hatch additionalConnections for MM by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3829 (5.09.51.85)
+>* Disable CRIB pattern pushing when working disabled by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3830 (5.09.51.85)
+>* Allow limited multiamp on HILE by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3832 (5.09.51.85)
+>* Add missed materials to multi-plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3833 (5.09.51.85)
+>* Change QFT hatch requirements by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3813 (5.09.51.83)
+>* Improve gt solars by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3827 (5.09.51.83)
+>* Add subtag for generating multi-plates by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3821 (5.09.51.83)
+>* Retexture RTG, Charcoal Pile Igniter, Seismic Prospector by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3788 (5.09.51.83)
+>* Remove Old GT++ UI from some multiblocks by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3819 (5.09.51.79)
+>* Remove multi-ingot by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3815 (5.09.51.77)
+>* Correct tengam for magnetic upgrade in Antimatter forge by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3818 (5.09.51.77)
+>* fix error in tooltip by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3816 (5.09.51.75)
+>* Lsc wireless mode improvements by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3814 (5.09.51.75)
+>* Change Neutronium Recipe Cost to properly behave in compact mk4 by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3812 (5.09.51.73)
+>* Factory pipe system by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3621 (5.09.51.73)
+>* Cleaned up Throwable try catches by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3280 (5.09.51.73)
+>* Change block autogen to use material mass for duration by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3804 (5.09.51.73)
+>* Add supercritical steams to steam valve and regulator by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3809 (5.09.51.72)
+>* Add ways to modify ingredients shown on NEI by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3805 (5.09.51.72)
+>* Retier CRIB, proxy, adv stocking hatch by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3766 (5.09.51.71)
+>* Remove beamline mask repairing by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3798 (5.09.51.71)
+>* Allow screwdriver in toolbox for programmed circuit by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3775 (5.09.51.71)
+>* Fix 1 tick research completer recipes not draining vis by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3806 (5.09.51.71)
+>* change busses to buses in Tooltips etc by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3807 (5.09.51.71)
+>* Restore stability waila info for black hole by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3803 (5.09.51.71)
+>* Add superstable black hole seed by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3808 (5.09.51.71)
+>* Rotating machines break adjacent enets by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3810 (5.09.51.71)
+>* Update recipes to gt solar panels by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3811 (5.09.51.71)
+>* Change tier textures for Auto-Taping, Uncertanty Resolver, and Wireless Data Hatches by @Bjdufre1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3795 (5.09.51.70)
+>* Remove Teflon by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3801 (5.09.51.70)
+>* Allow GT++ apiary frames to be repaired by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3799 (5.09.51.70)
+>* Allow GT++ charge pack to charge RF items by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3800 (5.09.51.70)
+>* Order DTPF Recipes by Catalyst Tier by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3796 (5.09.51.70)
+>* Make multiblocks able to better modify their NEI preview by @Lyfts in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3792 (5.09.51.70)
+>* Cribs super recipe check by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3608 (5.09.51.69)
+>* Update super chests description by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3794 (5.09.51.69)
+>* fix end dust bee by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3793 (5.09.51.69)
+>* fix bw fluid names by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3797 (5.09.51.69)
+>* Remove MuTE leftover & minor refactor around ProcessingLogic by @miozune in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3802 (5.09.51.69)
+>* Ender tank voiding fluids in gt tank input slot fix by @Shadow1590 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3790 (5.09.51.67)
+>* Add NC hatches for PCB Factory and QFT  by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3737 (5.09.51.67)
+>* remove ic2 valuable ore compat, ic2 miner, and ic2 scanners by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3785 (5.09.51.65)
+>* Rebalance scanning times by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3761 (5.09.51.65)
+>* Fix multiblock extruder playing bender sound by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3777 (5.09.51.65)
+>* Add cells for missing coremod fluids by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3774 (5.09.51.65)
+>* Allow plunger to drain all fluid when sneaking by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3779 (5.09.51.65)
+>* Show "Working Disabled" instead of "Idle" when machine is soft malleted by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3780 (5.09.51.65)
+>* Add tooltip to parameter copy paste card by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3781 (5.09.51.65)
+>* Allow setting amperage with screwdriver on wireless lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3782 (5.09.51.65)
+>* Renaming MEBF to MBF by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3772 (5.09.51.65)
+>* Remove more naqfuels by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3786 (5.09.51.65)
+>* remove weak turbine cutoff by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3739 (5.09.51.65)
+>* Widen Modifiers to `protected` in MTEHatchInputBusME and MTEHatchOutputBusME by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3787 (5.09.51.65)
+>* Add casing minimum to Chemical Plant tooltip by @Breviel in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3770 (5.09.51.65)
+>* Show EEC current mob in WAILA and tricorder by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3776 (5.09.51.65)
+>* Refactor Biovat and Radio Hatches by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3728 (5.09.51.65)
+>* Fix traversal order of `RecipeMap`. by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3764 (5.09.51.65)
+>* remove over 1000 recipes that were pure bloat by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3771 (5.09.51.63)
+>* Allow name remover to remove muffler upgrades by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3778 (5.09.51.63)
+>* Remove GT++ naq fuels by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3783 (5.09.51.63)
+>* Combine duplicate Titansteel fluids in UHV charge pack recipe by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3784 (5.09.51.63)
+>* Add perfect Isolation to CRIB Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3768 (5.09.51.61)
+>* Remove pollution fluid mechanic from ebf by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3677 (5.09.51.60)
+>* Added Assembler Recipe for the Distillation Tower by @SafariXiu in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3758 (5.09.51.60)
+>* Allow pulling from the auto workbench's first byproduct slot (slot 9). by @nshepperd in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3759 (5.09.51.60)
+>* Disable redstone control on the superchest/quantumchest itself by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3762 (5.09.51.60)
+>* Let QFT recognize programmed circuits in input buses. by @Vlamonster in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3763 (5.09.51.60)
+>* Fixed GT++ Logs Missing Recipes by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3752 (5.09.51.60)
+>* More gt recipe cleanup by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3765 (5.09.51.60)
+>* Remove metadata casts to byte by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3706 (5.09.51.60)
+>* Migrate coremod machines to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3767 (5.09.51.60)
+>* Revert "Changing name of MBF to MEBF" by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3760 (5.09.51.60)
+>* add MBF abbreviation in Tooltip by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3755 (5.09.51.58)
+>* More batch mode by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3751 (5.09.51.56)
+>* remove froth recycling Circuits by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3757 (5.09.51.56)
+>* fix HV tank recipes by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3753 (5.09.51.56)
+>* Changing name of MBF to MEBF by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3756 (5.09.51.56)
+>* Migrate coremod casings to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3732 (5.09.51.56)
+>* Make degasser not form without control hatch by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3750 (5.09.51.54)
+>* Enhance Wireless Detectors with toggle-able sided redstone manipulation by @Sanduhr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3617 (5.09.51.54)
+>* some Multiblock Tooltip fixes by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3748 (5.09.51.52)
+>* Clean up some deprecation usages by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3698 (5.09.51.52)
+>* Don't ignore Tinker's Construct blocks in ore registration. by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3709 (5.09.51.50)
+>* fix chem formulas for a few lanth materials by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3744 (5.09.51.50)
+>* No Free Computation by @DylanTaylor1 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3745 (5.09.51.50)
+>* Update structure size tooltips for Large Electric Compressor / HIP by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3746 (5.09.51.50)
+>* fix Tooltip of Molecular Transformer by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3747 (5.09.51.50)
+>* Simplified Multiblock Lathe by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3724 (5.09.51.50)
+>* Fix AL output amount by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3749 (5.09.51.50)
+>* Cache last recipe done by Target Chamber by @Elisis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3738 (5.09.51.48)
+>* Cap waterline T3 success to avoid cheese by @NotAPenguin0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3741 (5.09.51.48)
+>* Material chem balance fixes by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3743 (5.09.51.48)
+>* Reduce CAL recipe time by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3742 (5.09.51.48)
+>* fix ptfe melting temp by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3740 (5.09.51.46)
+>* Fix plasma arc recipes by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3736 (5.09.51.40)
+>* Symetrize mapiary bottom by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3727 (5.09.51.38)
+>* Add Hafnium Output to QFT by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3729 (5.09.51.38)
+>* Fix PrAss not working with stocking bus notifications by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3730 (5.09.51.38)
+>* remove unnecessary recipes by @Pxx500 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3731 (5.09.51.38)
+>* fix hazmat-protection tooltip hard code to help localize by @miaowwwwww in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3734 (5.09.51.38)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3735 (5.09.51.38)
+>* Fix goodgen controller textures missing by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3723 (5.09.51.36)
+>* Move MTE IDs around by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3725 (5.09.51.36)
+>* Fix crash on serializing space teams by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3726 (5.09.51.36)
+>* Updates Structure checks to add error hinting by @kstvr32 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3254 (5.09.51.33)
+>* Add separate minimum & default tick rates for covers by @S4mpsa in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3722 (5.09.51.33)
+>* Disable wirecutter interaction on EOH when it's working by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3710 (5.09.51.33)
+>* Matter manipulator compat by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3222 (5.09.51.33)
+>* re enable Multi Tool by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3711 (5.09.51.31)
+>* Boldarnator (industrial rock breaker) GPL by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3668 (5.09.51.31)
+>* Change Strontium Processing Recipe  by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3720 (5.09.51.31)
+>* Restore gem implosion by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3714 (5.09.51.31)
+>* Clean up no longer needed galaxyspace isModLoaded check by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3705 (5.09.51.31)
+>* Change Semifluid generator EBF gating by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3719 (5.09.51.31)
+>* Remove MuTE code from master branch by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3716 (5.09.51.31)
+>* Selenium processing tweak by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3721 (5.09.51.31)
+>* Gt tools removal by @Dream-Master in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3717 (5.09.51.31)
+>* GT++ multiblock glow texture support by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3704 (5.09.51.31)
+>* Prospector scanner recipe fix by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3708 (5.09.51.29)
+>* Wireless energy covers by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3701 (5.09.51.27)
+>* Fixes for dyson galaxyspace to intergalactic migration by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3700 (5.09.51.27)
+>* Fix fluid extractor and solidifier overdraw by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3691 (5.09.51.22)
+>* Add steam fill bars to steam machines by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3690 (5.09.51.22)
+>* Add tiered solar generators to gt by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3689 (5.09.51.22)
+>* LES UI update by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3694 (5.09.51.22)
+>* Add some plasma recipes to Mk4 Fusion by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3695 (5.09.51.22)
+>* Refactor Sparge Tower by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3693 (5.09.51.22)
+>* Widen the Voltage enum in ItemComb by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3697 (5.09.51.22)
+>* Buff godforge conversion milestone scaling by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3688 (5.09.51.20)
+>* Introducing the Klein bottle! An "Infinite" "Volumetric" "Flask" by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3490 (5.09.51.20)
+>* Add Chemical Bath + Thermal Centrifuge mode to IOF by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3539 (5.09.51.18)
+>* fix Space Project NEI GUI by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3687 (5.09.51.16)
+>* Add onPlayerDestroyItem event when using a tool on a machine by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3686 (5.09.51.15)
+>* Add extra null checks for waila outputs data by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3682 (5.09.51.15)
+>* double patterns cribs by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3461 (5.09.51.15)
+>* Remove transitional platinum concentrate recipe by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3676 (5.09.51.14)
+>* Fix flipped bolt/screwdriver image encoding issues by @kumquat-ir in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3678 (5.09.51.14)
+>* Fix circuit 9 Heavy Oil by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3680 (5.09.51.14)
+>* Remove duplicate stone dust recipe by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3681 (5.09.51.14)
+>* Fix lsc crash at full capacity by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3679 (5.09.51.14)
+>* Fix fluid shaper glass amount range tooltip by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3683 (5.09.51.14)
+>* Swap Draconic and Wyvern DEFC textures by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3684 (5.09.51.14)
+>* Fix the Sound of Saplings from GT++ by @Taskeren in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3685 (5.09.51.14)
+>* Fix multiblock tooltips by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3674 (5.09.51.14)
+>* Fix autobuild of first godforge ring by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3675 (5.09.51.13)
+>* Prevent fill by hand reservoir/air intake hatch with incorrect fluid by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3673 (5.09.51.13)
+>* Alternate lsc info fix by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3669 (5.09.51.12)
+>* Fix Bio Lab recipe voltages that uses transform module by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3671 (5.09.51.12)
+>* Fix structure of mapiary by @C0bra5 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3670 (5.09.51.12)
+>* Fix SLAM structure and Antimatter Multi Tooltips by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3672 (5.09.51.12)
+>* Add Oredict Tag to Beamline Masks by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3663 (5.09.51.11)
+>* Move ingot macerating and ingot/dust fluid extracting out of recycling by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3664 (5.09.51.11)
+>* Set an owner in force load chunk NBT for opis by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3666 (5.09.51.11)
+>* Spotless apply for branch chunkloader-add-type-information for #3666 by @github-actions in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3667 (5.09.51.11)
+>* Updated Maintenance texts to become easier to identify by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3541 (5.09.51.11)
+>* Fix multi ui text position by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3665 (5.09.51.11)
+>* Remove priest tier skip by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3660 (5.09.51.10)
+>* change: fix symmetry of decontaminant degasser by @combusterf in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3661 (5.09.51.10)
+>* Reallow dynamo hatches on Data Bank for power pass by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3653 (5.09.51.09)
+>* Migrate Research Completer to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3620 (5.09.51.09)
+>* Fix Zircaloy-4 dust recipe conflict by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3654 (5.09.51.09)
+>* Add a small bonus applied to fuels with large burntime to GT large boilers.   by @spacebuilder2020 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3418 (5.09.51.09)
+>* Align multiblock text to left by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3553 (5.09.51.09)
+>* Refactoring LES code for better readability by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3569 (5.09.51.09)
+>* Fix lag probably caused by crib by @HoleFish in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3655 (5.09.51.09)
+>* LES Tricorder Parallel count info by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3656 (5.09.51.09)
+>* Change scanner to respect fake recipe item count by @RecursivePineapple in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3657 (5.09.51.09)
+>* HIP Unit mini rework  by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3658 (5.09.51.09)
+>* Reduce Naquadria plasma amount in stellar catalyst by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3659 (5.09.51.09)
+>* Single-block boilers accept empty containers again by @YannickMG in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3651 (5.09.51.08)
+>* Revisiting Neutron Accelerators by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3538 (5.09.51.07)
+>* fix bug in werkstoff recipe autogen by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3652 (5.09.51.07)
+>* Add some more missing solidifier recipes by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3649 (5.09.51.06)
+>* PArt 1 of Wire/cable rebalance, take 2 by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3510 (5.09.51.06)
+>* Make Uncertain Resolver X the default version by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3408 (5.09.51.06)
+>* fix reservoir hatch crash by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3646 (5.09.51.05)
+>* Add Research Station to NEI Scanner List by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3647 (5.09.51.05)
+>* Refactor Steam Input Bus to extend MTEHatchInputBus by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3642 (5.09.51.05)
+>* Making Plasma Arc Furnace more useful by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3357 (5.09.51.05)
+>* Adds Tin Alloy mixer recipe by @LazyFleshWasTaken in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3542 (5.09.51.05)
+>* Fix a few Glass Tooltips by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3648 (5.09.51.05)
+>* Rotate Screwdriver 90� From File by @benjamin-kirkbride in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3640 (5.09.51.04)
+>* Fix Wrong Nether/Fluix Quartz Seed Amount in Autoclave by @Ruling-0 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3636 (5.09.51.03)
+>* Fix LSC wireless rebalance push wrong info. by @lordIcocain in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3638 (5.09.51.03)
+>* Fix Rocket engine pollution by @zhehedream in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3635 (5.09.51.03)
+>* Remove a few more commands the shouldn't be in use. by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3634 (5.09.51.03)
+>* Allow I/O Hatches to be placed on all Steel Casings in the Industrial Lathe  by @purebluez in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3637 (5.09.51.03)
+>* Fix UUA time multiplier by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3641 (5.09.51.03)
+>* remove outdated compat code by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3307 (5.09.51.03)
+>* Separate tool crafting sound from getContainerItem by @Caedis in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3639 (5.09.51.03)
+>* Remove some GT tools by @Connor-Colenso in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3203 (5.09.51.03)
+>* Add missing goodgenerator solidifier recipes by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3645 (5.09.51.03)
+>* Deprecate BW low power lasers by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3644 (5.09.51.03)
+>* Migrate GalaxySpace materials to GT5u by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3520 (5.09.51.03)
+>* Add Signalium, Lumiium and Enderium ABS recipes by @BlueHero233 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3355 (5.09.51.03)
+>* Fix DTPF convergence item consumption by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3629 (5.09.51.02)
+>* Fix fusion hatch textures by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3632 (5.09.51.02)
+>* Delete the RunGC command by @Ethryan in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3631 (5.09.51.02)
+>* fix NPE in MTEMultiAutoclave.getWailaNBTData by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3624 (5.09.51.01)
+>* bandaid fix for rotated turbine overlay by @Glease in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3622 (5.09.51.01)
+>* localize research station mode for waila by @chochem in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3623 (5.09.51.01)
+>* Fix modded music disk playback in the electric jukebox using the new GTNHLib api by @eigenraven in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3628 (5.09.51.01)
+>* Remove second Description Line of Network Switch by @Yoshy2002 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3615 (5.09.51.00)
+>* Add efficiency to cleanroom gui by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3616 (5.09.51.00)
+>* Decrease TF-specific vein max height spawn by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3590 (5.09.51.00)
+>* Downtier Transformation Module by @StaffiX in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3527 (5.09.51.00)
+>* Consistent recipe check order for ME crafting buses. by @AbdielKavash in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3555 (5.09.51.00)
+>* Add WAILA info displaying recipe outputs to multiblocks by @FourIsTheNumber in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3586 (5.09.51.00)
+>* Fix NEI fuel recipes for large boilers by @Ableytner in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3565 (5.09.51.00)
+>* Unifying multi-mode multis tooltips, adds "shortnames" to some multis by @CrystieColon3 in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3560 (5.09.51.00)
+>* Add an upgradable hand pump by @GDCloudstrike in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3485 (5.09.51.00)
+>* Remove Compact Fusion force chunk loading by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3618 (5.09.51.00)
+>* Remove DTPF force chunk loading by @serenibyss in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3619 (5.09.51.00)
+>* Refactored BioLab and Radio Hatch Recipes by @Nockyx in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3515 (5.09.51.00)
 
 # Updated - GTNH-TC-Wands - 1.4.1 --> 1.4.5
-## *1.4.5*
->## What's Changed
->* Add Getters by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/24
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNH-TC-Wands/compare/1.4.4...1.4.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/GTNH-TC-Wands/compare/1.4.1...1.4.5
 
-## *1.4.4*
->## What's Changed
->* Keep this data for use by other mods by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/23
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNH-TC-Wands/compare/1.4.3...1.4.4
->
-
-## *1.4.3*
->## What's Changed
->* Necromancer's Staff Core Recipes by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/22
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/22
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNH-TC-Wands/compare/1.4.1...1.4.3
->
+## What's Changed:
+>* Add Getters by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/24 (1.4.5)
+>* Keep this data for use by other mods by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/23 (1.4.4)
+>* Necromancer's Staff Core Recipes by @koolkrafter5 in https://github.com/GTNewHorizons/GTNH-TC-Wands/pull/22 (1.4.3)
 
 # Updated - GTNHLib - 0.5.23 --> 0.6.37
-## *0.6.37*
->## What's Changed
->* Add Cyrillic support for MathExpressionParser by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GTNHLib/pull/160
->* Initial gamerule API by @Cleptomania in https://github.com/GTNewHorizons/GTNHLib/pull/159
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/153
->
->## New Contributors
->* @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/160
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.36...0.6.37
->
+**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.5.23...0.6.37
 
-## *0.6.36*
->## What's Changed
->* Make BlockPos#toString() more reasonable by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/158
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.35...0.6.36
->
-
-## *0.6.35*
->## What's Changed
->* add ArrayProximityCheck4D and ArrayProximityMap4D<T> by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/157
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.34...0.6.35
->
-
-## *0.6.34*
->## What's Changed
->* Expose SyncedKeybind keyCode by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/155
->* Remove key pressed packet by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/156
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.33...0.6.34
->
-
-## *0.6.33*
->## What's Changed
->* Add support for mouse buttons in SyncedKeybinds by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/154
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.32...0.6.33
->
-
-## *0.6.32*
->## What's Changed
->* Added `hasValue` function for Lazy by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/148
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.31...0.6.32
->
-
-## *0.6.31*
->## What's Changed
->* add VolumeMembershipCheck by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/146
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.30...0.6.31
->
-
-## *0.6.30*
->## What's Changed
->* Add contains method to SpatialHashGrid by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/145
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.29...0.6.30
->
-
-## *0.6.29*
->## What's Changed
->* Add Z axis rotation to Variant & fix swapped XY axes by @Anonymagpie in https://github.com/GTNewHorizons/GTNHLib/pull/141
->
->## New Contributors
->* @Anonymagpie made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/141
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.28...0.6.29
->
-
-## *0.6.28*
->## What's Changed
->* Rework spatial hash grid by @kurrycat2004 in https://github.com/GTNewHorizons/GTNHLib/pull/143
->
->## New Contributors
->* @kurrycat2004 made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/143
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.27...0.6.28
->
-
-## *0.6.27*
->## What's Changed
->* Iterator impl + findFirst + findClosest by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/139
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.26...0.6.27
->
-
-## *0.6.26*
->## What's Changed
->* add close() to ShaderProgram to free resources by @MeiTianyou in https://github.com/GTNewHorizons/GTNHLib/pull/140
->
->## New Contributors
->* @MeiTianyou made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/140
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.25...0.6.26
->
-
-## *0.6.25*
->## What's Changed
->* Update SpatialHashGrid findNearby by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/138
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.24...0.6.25
->
-
-## *0.6.24*
->## What's Changed
->* Extract out the distance methods to a static util class by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/137
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.23...0.6.24
->
-
-## *0.6.23*
->## What's Changed
->* Add Spatial Hash Grid Data Structure by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/135
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.22...0.6.23
->
-
-## *0.6.22*
->## What's Changed
->* Add convenience method to ObjectPooler by @ah-OOG-ah in https://github.com/GTNewHorizons/GTNHLib/pull/130
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.21...0.6.22
->
-
-## *0.6.21*
->## What's Changed
->* Add 32-bit and 64-bit FNV-1a hash function utilities by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/128
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.20...0.6.21
->
-
-## *0.6.20*
->## What's Changed
->* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/GTNHLib/pull/114
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/114
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.19...0.6.20
->
-
-## *0.6.19*
->## What's Changed
->* Backport callFromMainThread() and addScheduledTask() by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/126
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.18...0.6.19
->
-
-## *0.6.18*
->## What's Changed
->* New mixin infrastructure by @Cleptomania in https://github.com/GTNewHorizons/GTNHLib/pull/127
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.17...0.6.18
->
-
-## *0.6.17*
->## What's Changed
->* Added offset(int, int, int) and copy() for BlockPos by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/125
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.16...0.6.17
->
-
-## *0.6.16*
->## What's Changed
->* Make BlockPos modifications return BlockPos instead of IBlockPos by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/124
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/124
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.15...0.6.16
->
-
-## *0.6.15*
->## What's Changed
->* Add VAO utilities for easier core profile compatibility by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/123
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.14...0.6.15
->
-
-## *0.6.14*
->## What's Changed
->* Updates for IStateStack by @mitchej123 in https://github.com/GTNewHorizons/GTNHLib/pull/120
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.13...0.6.14
->
-
-## *0.6.13*
->## What's Changed
->* Notify client of servers view distance by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/116
->* Move LoreHolder registration to a later init stage by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/118
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.12...0.6.13
->
-
-## *0.6.12*
->## What's Changed
->* Add mixin to register LivingEquipmentChangeEvent by @FourIsTheNumber in https://github.com/GTNewHorizons/GTNHLib/pull/117
->
->## New Contributors
->* @FourIsTheNumber made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/117
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.11...0.6.12
->
-
-## *0.6.11*
->## What's Changed
->* Introduce Capability system by @miozune in https://github.com/GTNewHorizons/GTNHLib/pull/112
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.10...0.6.11
->
-
-## *0.6.10*
->## What's Changed
->* Fix versionPattern by @miozune in https://github.com/GTNewHorizons/GTNHLib/pull/111
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.9...0.6.10
->
-
-## *0.6.9*
->## What's Changed
->* Add NEI Version Check by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/109
->* Update the constant pool parser for Java 25 by @ah-OOG-ah in https://github.com/GTNewHorizons/GTNHLib/pull/110
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.8...0.6.9
->
-
-## *0.6.8*
->## What's Changed
->* Amend previous commit, don't set keyCode to -1 by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/108
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.7...0.6.8
->
-
-## *0.6.7*
->## What's Changed
->* Fix MC keybinding-backed synced keybind listeners by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/107
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.6...0.6.7
->
-
-## *0.6.6*
->## What's Changed
->* Backport LWJGL3 memory utilities to enable more efficient ByteBuffer usage by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/105
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.5...0.6.6
->
-
-## *0.6.5*
->## What's Changed
->* Synced Keybinds API by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/104
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.3...0.6.5
->
-
-## *0.6.3*
->## What's Changed
->* Easily sync config values between server & client by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/102
->* Register config sync event bus in init by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/103
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.2...0.6.3
->
-
-## *0.6.2*
->## What's Changed
->* Automatic LoreHolder Discovery by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/101
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.1...0.6.2
->
-
-## *0.6.1*
->## What's Changed
->* Add block/meta and item/meta pair classes by @RecursivePineapple in https://github.com/GTNewHorizons/GTNHLib/pull/98
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/GTNHLib/pull/98
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.6.0...0.6.1
->
-
-## *0.6.0*
->## What's Changed
->* Add `RenderTooltipEvent` by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/81
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/GTNHLib/compare/0.5.23...0.6.0
->
+## What's Changed:
+>* Add Cyrillic support for MathExpressionParser by @Eldrinn-Elantey in https://github.com/GTNewHorizons/GTNHLib/pull/160 (0.6.37)
+>* Initial gamerule API by @Cleptomania in https://github.com/GTNewHorizons/GTNHLib/pull/159 (0.6.37)
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/153 (0.6.37)
+>* Make BlockPos#toString() more reasonable by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/158 (0.6.36)
+>* add ArrayProximityCheck4D and ArrayProximityMap4D<T> by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/157 (0.6.35)
+>* Expose SyncedKeybind keyCode by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/155 (0.6.34)
+>* Remove key pressed packet by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/156 (0.6.34)
+>* Add support for mouse buttons in SyncedKeybinds by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/154 (0.6.33)
+>* Added `hasValue` function for Lazy by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/148 (0.6.32)
+>* add VolumeMembershipCheck by @Alexdoru in https://github.com/GTNewHorizons/GTNHLib/pull/146 (0.6.31)
+>* Add contains method to SpatialHashGrid by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/145 (0.6.30)
+>* Add Z axis rotation to Variant & fix swapped XY axes by @Anonymagpie in https://github.com/GTNewHorizons/GTNHLib/pull/141 (0.6.29)
+>* Rework spatial hash grid by @kurrycat2004 in https://github.com/GTNewHorizons/GTNHLib/pull/143 (0.6.28)
+>* Iterator impl + findFirst + findClosest by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/139 (0.6.27)
+>* add close() to ShaderProgram to free resources by @MeiTianyou in https://github.com/GTNewHorizons/GTNHLib/pull/140 (0.6.26)
+>* Update SpatialHashGrid findNearby by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/138 (0.6.25)
+>* Extract out the distance methods to a static util class by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/137 (0.6.24)
+>* Add Spatial Hash Grid Data Structure by @Caedis in https://github.com/GTNewHorizons/GTNHLib/pull/135 (0.6.23)
+>* Add convenience method to ObjectPooler by @ah-OOG-ah in https://github.com/GTNewHorizons/GTNHLib/pull/130 (0.6.22)
+>* Add 32-bit and 64-bit FNV-1a hash function utilities by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/128 (0.6.21)
+>* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/GTNHLib/pull/114 (0.6.20)
+>* Backport callFromMainThread() and addScheduledTask() by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/126 (0.6.19)
+>* New mixin infrastructure by @Cleptomania in https://github.com/GTNewHorizons/GTNHLib/pull/127 (0.6.18)
+>* Added offset(int, int, int) and copy() for BlockPos by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/125 (0.6.17)
+>* Make BlockPos modifications return BlockPos instead of IBlockPos by @Taskeren in https://github.com/GTNewHorizons/GTNHLib/pull/124 (0.6.16)
+>* Add VAO utilities for easier core profile compatibility by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/123 (0.6.15)
+>* Updates for IStateStack by @mitchej123 in https://github.com/GTNewHorizons/GTNHLib/pull/120 (0.6.14)
+>* Notify client of servers view distance by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/116 (0.6.13)
+>* Move LoreHolder registration to a later init stage by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/118 (0.6.13)
+>* Add mixin to register LivingEquipmentChangeEvent by @FourIsTheNumber in https://github.com/GTNewHorizons/GTNHLib/pull/117 (0.6.12)
+>* Introduce Capability system by @miozune in https://github.com/GTNewHorizons/GTNHLib/pull/112 (0.6.11)
+>* Fix versionPattern by @miozune in https://github.com/GTNewHorizons/GTNHLib/pull/111 (0.6.10)
+>* Add NEI Version Check by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/109 (0.6.9)
+>* Update the constant pool parser for Java 25 by @ah-OOG-ah in https://github.com/GTNewHorizons/GTNHLib/pull/110 (0.6.9)
+>* Amend previous commit, don't set keyCode to -1 by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/108 (0.6.8)
+>* Fix MC keybinding-backed synced keybind listeners by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/107 (0.6.7)
+>* Backport LWJGL3 memory utilities to enable more efficient ByteBuffer usage by @eigenraven in https://github.com/GTNewHorizons/GTNHLib/pull/105 (0.6.6)
+>* Synced Keybinds API by @serenibyss in https://github.com/GTNewHorizons/GTNHLib/pull/104 (0.6.5)
+>* Easily sync config values between server & client by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/102 (0.6.3)
+>* Register config sync event bus in init by @Lyfts in https://github.com/GTNewHorizons/GTNHLib/pull/103 (0.6.3)
+>* Automatic LoreHolder Discovery by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/101 (0.6.2)
+>* Add block/meta and item/meta pair classes by @RecursivePineapple in https://github.com/GTNewHorizons/GTNHLib/pull/98 (0.6.1)
+>* Add `RenderTooltipEvent` by @glowredman in https://github.com/GTNewHorizons/GTNHLib/pull/81 (0.6.0)
 
 # Updated - Gadomancy - 1.3.8 --> 1.4.6
-## *1.4.6*
->## What's Changed
->* Delete overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/Gadomancy/pull/39
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.4.4...1.4.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.3.8...1.4.6
 
-## *1.4.4*
->## What's Changed
->* Delete access transformer for gamerules map by @Alexdoru in https://github.com/GTNewHorizons/Gadomancy/pull/38
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/38
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.4.3...1.4.4
->
-
-## *1.4.3*
->## What's Changed
->* Use mixins instead of registry replacement by @ah-OOG-ah in https://github.com/GTNewHorizons/Gadomancy/pull/37
->
->## New Contributors
->* @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/37
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.4.2...1.4.3
->
-
-## *1.4.2*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Gadomancy/pull/36
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.4.1...1.4.2
->
-
-## *1.4.1*
->## What's Changed
->* Fix mirrored jar labels not saving by @serenibyss in https://github.com/GTNewHorizons/Gadomancy/pull/35
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.4.0...1.4.1
->
-
-## *1.4.0*
->## What's Changed
->* Optimize mirrored jar by @serenibyss in https://github.com/GTNewHorizons/Gadomancy/pull/33
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Gadomancy/pull/33
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gadomancy/compare/1.3.6...1.4.0
->
+## What's Changed:
+>* Delete overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/Gadomancy/pull/39 (1.4.6)
+>* Delete access transformer for gamerules map by @Alexdoru in https://github.com/GTNewHorizons/Gadomancy/pull/38 (1.4.4)
+>* Use mixins instead of registry replacement by @ah-OOG-ah in https://github.com/GTNewHorizons/Gadomancy/pull/37 (1.4.3)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Gadomancy/pull/36 (1.4.2)
+>* Fix mirrored jar labels not saving by @serenibyss in https://github.com/GTNewHorizons/Gadomancy/pull/35 (1.4.1)
+>* Optimize mirrored jar by @serenibyss in https://github.com/GTNewHorizons/Gadomancy/pull/33 (1.4.0)
 
 # Updated - Galacticraft - 3.2.10-GTNH --> 3.3.9-GTNH
-## *3.3.9-GTNH*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Galacticraft/pull/108
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.8-GTNH...3.3.9-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.2.10-GTNH...3.3.9-GTNH
 
-## *3.3.8-GTNH*
->## What's Changed
->* Removed duplicate lang-file entries by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Galacticraft/pull/107
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/107
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.7-GTNH...3.3.8-GTNH
->
-
-## *3.3.7-GTNH*
->## What's Changed
->* Gas name fix by @MysticalBlade in https://github.com/GTNewHorizons/Galacticraft/pull/106
->
->## New Contributors
->* @MysticalBlade made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/106
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.6-GTNH...3.3.7-GTNH
->
-
-## *3.3.6-GTNH*
->## What's Changed
->* Optimizes the Arc Lamp's `lightArea()` by @mitchej123 in https://github.com/GTNewHorizons/Galacticraft/pull/105
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.5-GTNH...3.3.6-GTNH
->
-
-## *3.3.5-GTNH*
->## What's Changed
->* Add back Missing Characters in License by @glowredman in https://github.com/GTNewHorizons/Galacticraft/pull/102
->* Add config option + Translucency enchant to hide GC gear from rendering on the player body by @Kortako in https://github.com/GTNewHorizons/Galacticraft/pull/103
->
->## New Contributors
->* @Kortako made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/103
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.4-GTNH...3.3.5-GTNH
->
-
-## *3.3.4-GTNH*
->## What's Changed
->* Breathing underwater  by @mak8427 in https://github.com/GTNewHorizons/Galacticraft/pull/101
->
->## New Contributors
->* @mak8427 made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/101
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.3-GTNH...3.3.4-GTNH
->
-
-## *3.3.3-GTNH*
->## What's Changed
->* Fix some entity translations by @Ableytner in https://github.com/GTNewHorizons/Galacticraft/pull/100
->
->## New Contributors
->* @Ableytner made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/100
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.2-GTNH...3.3.3-GTNH
->
-
-## *3.3.2-GTNH*
->## What's Changed
->* GCPlanets item and recipe cleanup for gtnh by @chochem in https://github.com/GTNewHorizons/Galacticraft/pull/99
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.1-GTNH...3.3.2-GTNH
->
-
-## *3.3.1-GTNH*
->## What's Changed
->* GCcore item and recipe cleanup for GTNH by @chochem in https://github.com/GTNewHorizons/Galacticraft/pull/98
->
->## New Contributors
->* @chochem made their first contribution in https://github.com/GTNewHorizons/Galacticraft/pull/98
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.3.0-GTNH...3.3.1-GTNH
->
-
-## *3.3.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Galacticraft/compare/3.2.9-GTNH...3.3.0-GTNH
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Galacticraft/pull/108 (3.3.9-GTNH)
+>* Removed duplicate lang-file entries by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/Galacticraft/pull/107 (3.3.8-GTNH)
+>* Gas name fix by @MysticalBlade in https://github.com/GTNewHorizons/Galacticraft/pull/106 (3.3.7-GTNH)
+>* Optimizes the Arc Lamp's `lightArea()` by @mitchej123 in https://github.com/GTNewHorizons/Galacticraft/pull/105 (3.3.6-GTNH)
+>* Add back Missing Characters in License by @glowredman in https://github.com/GTNewHorizons/Galacticraft/pull/102 (3.3.5-GTNH)
+>* Add config option + Translucency enchant to hide GC gear from rendering on the player body by @Kortako in https://github.com/GTNewHorizons/Galacticraft/pull/103 (3.3.5-GTNH)
+>* Breathing underwater  by @mak8427 in https://github.com/GTNewHorizons/Galacticraft/pull/101 (3.3.4-GTNH)
+>* Fix some entity translations by @Ableytner in https://github.com/GTNewHorizons/Galacticraft/pull/100 (3.3.3-GTNH)
+>* GCPlanets item and recipe cleanup for gtnh by @chochem in https://github.com/GTNewHorizons/Galacticraft/pull/99 (3.3.2-GTNH)
+>* GCcore item and recipe cleanup for GTNH by @chochem in https://github.com/GTNewHorizons/Galacticraft/pull/98 (3.3.1-GTNH)
 
 # Updated - Galaxy-Space-GTNH - 1.1.99-GTNH --> 1.1.116-GTNH
-## *1.1.116-GTNH*
->## What's Changed
->* Make Spawn Egg colors unique by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/130
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.115-GTNH...1.1.116-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.99-GTNH...1.1.116-GTNH
 
-## *1.1.115-GTNH*
->## What's Changed
->* Fix wrong Control Computer in T3 Rocket Schematic Container by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/129
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.114-GTNH...1.1.115-GTNH
->
-
-## *1.1.114-GTNH*
->## What's Changed
->* Make α Centauri Bb Grunt ignite entities on contact by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/128
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.113-GTNH...1.1.114-GTNH
->
-
-## *1.1.113-GTNH*
->## What's Changed
->* Major Code Rework by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/125
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.111-GTNH...1.1.113-GTNH
->
-
-## *1.1.111-GTNH*
->## What's Changed
->* Move Spacesuit to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/127
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/127
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.109-GTNH...1.1.111-GTNH
->
-
-## *1.1.109-GTNH*
->## What's Changed
->* Add nbt override for spacesuit functionality by @FourIsTheNumber in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/126
->
->## New Contributors
->* @FourIsTheNumber made their first contribution in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/126
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.106-GTNH...1.1.109-GTNH
->
-
-## *1.1.106-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.105-GTNH...1.1.106-GTNH
->
-
-## *1.1.105-GTNH*
->## What's Changed
->* Remove gt dependency by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/124
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.104-GTNH...1.1.105-GTNH
->
-
-## *1.1.104-GTNH*
->## What's Changed
->* Remove Dyson and GT recipes from GalaxySpace by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/122
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.102-GTNH...1.1.104-GTNH
->
-
-## *1.1.102-GTNH*
->## What's Changed
->* Optimize enceladus worldgen by @RecursivePineapple in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/123
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/123
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.100-GTNH...1.1.102-GTNH
->
-
-## *1.1.100-GTNH*
->## What's Changed
->* Migrate GalaxySpace materials to GT5u by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/121
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Galaxy-Space-GTNH/compare/1.1.97-GTNH...1.1.100-GTNH
->
+## What's Changed:
+>* Make Spawn Egg colors unique by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/130 (1.1.116-GTNH)
+>* Fix wrong Control Computer in T3 Rocket Schematic Container by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/129 (1.1.115-GTNH)
+>* Make  Centauri Bb Grunt ignite entities on contact by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/128 (1.1.114-GTNH)
+>* Major Code Rework by @glowredman in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/125 (1.1.113-GTNH)
+>* Move Spacesuit to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/127 (1.1.111-GTNH)
+>* Add nbt override for spacesuit functionality by @FourIsTheNumber in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/126 (1.1.109-GTNH)
+>* Remove gt dependency by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/124 (1.1.105-GTNH)
+>* Remove Dyson and GT recipes from GalaxySpace by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/122 (1.1.104-GTNH)
+>* Optimize enceladus worldgen by @RecursivePineapple in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/123 (1.1.102-GTNH)
+>* Migrate GalaxySpace materials to GT5u by @serenibyss in https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/121 (1.1.100-GTNH)
 
 # Updated - Gravitation-Suite-Neo - 1.2.2 --> 1.3.6
-## *1.3.6*
->## What's Changed
->* Change modid in optional decorators to `gregtech_nh` instead of `gregtech` to work with gt6 again by @felixfour in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/28
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.3.5...1.3.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.2.2...1.3.6
 
-## *1.3.5*
->## What's Changed
->* change loader checks to avoid gt6 conflict by @felixfour in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/27
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.3.4...1.3.5
->
-
-## *1.3.4*
->## What's Changed
->* Move GraviSuite Armors to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/26
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.3.3...1.3.4
->
-
-## *1.3.3*
->## What's Changed
->* Fix conflict with NHCore by @glowredman in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/25
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.3.2...1.3.3
->
-
-## *1.3.2*
->## What's Changed
->* Fix falling with enabled hover mode and holding both jump and sneak key by @kuba6000 in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/24
->
->## New Contributors
->* @kuba6000 made their first contribution in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/24
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.3.0...1.3.2
->
-
-## *1.3.0*
->## What's Changed
->* Don't consume water (or other) cells to extinguish wearers of the Advanced NanoChestPlate by @YannickMG in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/23
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/23
->
->**Full Changelog**: https://github.com/GTNewHorizons/Gravitation-Suite-Neo/compare/1.2.2...1.3.0
->
+## What's Changed:
+>* Change modid in optional decorators to `gregtech_nh` instead of `gregtech` to work with gt6 again by @felixfour in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/28 (1.3.6)
+>* change loader checks to avoid gt6 conflict by @felixfour in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/27 (1.3.5)
+>* Move GraviSuite Armors to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/26 (1.3.4)
+>* Fix conflict with NHCore by @glowredman in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/25 (1.3.3)
+>* Fix falling with enabled hover mode and holding both jump and sneak key by @kuba6000 in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/24 (1.3.2)
+>* Don't consume water (or other) cells to extinguish wearers of the Advanced NanoChestPlate by @YannickMG in https://github.com/GTNewHorizons/Gravitation-Suite-Neo/pull/23 (1.3.0)
 
 # Updated - Hardcore-Ender-Expansion - 1.12.1-GTNH --> 1.12.8-GTNH
-## *1.12.8-GTNH*
->## What's Changed
->* add @MCVersion to IFMLLoadingPlugin by @Alexdoru in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/27
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.7-GTNH...1.12.8-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.1-GTNH...1.12.8-GTNH
 
-## *1.12.7-GTNH*
->## What's Changed
->* Delete  overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/26
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.5-GTNH...1.12.7-GTNH
->
-
-## *1.12.5-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/25
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/25
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.4-GTNH...1.12.5-GTNH
->
-
-## *1.12.4-GTNH*
->## What's Changed
->* Replace reflective registry replacement with minor mixined method by @ah-OOG-ah in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/24
->
->## New Contributors
->* @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/24
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.3-GTNH...1.12.4-GTNH
->
-
-## *1.12.3-GTNH*
->## What's Changed
->* do not persist technical entity by @Glease in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/23
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/compare/1.12.1-GTNH...1.12.3-GTNH
->
+## What's Changed:
+>* add @MCVersion to IFMLLoadingPlugin by @Alexdoru in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/27 (1.12.8-GTNH)
+>* Delete  overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/26 (1.12.7-GTNH)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/25 (1.12.5-GTNH)
+>* Replace reflective registry replacement with minor mixined method by @ah-OOG-ah in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/24 (1.12.4-GTNH)
+>* do not persist technical entity by @Glease in https://github.com/GTNewHorizons/Hardcore-Ender-Expansion/pull/23 (1.12.3-GTNH)
 
 # Updated - Hodgepodge - 2.5.90 --> 2.6.91
-## *2.6.91*
->## What's Changed
->* Small improvements on removeFormattingCodes by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/579
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.90...2.6.91
->
+**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.5.90...2.6.91
 
-## *2.6.90*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/574
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.89...2.6.90
->
-
-## *2.6.89*
->## What's Changed
->* Add game rule to disable hunger `"disableHunger"` by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/577
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.87...2.6.89
->
-
-## *2.6.87*
->## What's Changed
->* Improve pick block by @VendoAU in https://github.com/GTNewHorizons/Hodgepodge/pull/575
->
->## New Contributors
->* @VendoAU made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/575
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.86...2.6.87
->
-
-## *2.6.86*
->## What's Changed
->* Config fixes by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/572
->* Fix loading client only mixins on the server by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/573
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.84...2.6.86
->
-
-## *2.6.84*
->## What's Changed
->* Speedup `EnumChatFormatting.getTextWithoutFormattingCodes` by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/571
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.83...2.6.84
->
-
-## *2.6.83*
->## What's Changed
->* Fix compat with ModernKeybindings by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/569
->* Delete unnecessary invoker interface for MixinNBTTagList_speedup by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/570
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.82...2.6.83
->
-
-## *2.6.82*
->## What's Changed
->* Expand #540 to check for '' (empty) sounds, and to cover more than just EntityLiving#getLivingSound by @Charsy89 in https://github.com/GTNewHorizons/Hodgepodge/pull/565
->* Rework Bed Set Spawn Mixin by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/566
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.81...2.6.82
->
-
-## *2.6.81*
->## What's Changed
->* Disable some patches when ultramine present by @SKProCH in https://github.com/GTNewHorizons/Hodgepodge/pull/562
->* Refer to Galacticraft by its name instead of an abbreviation by @Charsy89 in https://github.com/GTNewHorizons/Hodgepodge/pull/567
->
->## New Contributors
->* @SKProCH made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/562
->* @Charsy89 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/567
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.79...2.6.81
->
-
-## *2.6.79*
->## What's Changed
->* Remove unregistered events from MixinEventBus.listenerOwners by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/563
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.78...2.6.79
->
-
-## *2.6.78*
->## What's Changed
->* Fix eventbus keeping object references after unregistering handler by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/554
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.77...2.6.78
->
-
-## *2.6.77*
->## What's Changed
->* Fix adding Thrower to inventory-dropped items by @Ruling-0 in https://github.com/GTNewHorizons/Hodgepodge/pull/559
->* Add mixins to synchonize from server to client the thrower of an item entity by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/560
->* Dont use Class.forName in the coremod by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/561
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/559
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.76...2.6.77
->
-
-## *2.6.76*
->## What's Changed
->* Change obfuscated environment detection for ASM coremod by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/556
->* Rename embedID config to force disable it for previous configs by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/557
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.75...2.6.76
->
-
-## *2.6.75*
->## What's Changed
->* add @Unique annotation on mixin added fields of MixinSpawnerAnimals_optimizeSpawning by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/555
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.74...2.6.75
->
-
-## *2.6.74*
->## What's Changed
->* Fix Crash Loop with EU Ender Collector by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/546
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.72...2.6.74
->
-
-## *2.6.72*
->## What's Changed
->* Witch Potion Metadata by @koolkrafter5 in https://github.com/GTNewHorizons/Hodgepodge/pull/548
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.69...2.6.72
->
-
-## *2.6.69*
->## What's Changed
->* Disable Embed IDs by default by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/549
->* Check the cast in case the config isn't enabled by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/550
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.66...2.6.69
->
-
-## *2.6.66*
->## What's Changed
->* Make Etheric Sword truly Unbreakble by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/545
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.65...2.6.66
->
-
-## *2.6.65*
->## What's Changed
->* Silence some "none" sounds by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/540
->* Set ID on inner map by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/535
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.64...2.6.65
->
-
-## *2.6.64*
->## What's Changed
->* SpeedupOreDictionaryTransformer by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/522
->* Add Mixins to fix Redstone output for Extra Utilities Chests not updating on Inventory Change by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/544
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/544
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.53...2.6.64
->
-
-## *2.6.53*
->## What's Changed
->* ignore preexisting voxelmap data files when trying to change ext by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/534
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.51...2.6.53
->
-
-## *2.6.51*
->## What's Changed
->* Fix crash with BetterModList and ClickableURL by @0hwx in https://github.com/GTNewHorizons/Hodgepodge/pull/533
->* Enderman Griefing Configs by @koolkrafter5 in https://github.com/GTNewHorizons/Hodgepodge/pull/512
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/512
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.48...2.6.51
->
-
-## *2.6.48*
->## What's Changed
->* Fixed egg particles (MC-7807) by @JackOfNoneTrades in https://github.com/GTNewHorizons/Hodgepodge/pull/527
->* Fix KleeSlabs mod metadata by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/525
->* Added mixin that makes mod urls clickable by @JackOfNoneTrades in https://github.com/GTNewHorizons/Hodgepodge/pull/526
->* Namespace injected method by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/530
->* Migrate Ingame Mod List Fix from EnderCore ASM by @0hwx in https://github.com/GTNewHorizons/Hodgepodge/pull/524
->* Fix Simulation distance patch with Thermos by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/520
->
->## New Contributors
->* @JackOfNoneTrades made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/527
->* @0hwx made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/524
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.46...2.6.48
->
-
-## *2.6.46*
->## What's Changed
->* Remove recursive slotClick calls when shift clicking a slot by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/521
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.40...2.6.46
->
-
-## *2.6.40*
->## What's Changed
->* Catch null and never registered cases when embedding block IDs by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/519
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.39...2.6.40
->
-
-## *2.6.39*
->## What's Changed
->* Convert mixin setup to use GTNHLib by @Cleptomania in https://github.com/GTNewHorizons/Hodgepodge/pull/513
->* Simulation distance feature: Disable when optifine is present by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/516
->* ArchaicFix and Angelica (removal) compat by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/514
->* Add various speedups around chunk generation by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/515
->* Update dependencies.gradle by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/517
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.38...2.6.39
->
-
-## *2.6.38*
->## What's Changed
->* Add ASM to swap out an ArrayList and multiple contains() calls with a better data structure (Set) by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/508
->* Swap out ObjectIntIdentityMap with ProperObjectIntIdentityMap to avoid Box/Unbox of ints by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/509
->* Add option to set simulation distance by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/507
->* Better hashcode for ChunkCoordIntPair by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/510
->* Bump required deps for nhlib & unimixins by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/511
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/507
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.37...2.6.38
->
-
-## *2.6.37*
->## What's Changed
->* Fix the healing axe not healing entities when attacking them by @EmperorSuper in https://github.com/GTNewHorizons/Hodgepodge/pull/498
->* Add option to synchronize IC2 reactors by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/502
->
->## New Contributors
->* @EmperorSuper made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/498
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.35...2.6.37
->
-
-## *2.6.35*
->## What's Changed
->* Fix xp not loading when changing dimensions by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/504
->* Fix Glass Bottles filling with water from some other Fluid blocks by @serenibyss in https://github.com/GTNewHorizons/Hodgepodge/pull/506
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.31...2.6.35
->
-
-## *2.6.31*
->## What's Changed
->* Add `/time get` by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/499
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.30...2.6.31
->
-
-## *2.6.30*
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.29...2.6.30
->
-
-## *2.6.29*
->## What's Changed
->* Stop searching the same file multiple times for languages. by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/495
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.28...2.6.29
->
-
-## *2.6.28*
->## What's Changed
->* Small Fixes by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/494
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.27...2.6.28
->
-
-## *2.6.27*
->## What's Changed
->* Fix client desync with item in hand by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/490
->* Prevent lava from loading chunks by @RecursivePineapple in https://github.com/GTNewHorizons/Hodgepodge/pull/491
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.26...2.6.27
->
-
-## *2.6.26*
->## What's Changed
->* Prevent CastClassException on invalid duct network by @DrParadox7 in https://github.com/GTNewHorizons/Hodgepodge/pull/488
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.25...2.6.26
->
-
-## *2.6.25*
->## What's Changed
->* Animation/Texture Mixins moved to Angelica by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/487
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.24...2.6.25
->
-
-## *2.6.24*
->## What's Changed
->* fix entity attributes range by @raylras in https://github.com/GTNewHorizons/Hodgepodge/pull/486
->
->## New Contributors
->* @raylras made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/486
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.23...2.6.24
->
-
-## *2.6.23*
->## What's Changed
->* Modular Powersuits energy methods to only interacts with MPS equipment by @DrParadox7 in https://github.com/GTNewHorizons/Hodgepodge/pull/482
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.22...2.6.23
->
-
-## *2.6.22*
->## What's Changed
->* fix extra utilities ender quarry freeze/soft-lock randomly by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/480
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.20...2.6.22
->
-
-## *2.6.20*
->## What's Changed
->* ensure drops is not null by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/479
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.18...2.6.20
->
-
-## *2.6.18*
->## What's Changed
->* Improve several simulated block break actions of mods by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/478
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.17...2.6.18
->
-
-## *2.6.17*
->## What's Changed
->* Localise bed respawn message by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/475
->* Update zh_CN.lang by @huihiuhuai in https://github.com/GTNewHorizons/Hodgepodge/pull/476
->
->## New Contributors
->* @huihiuhuai made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/476
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.16...2.6.17
->
-
-## *2.6.16*
->## What's Changed
->* Backport instant bed spawn setting by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/473
->* Updates the player's container when the container is closed and the i… by @benTicks in https://github.com/GTNewHorizons/Hodgepodge/pull/474
->
->## New Contributors
->* @benTicks made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/474
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.15...2.6.16
->
-
-## *2.6.15*
->## What's Changed
->* Fix skin manager leaking client world by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/469
->* Backport 1.20's 'pause-when-empty-seconds' server property by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/470
->* Revert "Backport 1.20's 'pause-when-empty-seconds' server property (#… by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/472
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.13...2.6.15
->
-
-## *2.6.14*
->## What's Changed
->* Backport instant bed spawn setting by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/473
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.15...2.6.14
->
-
-## *2.6.13*
->## What's Changed
->* Display Mod Name under the Item's Name in Item / Block Stat GUI by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/465
->* Fix race condition in COFH's oredict initialization by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/466
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.12...2.6.13
->
-
-## *2.6.12*
->## What's Changed
->* Fix lag when trying to right click items but the interaction fails by @kuba6000 in https://github.com/GTNewHorizons/Hodgepodge/pull/463
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.11...2.6.12
->
-
-## *2.6.11*
->## What's Changed
->* Fix coretweaks hard-dep by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/460
->* fix getFloatTemperature causing lag by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/461
->* fix placing blocks isn't working downwards by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/462
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.9...2.6.11
->
-
-## *2.6.9*
->## What's Changed
->* Various Optimizations by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/455
->* fix wrong block placement distance check by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/458
->
->## New Contributors
->* @Pilzinsel64 made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/458
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.6...2.6.9
->
-
-## *2.6.6*
->## What's Changed
->* Fix Sugar Cane placement on replaceable blocks by @YannickMG in https://github.com/GTNewHorizons/Hodgepodge/pull/454
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/454
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.4...2.6.6
->
-
-## *2.6.4*
->## What's Changed
->* Use custom iterators instead of streams by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/453
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.3...2.6.4
->
-
-## *2.6.3*
->## What's Changed
->* fix stream by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/452
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.2...2.6.3
->
-
-## *2.6.2*
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.1...2.6.2
->
-
-## *2.6.1*
->## What's Changed
->* Adjust GTNHLib coremod name in TargetedMod by @Georggi in https://github.com/GTNewHorizons/Hodgepodge/pull/451
->
->## New Contributors
->* @Georggi made their first contribution in https://github.com/GTNewHorizons/Hodgepodge/pull/451
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.6.0...2.6.1
->
-
-## *2.6.0*
->## What's Changed
->* Fix off by one int clamp in Witchery's glyph rendering by @Cleptomania in https://github.com/GTNewHorizons/Hodgepodge/pull/448
->* cleanup MixinContainerFilingCabinet by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/450
->* Configurable ender quarry RF storage by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/446
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Hodgepodge/compare/2.5.82...2.6.0
->
+## What's Changed:
+>* Small improvements on removeFormattingCodes by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/579 (2.6.91)
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/574 (2.6.90)
+>* Add game rule to disable hunger `"disableHunger"` by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/577 (2.6.89)
+>* Improve pick block by @VendoAU in https://github.com/GTNewHorizons/Hodgepodge/pull/575 (2.6.87)
+>* Config fixes by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/572 (2.6.86)
+>* Fix loading client only mixins on the server by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/573 (2.6.86)
+>* Speedup `EnumChatFormatting.getTextWithoutFormattingCodes` by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/571 (2.6.84)
+>* Fix compat with ModernKeybindings by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/569 (2.6.83)
+>* Delete unnecessary invoker interface for MixinNBTTagList_speedup by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/570 (2.6.83)
+>* Expand #540 to check for '' (empty) sounds, and to cover more than just EntityLiving#getLivingSound by @Charsy89 in https://github.com/GTNewHorizons/Hodgepodge/pull/565 (2.6.82)
+>* Rework Bed Set Spawn Mixin by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/566 (2.6.82)
+>* Disable some patches when ultramine present by @SKProCH in https://github.com/GTNewHorizons/Hodgepodge/pull/562 (2.6.81)
+>* Refer to Galacticraft by its name instead of an abbreviation by @Charsy89 in https://github.com/GTNewHorizons/Hodgepodge/pull/567 (2.6.81)
+>* Remove unregistered events from MixinEventBus.listenerOwners by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/563 (2.6.79)
+>* Fix eventbus keeping object references after unregistering handler by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/554 (2.6.78)
+>* Fix adding Thrower to inventory-dropped items by @Ruling-0 in https://github.com/GTNewHorizons/Hodgepodge/pull/559 (2.6.77)
+>* Add mixins to synchonize from server to client the thrower of an item entity by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/560 (2.6.77)
+>* Dont use Class.forName in the coremod by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/561 (2.6.77)
+>* Change obfuscated environment detection for ASM coremod by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/556 (2.6.76)
+>* Rename embedID config to force disable it for previous configs by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/557 (2.6.76)
+>* add @Unique annotation on mixin added fields of MixinSpawnerAnimals_optimizeSpawning by @Alexdoru in https://github.com/GTNewHorizons/Hodgepodge/pull/555 (2.6.75)
+>* Fix Crash Loop with EU Ender Collector by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/546 (2.6.74)
+>* Witch Potion Metadata by @koolkrafter5 in https://github.com/GTNewHorizons/Hodgepodge/pull/548 (2.6.72)
+>* Disable Embed IDs by default by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/549 (2.6.69)
+>* Check the cast in case the config isn't enabled by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/550 (2.6.69)
+>* Make Etheric Sword truly Unbreakble by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/545 (2.6.66)
+>* Silence some "none" sounds by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/540 (2.6.65)
+>* Set ID on inner map by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/535 (2.6.65)
+>* SpeedupOreDictionaryTransformer by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/522 (2.6.64)
+>* Add Mixins to fix Redstone output for Extra Utilities Chests not updating on Inventory Change by @Yoshy2002 in https://github.com/GTNewHorizons/Hodgepodge/pull/544 (2.6.64)
+>* ignore preexisting voxelmap data files when trying to change ext by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/534 (2.6.53)
+>* Fix crash with BetterModList and ClickableURL by @0hwx in https://github.com/GTNewHorizons/Hodgepodge/pull/533 (2.6.51)
+>* Enderman Griefing Configs by @koolkrafter5 in https://github.com/GTNewHorizons/Hodgepodge/pull/512 (2.6.51)
+>* Fixed egg particles (MC-7807) by @JackOfNoneTrades in https://github.com/GTNewHorizons/Hodgepodge/pull/527 (2.6.48)
+>* Fix KleeSlabs mod metadata by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/525 (2.6.48)
+>* Added mixin that makes mod urls clickable by @JackOfNoneTrades in https://github.com/GTNewHorizons/Hodgepodge/pull/526 (2.6.48)
+>* Namespace injected method by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/530 (2.6.48)
+>* Migrate Ingame Mod List Fix from EnderCore ASM by @0hwx in https://github.com/GTNewHorizons/Hodgepodge/pull/524 (2.6.48)
+>* Fix Simulation distance patch with Thermos by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/520 (2.6.48)
+>* Remove recursive slotClick calls when shift clicking a slot by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/521 (2.6.46)
+>* Catch null and never registered cases when embedding block IDs by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/519 (2.6.40)
+>* Convert mixin setup to use GTNHLib by @Cleptomania in https://github.com/GTNewHorizons/Hodgepodge/pull/513 (2.6.39)
+>* Simulation distance feature: Disable when optifine is present by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/516 (2.6.39)
+>* ArchaicFix and Angelica (removal) compat by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/514 (2.6.39)
+>* Add various speedups around chunk generation by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/515 (2.6.39)
+>* Update dependencies.gradle by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/517 (2.6.39)
+>* Add ASM to swap out an ArrayList and multiple contains() calls with a better data structure (Set) by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/508 (2.6.38)
+>* Swap out ObjectIntIdentityMap with ProperObjectIntIdentityMap to avoid Box/Unbox of ints by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/509 (2.6.38)
+>* Add option to set simulation distance by @DarkShadow44 in https://github.com/GTNewHorizons/Hodgepodge/pull/507 (2.6.38)
+>* Better hashcode for ChunkCoordIntPair by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/510 (2.6.38)
+>* Bump required deps for nhlib & unimixins by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/511 (2.6.38)
+>* Fix the healing axe not healing entities when attacking them by @EmperorSuper in https://github.com/GTNewHorizons/Hodgepodge/pull/498 (2.6.37)
+>* Add option to synchronize IC2 reactors by @ah-OOG-ah in https://github.com/GTNewHorizons/Hodgepodge/pull/502 (2.6.37)
+>* Fix xp not loading when changing dimensions by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/504 (2.6.35)
+>* Fix Glass Bottles filling with water from some other Fluid blocks by @serenibyss in https://github.com/GTNewHorizons/Hodgepodge/pull/506 (2.6.35)
+>* Add `/time get` by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/499 (2.6.31)
+>* Stop searching the same file multiple times for languages. by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/495 (2.6.29)
+>* Small Fixes by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/494 (2.6.28)
+>* Fix client desync with item in hand by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/490 (2.6.27)
+>* Prevent lava from loading chunks by @RecursivePineapple in https://github.com/GTNewHorizons/Hodgepodge/pull/491 (2.6.27)
+>* Prevent CastClassException on invalid duct network by @DrParadox7 in https://github.com/GTNewHorizons/Hodgepodge/pull/488 (2.6.26)
+>* Animation/Texture Mixins moved to Angelica by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/487 (2.6.25)
+>* fix entity attributes range by @raylras in https://github.com/GTNewHorizons/Hodgepodge/pull/486 (2.6.24)
+>* Modular Powersuits energy methods to only interacts with MPS equipment by @DrParadox7 in https://github.com/GTNewHorizons/Hodgepodge/pull/482 (2.6.23)
+>* fix extra utilities ender quarry freeze/soft-lock randomly by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/480 (2.6.22)
+>* ensure drops is not null by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/479 (2.6.20)
+>* Improve several simulated block break actions of mods by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/478 (2.6.18)
+>* Localise bed respawn message by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/475 (2.6.17)
+>* Update zh_CN.lang by @huihiuhuai in https://github.com/GTNewHorizons/Hodgepodge/pull/476 (2.6.17)
+>* Backport instant bed spawn setting by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/473 (2.6.16)
+>* Updates the player's container when the container is closed and the i� by @benTicks in https://github.com/GTNewHorizons/Hodgepodge/pull/474 (2.6.16)
+>* Fix skin manager leaking client world by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/469 (2.6.15)
+>* Backport 1.20's 'pause-when-empty-seconds' server property by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/470 (2.6.15)
+>* Revert "Backport 1.20's 'pause-when-empty-seconds' server property (#� by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/472 (2.6.15)
+>* Backport instant bed spawn setting by @Caedis in https://github.com/GTNewHorizons/Hodgepodge/pull/473 (2.6.14)
+>* Display Mod Name under the Item's Name in Item / Block Stat GUI by @glowredman in https://github.com/GTNewHorizons/Hodgepodge/pull/465 (2.6.13)
+>* Fix race condition in COFH's oredict initialization by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/466 (2.6.13)
+>* Fix lag when trying to right click items but the interaction fails by @kuba6000 in https://github.com/GTNewHorizons/Hodgepodge/pull/463 (2.6.12)
+>* Fix coretweaks hard-dep by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/460 (2.6.11)
+>* fix getFloatTemperature causing lag by @Lyfts in https://github.com/GTNewHorizons/Hodgepodge/pull/461 (2.6.11)
+>* fix placing blocks isn't working downwards by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/462 (2.6.11)
+>* Various Optimizations by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/455 (2.6.9)
+>* fix wrong block placement distance check by @Pilzinsel64 in https://github.com/GTNewHorizons/Hodgepodge/pull/458 (2.6.9)
+>* Fix Sugar Cane placement on replaceable blocks by @YannickMG in https://github.com/GTNewHorizons/Hodgepodge/pull/454 (2.6.6)
+>* Use custom iterators instead of streams by @mitchej123 in https://github.com/GTNewHorizons/Hodgepodge/pull/453 (2.6.4)
+>* fix stream by @Glease in https://github.com/GTNewHorizons/Hodgepodge/pull/452 (2.6.3)
+>* Adjust GTNHLib coremod name in TargetedMod by @Georggi in https://github.com/GTNewHorizons/Hodgepodge/pull/451 (2.6.1)
+>* Fix off by one int clamp in Witchery's glyph rendering by @Cleptomania in https://github.com/GTNewHorizons/Hodgepodge/pull/448 (2.6.0)
+>* cleanup MixinContainerFilingCabinet by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/450 (2.6.0)
+>* Configurable ender quarry RF storage by @Midnight145 in https://github.com/GTNewHorizons/Hodgepodge/pull/446 (2.6.0)
 
 # Updated - HoloInventory - 2.5.0-GTNH --> 2.5.4-GTNH
-## *2.5.4-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.5.3-GTNH...2.5.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.5.0-GTNH...2.5.4-GTNH
 
-## *2.5.3-GTNH*
->## What's Changed
->* Fixed improper null checks on fluid info handling by @basdxz in https://github.com/GTNewHorizons/HoloInventory/pull/51
->
->## New Contributors
->* @basdxz made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/51
->
->**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.5.2-GTNH...2.5.3-GTNH
->
-
-## *2.5.2-GTNH*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/HoloInventory/pull/50
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.5.1-GTNH...2.5.2-GTNH
->
-
-## *2.5.1-GTNH*
->## What's Changed
->* Only render overlay in post by @RecursivePineapple in https://github.com/GTNewHorizons/HoloInventory/pull/49
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/HoloInventory/pull/49
->
->**Full Changelog**: https://github.com/GTNewHorizons/HoloInventory/compare/2.5.0-GTNH...2.5.1-GTNH
->
+## What's Changed:
+>* Fixed improper null checks on fluid info handling by @basdxz in https://github.com/GTNewHorizons/HoloInventory/pull/51 (2.5.3-GTNH)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/HoloInventory/pull/50 (2.5.2-GTNH)
+>* Only render overlay in post by @RecursivePineapple in https://github.com/GTNewHorizons/HoloInventory/pull/49 (2.5.1-GTNH)
 
 # Updated - HydroEnergy - 1.4.3 --> 1.4.9
-## *1.4.9*
->## What's Changed
->* Change mixin targeting to be more compatible by @Cleptomania in https://github.com/GTNewHorizons/HydroEnergy/pull/36
->
->## New Contributors
->* @Cleptomania made their first contribution in https://github.com/GTNewHorizons/HydroEnergy/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.8...1.4.9
->
+**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.3...1.4.9
 
-## *1.4.8*
->**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.7...1.4.8
->
-
-## *1.4.7*
->## What's Changed
->* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/HydroEnergy/pull/35
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/HydroEnergy/pull/35
->
->**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.5...1.4.7
->
-
-## *1.4.5*
->## What's Changed
->* Stop using deprecated onScrewdriverRightClick by @Kogepan229 in https://github.com/GTNewHorizons/HydroEnergy/pull/34
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/HydroEnergy/pull/34
->
->**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.4...1.4.5
->
-
-## *1.4.4*
->## What's Changed
->* Small Fixes by @glowredman in https://github.com/GTNewHorizons/HydroEnergy/pull/33
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/HydroEnergy/compare/1.4.3...1.4.4
->
+## What's Changed:
+>* Change mixin targeting to be more compatible by @Cleptomania in https://github.com/GTNewHorizons/HydroEnergy/pull/36 (1.4.9)
+>* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/HydroEnergy/pull/35 (1.4.7)
+>* Stop using deprecated onScrewdriverRightClick by @Kogepan229 in https://github.com/GTNewHorizons/HydroEnergy/pull/34 (1.4.5)
+>* Small Fixes by @glowredman in https://github.com/GTNewHorizons/HydroEnergy/pull/33 (1.4.4)
 
 # Updated - IguanaTweaksTConstruct - 2.6.0 --> 2.6.4
-## *2.6.4*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/21
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/IguanaTweaksTConstruct/compare/2.6.3...2.6.4
->
+**Full Changelog**: https://github.com/GTNewHorizons/IguanaTweaksTConstruct/compare/2.6.0...2.6.4
 
-## *2.6.3*
->## What's Changed
->* Move clay quartz bucket resources from ticon by @koolkrafter5 in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/20
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/20
->
->**Full Changelog**: https://github.com/GTNewHorizons/IguanaTweaksTConstruct/compare/2.6.2...2.6.3
->
-
-## *2.6.2*
->## What's Changed
->* New clay buckets by @YannickMG in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/19
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/19
->
->**Full Changelog**: https://github.com/GTNewHorizons/IguanaTweaksTConstruct/compare/2.6.0...2.6.2
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/21 (2.6.4)
+>* Move clay quartz bucket resources from ticon by @koolkrafter5 in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/20 (2.6.3)
+>* New clay buckets by @YannickMG in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/19 (2.6.2)
 
 # Updated - InGame-Info-XML - 2.8.20 --> 2.8.25
-## *2.8.25*
->## What's Changed
->* Refactored `updateChildren` in `InfoText.java` to avoid a crash by @glektarssza in https://github.com/GTNewHorizons/InGame-Info-XML/pull/31
->
->## New Contributors
->* @glektarssza made their first contribution in https://github.com/GTNewHorizons/InGame-Info-XML/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/InGame-Info-XML/compare/2.8.23...2.8.25
->
+**Full Changelog**: https://github.com/GTNewHorizons/InGame-Info-XML/compare/2.8.20...2.8.25
 
-## *2.8.23*
->## What's Changed
->* Add delimiter formatting for life essence from BloodMagic by @Shinusei in https://github.com/GTNewHorizons/InGame-Info-XML/pull/30
->
->## New Contributors
->* @Shinusei made their first contribution in https://github.com/GTNewHorizons/InGame-Info-XML/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/InGame-Info-XML/compare/2.8.21...2.8.23
->
-
-## *2.8.21*
->## What's Changed
->* fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/InGame-Info-XML/pull/29
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InGame-Info-XML/compare/2.8.20...2.8.21
->
+## What's Changed:
+>* Refactored `updateChildren` in `InfoText.java` to avoid a crash by @glektarssza in https://github.com/GTNewHorizons/InGame-Info-XML/pull/31 (2.8.25)
+>* Add delimiter formatting for life essence from BloodMagic by @Shinusei in https://github.com/GTNewHorizons/InGame-Info-XML/pull/30 (2.8.23)
+>* fix WorldClient memory leak by @Alexdoru in https://github.com/GTNewHorizons/InGame-Info-XML/pull/29 (2.8.21)
 
 # Updated - Infernal-Mobs - 1.9.2-GTNH --> 1.10.2-GTNH
-## *1.10.2-GTNH*
->## What's Changed
->* Block webbing effect if mob griefing is disabled by @serenibyss in https://github.com/GTNewHorizons/Infernal-Mobs/pull/20
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Infernal-Mobs/pull/20
->
->**Full Changelog**: https://github.com/GTNewHorizons/Infernal-Mobs/compare/1.10.0-GTNH...1.10.2-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Infernal-Mobs/compare/1.9.2-GTNH...1.10.2-GTNH
 
-## *1.10.0-GTNH*
->## What's Changed
->* Move mob name above healthbar and adjust name colors by @wlhlm in https://github.com/GTNewHorizons/Infernal-Mobs/pull/18
->* Fix mob display name in boss bar by @wlhlm in https://github.com/GTNewHorizons/Infernal-Mobs/pull/17
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Infernal-Mobs/compare/1.9.1-GTNH...1.10.0-GTNH
->
+## What's Changed:
+>* Block webbing effect if mob griefing is disabled by @serenibyss in https://github.com/GTNewHorizons/Infernal-Mobs/pull/20 (1.10.2-GTNH)
+>* Move mob name above healthbar and adjust name colors by @wlhlm in https://github.com/GTNewHorizons/Infernal-Mobs/pull/18 (1.10.0-GTNH)
+>* Fix mob display name in boss bar by @wlhlm in https://github.com/GTNewHorizons/Infernal-Mobs/pull/17 (1.10.0-GTNH)
 
 # New Mod - InventoryBogoSorter:1.2.42-GTNH
-## *1.2.42-GTNH*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/107
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.41-GTNH...1.2.42-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.0-GTNH...1.2.42-GTNH
 
-## *1.2.41-GTNH*
->## What's Changed
->* Disable keybindings by default by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/104
->* Update Deps by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/105
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.40-GTNH...1.2.41-GTNH
->
-
-## *1.2.40-GTNH*
->## What's Changed
->* Refactor configuration to use GTNHLib's config system by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/93
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.39-GTNH...1.2.40-GTNH
->
-
-## *1.2.39-GTNH*
->## What's Changed
->* feat: add Actually Additions and GT6 support by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/97
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.38-GTNH...1.2.39-GTNH
->
-
-## *1.2.38-GTNH*
->## What's Changed
->* Fix the button's position inside the backpack by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/98
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.36-GTNH...1.2.38-GTNH
->
-
-## *1.2.36-GTNH*
->## What's Changed
->* Add precaution for future refill issues by @ThexXTURBOXx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/95
->
->## New Contributors
->* @ThexXTURBOXx made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/95
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.35-GTNH...1.2.36-GTNH
->
-
-## *1.2.35-GTNH*
->## What's Changed
->* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/91
->* Add tooltip on inventory buttons by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/92
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/91
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.34-GTNH...1.2.35-GTNH
->
-
-## *1.2.34-GTNH*
->## What's Changed
->* return empty string instead of crashing by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/86
->* Fixed right click crafting by @tyrannus00 in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/84
->
->## New Contributors
->* @tyrannus00 made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/84
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.31-GTNH...1.2.34-GTNH
->
-
-## *1.2.31-GTNH*
->## What's Changed
->* MUI2 update by @YannickMG in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/85
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/85
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.30-GTNH...1.2.31-GTNH
->
-
-## *1.2.30-GTNH*
->## What's Changed
->* Fix Tweak Button Position by @slprime in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/82
->
->## New Contributors
->* @slprime made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/82
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.28-GTNH...1.2.30-GTNH
->
-
-## *1.2.28-GTNH*
->## What's Changed
->* Fixes issue with dropoffTargetNames not working for localized games by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/81
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.27-GTNH...1.2.28-GTNH
->
-
-## *1.2.27-GTNH*
->## What's Changed
->* Add config option to specify custom dropoff targets by @MellowArpeggiation in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/78
->* CompactStorage  && EFR by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/79
->
->## New Contributors
->* @MellowArpeggiation made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/78
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.26-GTNH...1.2.27-GTNH
->
-
-## *1.2.26-GTNH*
->## What's Changed
->* Split up IC2 and IC2Classic checks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/75
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.25-GTNH...1.2.26-GTNH
->
-
-## *1.2.25-GTNH*
->## What's Changed
->* fix display name sorting crash on server by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/67
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.24-GTNH...1.2.25-GTNH
->
-
-## *1.2.24-GTNH*
->## What's Changed
->* Fix #64 by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/66
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.23-GTNH...1.2.24-GTNH
->
-
-## *1.2.23-GTNH*
->## What's Changed
->* Respect NBT by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/65
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.22-GTNH...1.2.23-GTNH
->
-
-## *1.2.22-GTNH*
->## What's Changed
->* Fix #45 by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/64
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.21-GTNH...1.2.22-GTNH
->
-
-## *1.2.21-GTNH*
->## What's Changed
->* BetterStorage+Fix-Dupe by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/62
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.20-GTNH...1.2.21-GTNH
->
-
-## *1.2.20-GTNH*
->## What's Changed
->* tinkers construct backpack  by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/59
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.19-GTNH...1.2.20-GTNH
->
-
-## *1.2.19-GTNH*
->## What's Changed
->* Fix compatiblity issues with MUI2 by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/57
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.18-GTNH...1.2.19-GTNH
->
-
-## *1.2.18-GTNH*
->## What's Changed
->* Fix cast by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/52
->* Backhand support by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/53
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.17-GTNH...1.2.18-GTNH
->
-
-## *1.2.17-GTNH*
->## What's Changed
->* fix 1x2 and 2x2 storage drawers by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/51
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.16-GTNH...1.2.17-GTNH
->
-
-## *1.2.16-GTNH*
->## What's Changed
->* Fix LMBTweakWithItem  by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/50
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.15-GTNH...1.2.16-GTNH
->
-
-## *1.2.15-GTNH*
->## What's Changed
->* Add a toggle for hotbar sorting by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/49
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.14-GTNH...1.2.15-GTNH
->
-
-## *1.2.14-GTNH*
->## What's Changed
->* Backport Quark's Usage Ticker by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/46
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.13-GTNH...1.2.14-GTNH
->
-
-## *1.2.13-GTNH*
->## What's Changed
->* Fixed Crash with Hotbar Swap by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/43
->* The Horse SlotGroup has been corrected by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/41
->* Fix infinity chest by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/44
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.11-GTNH...1.2.13-GTNH
->
-
-## *1.2.11-GTNH*
->## What's Changed
->* Update README.md by @Csstform in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/40
->* Battlegear crash by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/39
->* Compat by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/38
->
->## New Contributors
->* @Csstform made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/40
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.9-GTNH...1.2.11-GTNH
->
-
-## *1.2.9-GTNH*
->## What's Changed
->* Add chunk claim checking to dropoff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/35
->* Fixed a crash occurring with littleMaidMobX by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/36
->* Compat by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/34
->* Rework dropoff button + fix tooltip by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/37
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.6-GTNH...1.2.9-GTNH
->
-
-## *1.2.6-GTNH*
->## What's Changed
->* Merging Mousetweaks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/28
->* Check for players only by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/30
->* Config Changes by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/31
->* Adding missed check + use .copy() by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/32
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.3-GTNH...1.2.6-GTNH
->
-
-## *1.2.5-GTNH*
->## What's Changed
->* Merging Mousetweaks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/28
->* Check for players only by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/30
->* Config Changes by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/31
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.3-GTNH...1.2.5-GTNH
->
-
-## *1.2.3-GTNH*
->## What's Changed
->* remove log message by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/26
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.2-GTNH...1.2.3-GTNH
->
-
-## *1.2.2-GTNH*
->## What's Changed
->* Fix MetaBaseItem by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/25
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.1-GTNH...1.2.2-GTNH
->
-
-## *1.2.1-GTNH*
->## What's Changed
->* Server-check by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/21
->* Clean up by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/22
->* Split up GT5u and GT6 checks by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/24
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.2.0-GTNH...1.2.1-GTNH
->
-
-## *1.2.0-GTNH*
->## What's Changed
->* Add dropoff quota; default 2ms by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/14
->* Packet throttling by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/15
->* Merge craftingtweaks by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/17
->* Change the Dropoff Button texture by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/16
->* Update crafting tweaks name to be more specific by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/18
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.1.2-GTNH...1.2.0-GTNH
->
-
-## *1.1.2-GTNH*
->## What's Changed
->* Capture player from damageItem for the DamageHelper by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/13
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.1.1-GTNH...1.1.2-GTNH
->
-
-## *1.1.1-GTNH*
->## What's Changed
->* Add SideOnly when using client only stuff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.1-GTNH...1.1.1-GTNH
->
-
-## *1.1-GTNH*
->## What's Changed
->* Fix configs not saving on closing config gui by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/9
->* Add GT5u mod checks to RefillHandler by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/10
->* Add config to show/hide dropoff button in inventory by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/11
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/compare/1.0-GTNH...1.1-GTNH
->
-
-## *1.0-GTNH*
->## What's Changed
->* Fix sorting on a server by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/2
->* Alt hotbar scrolling by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/3
->* Say goodbye to GlStateManager by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/4
->* Dropoff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/6
->* First try at Refill by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/7
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/2
->* @0hwx made their first contribution in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/3
->
->**Full Changelog**: https://github.com/GTNewHorizons/InventoryBogoSorter/commits/1.0-GTNH
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/107 (1.2.42-GTNH)
+>* Disable keybindings by default by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/104 (1.2.41-GTNH)
+>* Update Deps by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/105 (1.2.41-GTNH)
+>* Refactor configuration to use GTNHLib's config system by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/93 (1.2.40-GTNH)
+>* feat: add Actually Additions and GT6 support by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/97 (1.2.39-GTNH)
+>* Fix the button's position inside the backpack by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/98 (1.2.38-GTNH)
+>* Add precaution for future refill issues by @ThexXTURBOXx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/95 (1.2.36-GTNH)
+>* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/91 (1.2.35-GTNH)
+>* Add tooltip on inventory buttons by @Alexdoru in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/92 (1.2.35-GTNH)
+>* return empty string instead of crashing by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/86 (1.2.34-GTNH)
+>* Fixed right click crafting by @tyrannus00 in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/84 (1.2.34-GTNH)
+>* MUI2 update by @YannickMG in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/85 (1.2.31-GTNH)
+>* Fix Tweak Button Position by @slprime in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/82 (1.2.30-GTNH)
+>* Fixes issue with dropoffTargetNames not working for localized games by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/81 (1.2.28-GTNH)
+>* Add config option to specify custom dropoff targets by @MellowArpeggiation in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/78 (1.2.27-GTNH)
+>* CompactStorage  && EFR by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/79 (1.2.27-GTNH)
+>* Split up IC2 and IC2Classic checks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/75 (1.2.26-GTNH)
+>* fix display name sorting crash on server by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/67 (1.2.25-GTNH)
+>* Fix #64 by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/66 (1.2.24-GTNH)
+>* Respect NBT by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/65 (1.2.23-GTNH)
+>* Fix #45 by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/64 (1.2.22-GTNH)
+>* BetterStorage+Fix-Dupe by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/62 (1.2.21-GTNH)
+>* tinkers construct backpack  by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/59 (1.2.20-GTNH)
+>* Fix compatiblity issues with MUI2 by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/57 (1.2.19-GTNH)
+>* Fix cast by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/52 (1.2.18-GTNH)
+>* Backhand support by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/53 (1.2.18-GTNH)
+>* fix 1x2 and 2x2 storage drawers by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/51 (1.2.17-GTNH)
+>* Fix LMBTweakWithItem  by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/50 (1.2.16-GTNH)
+>* Add a toggle for hotbar sorting by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/49 (1.2.15-GTNH)
+>* Backport Quark's Usage Ticker by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/46 (1.2.14-GTNH)
+>* Fixed Crash with Hotbar Swap by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/43 (1.2.13-GTNH)
+>* The Horse SlotGroup has been corrected by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/41 (1.2.13-GTNH)
+>* Fix infinity chest by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/44 (1.2.13-GTNH)
+>* Update README.md by @Csstform in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/40 (1.2.11-GTNH)
+>* Battlegear crash by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/39 (1.2.11-GTNH)
+>* Compat by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/38 (1.2.11-GTNH)
+>* Add chunk claim checking to dropoff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/35 (1.2.9-GTNH)
+>* Fixed a crash occurring with littleMaidMobX by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/36 (1.2.9-GTNH)
+>* Compat by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/34 (1.2.9-GTNH)
+>* Rework dropoff button + fix tooltip by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/37 (1.2.9-GTNH)
+>* Merging Mousetweaks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/28 (1.2.6-GTNH)
+>* Check for players only by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/30 (1.2.6-GTNH)
+>* Config Changes by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/31 (1.2.6-GTNH)
+>* Adding missed check + use .copy() by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/32 (1.2.6-GTNH)
+>* Merging Mousetweaks by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/28 (1.2.5-GTNH)
+>* Check for players only by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/30 (1.2.5-GTNH)
+>* Config Changes by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/31 (1.2.5-GTNH)
+>* remove log message by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/26 (1.2.3-GTNH)
+>* Fix MetaBaseItem by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/25 (1.2.2-GTNH)
+>* Server-check by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/21 (1.2.1-GTNH)
+>* Clean up by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/22 (1.2.1-GTNH)
+>* Split up GT5u and GT6 checks by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/24 (1.2.1-GTNH)
+>* Add dropoff quota; default 2ms by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/14 (1.2.0-GTNH)
+>* Packet throttling by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/15 (1.2.0-GTNH)
+>* Merge craftingtweaks by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/17 (1.2.0-GTNH)
+>* Change the Dropoff Button texture by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/16 (1.2.0-GTNH)
+>* Update crafting tweaks name to be more specific by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/18 (1.2.0-GTNH)
+>* Capture player from damageItem for the DamageHelper by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/13 (1.1.2-GTNH)
+>* Add SideOnly when using client only stuff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/12 (1.1.1-GTNH)
+>* Fix configs not saving on closing config gui by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/9 (1.1-GTNH)
+>* Add GT5u mod checks to RefillHandler by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/10 (1.1-GTNH)
+>* Add config to show/hide dropoff button in inventory by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/11 (1.1-GTNH)
+>* Fix sorting on a server by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/2 (1.0-GTNH)
+>* Alt hotbar scrolling by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/3 (1.0-GTNH)
+>* Say goodbye to GlStateManager by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/4 (1.0-GTNH)
+>* Dropoff by @Caedis in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/6 (1.0-GTNH)
+>* First try at Refill by @0hwx in https://github.com/GTNewHorizons/InventoryBogoSorter/pull/7 (1.0-GTNH)
 
 # Updated - IronChestMinecarts - 1.1.0 --> 1.2.0
-## *1.2.0*
->## What's Changed
->* add consistent naming with Railcraft if Railcraft is installed by @2ndDerivative in https://github.com/GTNewHorizons/IronChestMinecarts/pull/8
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/IronChestMinecarts/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/IronChestMinecarts/compare/1.1.0...1.2.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/IronChestMinecarts/compare/1.1.0...1.2.0
+
+## What's Changed:
+>* add consistent naming with Railcraft if Railcraft is installed by @2ndDerivative in https://github.com/GTNewHorizons/IronChestMinecarts/pull/8 (1.2.0)
 
 # New Mod - IronTankMinecarts:1.0.9
-## *1.0.9*
->## What's Changed
->* Fix version info by @serenibyss in https://github.com/GTNewHorizons/IronTankMinecarts/pull/3
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/IronTankMinecarts/pull/3
->
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.8...1.0.9
->
+**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.0...1.0.9
 
-## *1.0.8*
->## What's Changed
->* add name consistency with Railcraft by @2ndDerivative in https://github.com/GTNewHorizons/IronTankMinecarts/pull/2
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/IronTankMinecarts/pull/2
->
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.7...1.0.8
->
-
-## *1.0.7*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.6...1.0.7
->
-
-## *1.0.6*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.5...1.0.6
->
-
-## *1.0.5*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.4...1.0.5
->
-
-## *1.0.4*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.3...1.0.4
->
-
-## *1.0.3*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/compare/1.0.2...1.0.3
->
-
-## *1.0.2*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/commits/1.0.2
->
-
-## *1.0.0*
->**Full Changelog**: https://github.com/GTNewHorizons/IronTankMinecarts/commits/1.0.0
->
+## What's Changed:
+>* Fix version info by @serenibyss in https://github.com/GTNewHorizons/IronTankMinecarts/pull/3 (1.0.9)
+>* add name consistency with Railcraft by @2ndDerivative in https://github.com/GTNewHorizons/IronTankMinecarts/pull/2 (1.0.8)
 
 # Updated - Irontanks - 1.3.0 --> 1.4.2
-## *1.4.2*
->**Full Changelog**: https://github.com/GTNewHorizons/Irontanks/compare/1.4.1...1.4.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/Irontanks/compare/1.3.0...1.4.2
 
-## *1.4.1*
->## What's Changed
->* fix upgrade logic by @2ndDerivative in https://github.com/GTNewHorizons/Irontanks/pull/14
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Irontanks/pull/14
->
->**Full Changelog**: https://github.com/GTNewHorizons/Irontanks/compare/1.4.0...1.4.1
->
-
-## *1.4.0*
->**Full Changelog**: https://github.com/GTNewHorizons/Irontanks/compare/1.3.0...1.4.0
->
+## What's Changed:
+>* fix upgrade logic by @2ndDerivative in https://github.com/GTNewHorizons/Irontanks/pull/14 (1.4.1)
 
 # Updated - Jabba - 1.4.7 --> 1.5.10
-## *1.5.10*
->## What's Changed
->* Add new "mixed" behavior for dropping items when breaking a barrel by @Alexdoru in https://github.com/GTNewHorizons/Jabba/pull/44
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/44
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.8...1.5.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.4.7...1.5.10
 
-## *1.5.8*
->## What's Changed
->* Drop all as 1 big stack instead by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/43
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.6...1.5.8
->
+## What's Changed:
+>* Add new "mixed" behavior for dropping items when breaking a barrel by @Alexdoru in https://github.com/GTNewHorizons/Jabba/pull/44 (1.5.10)
+>* Drop all as 1 big stack instead by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/43 (1.5.8)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Jabba/pull/42 (1.5.6)
+>* Drop all stacks instead of just 64 to match storage drawers by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/41 (1.5.5)
+>* barrels insert extracted items into inventory before dropping on floor by @asquared31415 in https://github.com/GTNewHorizons/Jabba/pull/39 (1.5.4)
+>* Add EFR Barrel Support by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/38 (1.5.3)
+>* Dolly support for Bibliocraft labels by @YannickMG in https://github.com/GTNewHorizons/Jabba/pull/37 (1.5.2)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Jabba/pull/36 (1.5.1)
+>* update tooltip to reflect config option by @brandyyn in https://github.com/GTNewHorizons/Jabba/pull/35 (1.5.0)
 
-## *1.5.6*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Jabba/pull/42
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/42
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.5...1.5.6
->
-
-## *1.5.5*
->## What's Changed
->* Drop all stacks instead of just 64 to match storage drawers by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/41
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.4...1.5.5
->
-
-## *1.5.4*
->## What's Changed
->* barrels insert extracted items into inventory before dropping on floor by @asquared31415 in https://github.com/GTNewHorizons/Jabba/pull/39
->
->## New Contributors
->* @asquared31415 made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/39
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.3...1.5.4
->
-
-## *1.5.3*
->## What's Changed
->* Add EFR Barrel Support by @Caedis in https://github.com/GTNewHorizons/Jabba/pull/38
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/38
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.2...1.5.3
->
-
-## *1.5.2*
->## What's Changed
->* Dolly support for Bibliocraft labels by @YannickMG in https://github.com/GTNewHorizons/Jabba/pull/37
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/37
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.1...1.5.2
->
-
-## *1.5.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Jabba/pull/36
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Jabba/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.5.0...1.5.1
->
-
-## *1.5.0*
->## What's Changed
->* update tooltip to reflect config option by @brandyyn in https://github.com/GTNewHorizons/Jabba/pull/35
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Jabba/compare/1.4.6...1.5.0
->
-
+# Updated - JourneyMap - 5.2.8-fairplay --> 5.2.10-fairplay
+Mod is client-side only.
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - LittleTiles - 1.4.0-GTNH --> 1.5.11-GTNH
-## *1.5.11-GTNH*
->## What's Changed
->* Big Refactoring and a fix for marked mode by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/13
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.5.8-GTNH...1.5.11-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.4.0-GTNH...1.5.11-GTNH
 
-## *1.5.8-GTNH*
->## What's Changed
->* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/16
->* Mark ISBRH as thread safe by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/18
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.5.6-GTNH...1.5.8-GTNH
->
-
-## *1.5.6-GTNH*
->## What's Changed
->* Move items into own creative tab by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/15
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.5.4-GTNH...1.5.6-GTNH
->
-
-## *1.5.4-GTNH*
->## What's Changed
->* Make Tiles cache their light value by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/17
->* Prevent texture shifting when using saw by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/14
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.5.2-GTNH...1.5.4-GTNH
->
-
-## *1.5.2-GTNH*
->## What's Changed
->* Remove threaded renderer and cleanup by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.5.0-GTNH...1.5.2-GTNH
->
-
-## *1.5.0-GTNH*
->## What's Changed
->* Merge CreativeCore into LittleTiles by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/11
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/LittleTiles/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/LittleTiles/compare/1.4.0-GTNH...1.5.0-GTNH
->
+## What's Changed:
+>* Big Refactoring and a fix for marked mode by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/13 (1.5.11-GTNH)
+>* Add functionality to fake blockId for shaders by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/16 (1.5.8-GTNH)
+>* Mark ISBRH as thread safe by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/18 (1.5.8-GTNH)
+>* Move items into own creative tab by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/15 (1.5.6-GTNH)
+>* Make Tiles cache their light value by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/17 (1.5.4-GTNH)
+>* Prevent texture shifting when using saw by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/14 (1.5.4-GTNH)
+>* Remove threaded renderer and cleanup by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/12 (1.5.2-GTNH)
+>* Merge CreativeCore into LittleTiles by @DarkShadow44 in https://github.com/GTNewHorizons/LittleTiles/pull/11 (1.5.0-GTNH)
 
 # Updated - LogisticsPipes - 1.3.6-GTNH --> 1.4.20-GTNH
-## *1.4.20-GTNH*
->## What's Changed
->* Update OpenComputers signal pushing to use sendToReachable by @DerekChan65535 in https://github.com/GTNewHorizons/LogisticsPipes/pull/96
->* Fix LP `isFluidContainer` and `getFluidFromContainer`  by @DerekChan65535 in https://github.com/GTNewHorizons/LogisticsPipes/pull/97
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.18-GTNH...1.4.20-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.3.6-GTNH...1.4.20-GTNH
 
-## *1.4.18-GTNH*
->## What's Changed
->* Fix wrong type of Collection being casted to by @glowredman in https://github.com/GTNewHorizons/LogisticsPipes/pull/93
->* Open computer improvements by @DeckerCHAN in https://github.com/GTNewHorizons/LogisticsPipes/pull/94
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.17-GTNH...1.4.18-GTNH
->
-
-## *1.4.17-GTNH*
->## What's Changed
->* Convert some ASM to Mixins by @glowredman in https://github.com/GTNewHorizons/LogisticsPipes/pull/90
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.15-GTNH...1.4.17-GTNH
->
-
-## *1.4.15-GTNH*
->## What's Changed
->* Adapt to breaking changes of MUI2 by @zyf051520 in https://github.com/GTNewHorizons/LogisticsPipes/pull/92
->* Added support ComputerCraft components and functions for OpenComputers by @Viptunbeqwfwew in https://github.com/GTNewHorizons/LogisticsPipes/pull/84
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/92
->* @Viptunbeqwfwew made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/84
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.10-GTNH...1.4.15-GTNH
->
-
-## *1.4.10-GTNH*
->## What's Changed
->* Update SinkReply to Fix Type Filter ItemSink Priority Being Too High by @DeckerCHAN in https://github.com/GTNewHorizons/LogisticsPipes/pull/88
->* Render crafting result of ModuleCrafter(MK2/MK3) item on sneak by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/85
->
->## New Contributors
->* @DeckerCHAN made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.7-GTNH...1.4.10-GTNH
->
-
-## *1.4.7-GTNH*
->## What's Changed
->* Replace the search bar in logistics request table by @OpusC in https://github.com/GTNewHorizons/LogisticsPipes/pull/87
->
->## New Contributors
->* @OpusC made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/87
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.5-GTNH...1.4.7-GTNH
->
-
-## *1.4.5-GTNH*
->## What's Changed
->* issue 17194. Fix integration ModuleExtractor and drawers by @qqqqqq452 in https://github.com/GTNewHorizons/LogisticsPipes/pull/86
->
->## New Contributors
->* @qqqqqq452 made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/86
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.2-GTNH...1.4.5-GTNH
->
-
-## *1.4.2-GTNH*
->## What's Changed
->* Search in the contents of Universal Fluid Cells by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/83
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.1-GTNH...1.4.2-GTNH
->
-
-## *1.4.1-GTNH*
->## What's Changed
->* Fix: Client crashes when inserting renamed crafting module into chassis. by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/82
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.4.0-GTNH...1.4.1-GTNH
->
-
-## *1.4.0-GTNH*
->## What's Changed
->* Fix memory leak in server packet decompressor by @amyavi in https://github.com/GTNewHorizons/LogisticsPipes/pull/81
->
->## New Contributors
->* @amyavi made their first contribution in https://github.com/GTNewHorizons/LogisticsPipes/pull/81
->
->**Full Changelog**: https://github.com/GTNewHorizons/LogisticsPipes/compare/1.3.6-GTNH...1.4.0-GTNH
->
+## What's Changed:
+>* Update OpenComputers signal pushing to use sendToReachable by @DerekChan65535 in https://github.com/GTNewHorizons/LogisticsPipes/pull/96 (1.4.20-GTNH)
+>* Fix LP `isFluidContainer` and `getFluidFromContainer`  by @DerekChan65535 in https://github.com/GTNewHorizons/LogisticsPipes/pull/97 (1.4.20-GTNH)
+>* Fix wrong type of Collection being casted to by @glowredman in https://github.com/GTNewHorizons/LogisticsPipes/pull/93 (1.4.18-GTNH)
+>* Open computer improvements by @DeckerCHAN in https://github.com/GTNewHorizons/LogisticsPipes/pull/94 (1.4.18-GTNH)
+>* Convert some ASM to Mixins by @glowredman in https://github.com/GTNewHorizons/LogisticsPipes/pull/90 (1.4.17-GTNH)
+>* Adapt to breaking changes of MUI2 by @zyf051520 in https://github.com/GTNewHorizons/LogisticsPipes/pull/92 (1.4.15-GTNH)
+>* Added support ComputerCraft components and functions for OpenComputers by @Viptunbeqwfwew in https://github.com/GTNewHorizons/LogisticsPipes/pull/84 (1.4.15-GTNH)
+>* Update SinkReply to Fix Type Filter ItemSink Priority Being Too High by @DeckerCHAN in https://github.com/GTNewHorizons/LogisticsPipes/pull/88 (1.4.10-GTNH)
+>* Render crafting result of ModuleCrafter(MK2/MK3) item on sneak by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/85 (1.4.10-GTNH)
+>* Replace the search bar in logistics request table by @OpusC in https://github.com/GTNewHorizons/LogisticsPipes/pull/87 (1.4.7-GTNH)
+>* issue 17194. Fix integration ModuleExtractor and drawers by @qqqqqq452 in https://github.com/GTNewHorizons/LogisticsPipes/pull/86 (1.4.5-GTNH)
+>* Search in the contents of Universal Fluid Cells by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/83 (1.4.2-GTNH)
+>* Fix: Client crashes when inserting renamed crafting module into chassis. by @godrja in https://github.com/GTNewHorizons/LogisticsPipes/pull/82 (1.4.1-GTNH)
+>* Fix memory leak in server packet decompressor by @amyavi in https://github.com/GTNewHorizons/LogisticsPipes/pull/81 (1.4.0-GTNH)
 
 # Updated - LootGames - 2.1.4 --> 2.2.0
-## *2.2.0*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/LootGames/pull/18
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/LootGames/compare/2.1.4...2.2.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/LootGames/compare/2.1.4...2.2.0
+
+## What's Changed:
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/LootGames/pull/18 (2.2.0)
 
 # Updated - MagicBees - 2.9.1-GTNH --> 2.9.4-GTNH
-## *2.9.4-GTNH*
->## What's Changed
->* Add missing equals sign. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/MagicBees/pull/55
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/55
->
->**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.9.3-GTNH...2.9.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.9.1-GTNH...2.9.4-GTNH
 
-## *2.9.3-GTNH*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/MagicBees/pull/54
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/54
->
->**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.9.2-GTNH...2.9.3-GTNH
->
-
-## *2.9.2-GTNH*
->## What's Changed
->* Give Enchanted Earth some minimal hardness by @YannickMG in https://github.com/GTNewHorizons/MagicBees/pull/52
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/MagicBees/pull/52
->
->**Full Changelog**: https://github.com/GTNewHorizons/MagicBees/compare/2.9.1-GTNH...2.9.2-GTNH
->
+## What's Changed:
+>* Add missing equals sign. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/MagicBees/pull/55 (2.9.4-GTNH)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/MagicBees/pull/54 (2.9.3-GTNH)
+>* Give Enchanted Earth some minimal hardness by @YannickMG in https://github.com/GTNewHorizons/MagicBees/pull/52 (2.9.2-GTNH)
 
 # Updated - MalisisDoors - 1.18.0-GTNH --> 1.18.1-GTNH
-## *1.18.1-GTNH*
->## What's Changed
->* Fixed configuration comments always beginning with "null" by @Charsy89 in https://github.com/GTNewHorizons/MalisisDoors/pull/21
->
->## New Contributors
->* @Charsy89 made their first contribution in https://github.com/GTNewHorizons/MalisisDoors/pull/21
->
->**Full Changelog**: https://github.com/GTNewHorizons/MalisisDoors/compare/1.18.0-GTNH...1.18.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/MalisisDoors/compare/1.18.0-GTNH...1.18.1-GTNH
+
+## What's Changed:
+>* Fixed configuration comments always beginning with "null" by @Charsy89 in https://github.com/GTNewHorizons/MalisisDoors/pull/21 (1.18.1-GTNH)
 
 # Updated - Mantle - 0.5.0 --> 0.5.1
-## *0.5.1*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Mantle/pull/10
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Mantle/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/Mantle/compare/0.5.0...0.5.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/Mantle/compare/0.5.0...0.5.1
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Mantle/pull/10 (0.5.1)
 
 # New Mod - MatterManipulator:0.0.35-GTNH
-## *0.0.35-GTNH*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/MatterManipulator/pull/8
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/MatterManipulator/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.34-GTNH...0.0.35-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.14...0.0.35-GTNH
 
-## *0.0.34-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.33-GTNH...0.0.34-GTNH
->
-
-## *0.0.33-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.31-GTNH...0.0.33-GTNH
->
-
-## *0.0.32-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.31-GTNH...0.0.32-GTNH
->
-
-## *0.0.31-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.30-GTNH...0.0.31-GTNH
->
-
-## *0.0.30-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.29-GTNH...0.0.30-GTNH
->
-
-## *0.0.29-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.28-GTNH...0.0.29-GTNH
->
-
-## *0.0.28-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.27-GTNH...0.0.28-GTNH
->
-
-## *0.0.27-GTNH*
->## What's Changed
->* Stop using deprecated onWireCutterRightClick by @Kogepan229 in https://github.com/GTNewHorizons/MatterManipulator/pull/5
->* Fix cover copy/paste code by @serenibyss in https://github.com/GTNewHorizons/MatterManipulator/pull/6
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/MatterManipulator/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.25-GTNH...0.0.27-GTNH
->
-
-## *0.0.25-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.24-GTNH...0.0.25-GTNH
->
-
-## *0.0.24-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.23-GTNH...0.0.24-GTNH
->
-
-## *0.0.23-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.22-GTNH...0.0.23-GTNH
->
-
-## *0.0.22-GTNH*
->## What's Changed
->* Move recipes to coremod by @serenibyss in https://github.com/GTNewHorizons/MatterManipulator/pull/3
->* removed the gt++ circuits by @Dream-Master in https://github.com/GTNewHorizons/MatterManipulator/pull/4
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/MatterManipulator/pull/3
->
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.21-GTNH...0.0.22-GTNH
->
-
-## *0.0.21-GTNH*
->## What's Changed
->* Update ManipulatorRecipes.java by @Breviel in https://github.com/GTNewHorizons/MatterManipulator/pull/2
->
->## New Contributors
->* @Breviel made their first contribution in https://github.com/GTNewHorizons/MatterManipulator/pull/2
->
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.20-GTNH...0.0.21-GTNH
->
-
-## *0.0.20-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.19-GTNH...0.0.20-GTNH
->
-
-## *0.0.19-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.18-GTNH...0.0.19-GTNH
->
-
-## *0.0.18-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.17...0.0.18-GTNH
->
-
-## *0.0.17*
->## What's Changed
->* change scanning time to new GT format by @Dream-Master in https://github.com/GTNewHorizons/MatterManipulator/pull/1
->
->## New Contributors
->* @Dream-Master made their first contribution in https://github.com/GTNewHorizons/MatterManipulator/pull/1
->
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.14...0.0.17
->
-
-## *0.0.15*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/compare/0.0.14...0.0.15
->
-
-## *0.0.14*
->**Full Changelog**: https://github.com/GTNewHorizons/MatterManipulator/commits/0.0.14
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/MatterManipulator/pull/8 (0.0.35-GTNH)
+>* Stop using deprecated onWireCutterRightClick by @Kogepan229 in https://github.com/GTNewHorizons/MatterManipulator/pull/5 (0.0.27-GTNH)
+>* Fix cover copy/paste code by @serenibyss in https://github.com/GTNewHorizons/MatterManipulator/pull/6 (0.0.27-GTNH)
+>* Move recipes to coremod by @serenibyss in https://github.com/GTNewHorizons/MatterManipulator/pull/3 (0.0.22-GTNH)
+>* removed the gt++ circuits by @Dream-Master in https://github.com/GTNewHorizons/MatterManipulator/pull/4 (0.0.22-GTNH)
+>* Update ManipulatorRecipes.java by @Breviel in https://github.com/GTNewHorizons/MatterManipulator/pull/2 (0.0.21-GTNH)
+>* change scanning time to new GT format by @Dream-Master in https://github.com/GTNewHorizons/MatterManipulator/pull/1 (0.0.17)
 
 # Updated - Minecraft-Backpack-Mod - 2.4.3-GTNH --> 2.5.4-GTNH
-## *2.5.4-GTNH*
->## What's Changed
->* feat: add adaptive big backpack screen by @TimeConqueror in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/14
->
->## New Contributors
->* @TimeConqueror made their first contribution in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/14
->
->**Full Changelog**: https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/compare/2.5.0-GTNH...2.5.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/compare/2.4.3-GTNH...2.5.4-GTNH
 
-## *2.5.0-GTNH*
->## What's Changed
->* Make Tier 2 craftable (non-GTNH only) by @Pilzinsel64 in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/13
->
->## New Contributors
->* @Pilzinsel64 made their first contribution in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/13
->
->**Full Changelog**: https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/compare/2.4.3-GTNH...2.5.0-GTNH
->
+## What's Changed:
+>* feat: add adaptive big backpack screen by @TimeConqueror in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/14 (2.5.4-GTNH)
+>* Make Tier 2 craftable (non-GTNH only) by @Pilzinsel64 in https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/13 (2.5.0-GTNH)
 
 # Updated - Minetweaker-Gregtech-5-Addon - 2.2.4 --> 2.3.1
-## *2.3.1*
->## What's Changed
->* Fix fusion threshold by @serenibyss in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/71
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/71
->
->**Full Changelog**: https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/compare/2.3.0...2.3.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/compare/2.2.4...2.3.1
 
-## *2.3.0*
->## What's Changed
->* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/70
->
->## New Contributors
->* @StaffiX made their first contribution in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/70
->
->**Full Changelog**: https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/compare/2.2.4...2.3.0
->
+## What's Changed:
+>* Fix fusion threshold by @serenibyss in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/71 (2.3.1)
+>* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon/pull/70 (2.3.0)
 
 # Updated - Mobs-Info - 0.4.7-GTNH --> 0.5.2-GTNH
-## *0.5.2-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.5.1-GTNH...0.5.2-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.4.7-GTNH...0.5.2-GTNH
 
-## *0.5.1-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.5.0-GTNH...0.5.1-GTNH
->
-
-## *0.5.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Mobs-Info/compare/0.4.7-GTNH...0.5.0-GTNH
->
-
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - ModTweaker - 0.11.0 --> 0.12.0
-## *0.12.0*
->**Full Changelog**: https://github.com/GTNewHorizons/ModTweaker/compare/0.11.0...0.12.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/ModTweaker/compare/0.11.0...0.12.0
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # New Mod - ModernMarkings:0.3.12-1.7.10
-## *0.3.12-1.7.10*
->## What's Changed
->* More Floor Path Markings by @DangerousMilk in https://github.com/GTNewHorizons/ModernMarkings/pull/19
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.10-1.7.10...0.3.12-1.7.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/v0.0.1...0.3.12-1.7.10
 
-## *0.3.10-1.7.10*
->## What's Changed
->* Add markings for power plants by @t3435ryt in https://github.com/GTNewHorizons/ModernMarkings/pull/18
->
->## New Contributors
->* @t3435ryt made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/18
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.7-1.7.10...0.3.10-1.7.10
->
-
-## *0.3.7-1.7.10*
->## What's Changed
->* Made WallMarking Block Bounds Flush With The Wall.  by @DangerousMilk in https://github.com/GTNewHorizons/ModernMarkings/pull/17
->
->## New Contributors
->* @DangerousMilk made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/17
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.5-1.7.10...0.3.7-1.7.10
->
-
-## *0.3.5-1.7.10*
->## What's Changed
->* Revert previous PR by @Alexdoru in https://github.com/GTNewHorizons/ModernMarkings/pull/15
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/15
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.4-1.7.10...0.3.5-1.7.10
->
-
-## *0.3.4-1.7.10*
->## What's Changed
->* Fix Y Letter Height by @jude123412 in https://github.com/GTNewHorizons/ModernMarkings/pull/11
->* Add flags by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/13
->
->## New Contributors
->* @jude123412 made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.3-1.7.10...0.3.4-1.7.10
->
-
-## *0.3.3-1.7.10*
->## What's Changed
->* Alphabet by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/10
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.2-1.7.10...0.3.3-1.7.10
->
-
-## *0.3.2-1.7.10*
->## What's Changed
->* Move markings out more by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/8
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/0.3.1-1.7.10...0.3.2-1.7.10
->
-
-## *0.3.1-1.7.10*
->## What's Changed
->* Update README.md by @Caedis in https://github.com/GTNewHorizons/ModernMarkings/pull/1
->* Add CF/MN project info by @mitchej123 in https://github.com/GTNewHorizons/ModernMarkings/pull/3
->* Changes as per glowredman's comments by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/2
->* Various lang fixes by @FourIsTheNumber in https://github.com/GTNewHorizons/ModernMarkings/pull/5
->* Add hazard diamond by @FourIsTheNumber in https://github.com/GTNewHorizons/ModernMarkings/pull/6
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/1
->* @mitchej123 made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/3
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/2
->* @FourIsTheNumber made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/v0.0.2...0.3.1-1.7.10
->
-
-## *0.3.0-1.7.10*
->## What's Changed
->* Update README.md by @Caedis in https://github.com/GTNewHorizons/ModernMarkings/pull/1
->* Add CF/MN project info by @mitchej123 in https://github.com/GTNewHorizons/ModernMarkings/pull/3
->* Changes as per glowredman's comments by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/2
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/1
->* @mitchej123 made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/3
->* @jurrejelle made their first contribution in https://github.com/GTNewHorizons/ModernMarkings/pull/2
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/v0.0.2...0.3.0-1.7.10
->
-
-## *v0.0.2*
->**Full Changelog**: https://github.com/GTNewHorizons/ModernMarkings/compare/v0.0.1...v0.0.2
->
+## What's Changed:
+>* More Floor Path Markings by @DangerousMilk in https://github.com/GTNewHorizons/ModernMarkings/pull/19 (0.3.12-1.7.10)
+>* Add markings for power plants by @t3435ryt in https://github.com/GTNewHorizons/ModernMarkings/pull/18 (0.3.10-1.7.10)
+>* Made WallMarking Block Bounds Flush With The Wall.  by @DangerousMilk in https://github.com/GTNewHorizons/ModernMarkings/pull/17 (0.3.7-1.7.10)
+>* Revert previous PR by @Alexdoru in https://github.com/GTNewHorizons/ModernMarkings/pull/15 (0.3.5-1.7.10)
+>* Fix Y Letter Height by @jude123412 in https://github.com/GTNewHorizons/ModernMarkings/pull/11 (0.3.4-1.7.10)
+>* Add flags by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/13 (0.3.4-1.7.10)
+>* Alphabet by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/10 (0.3.3-1.7.10)
+>* Move markings out more by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/8 (0.3.2-1.7.10)
+>* Update README.md by @Caedis in https://github.com/GTNewHorizons/ModernMarkings/pull/1 (0.3.1-1.7.10)
+>* Add CF/MN project info by @mitchej123 in https://github.com/GTNewHorizons/ModernMarkings/pull/3 (0.3.1-1.7.10)
+>* Changes as per glowredman's comments by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/2 (0.3.1-1.7.10)
+>* Various lang fixes by @FourIsTheNumber in https://github.com/GTNewHorizons/ModernMarkings/pull/5 (0.3.1-1.7.10)
+>* Add hazard diamond by @FourIsTheNumber in https://github.com/GTNewHorizons/ModernMarkings/pull/6 (0.3.1-1.7.10)
+>* Update README.md by @Caedis in https://github.com/GTNewHorizons/ModernMarkings/pull/1 (0.3.0-1.7.10)
+>* Add CF/MN project info by @mitchej123 in https://github.com/GTNewHorizons/ModernMarkings/pull/3 (0.3.0-1.7.10)
+>* Changes as per glowredman's comments by @jurrejelle in https://github.com/GTNewHorizons/ModernMarkings/pull/2 (0.3.0-1.7.10)
 
 # Updated - ModularUI - 1.2.18 --> 1.2.20
-## *1.2.20*
->## What's Changed
->* Fix FluidSlotWidget fluidChanged detect by @Taskeren in https://github.com/GTNewHorizons/ModularUI/pull/90
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/ModularUI/pull/90
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI/compare/1.2.18...1.2.20
->
+**Full Changelog**: https://github.com/GTNewHorizons/ModularUI/compare/1.2.18...1.2.20
+
+## What's Changed:
+>* Fix FluidSlotWidget fluidChanged detect by @Taskeren in https://github.com/GTNewHorizons/ModularUI/pull/90 (1.2.20)
 
 # Updated - ModularUI2 - 2.1.16-1.7.10 --> 2.2.15-1.7.10
-## *2.2.15-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.15-1.7.10 -->
->
->## What's Changed
->* Add grouping support to number text fields by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/34
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.14-1.7.10...2.2.15-1.7.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.1.16-1.7.10...2.2.15-1.7.10
 
-## *2.2.14-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.14-1.7.10 -->
->
->## What's Changed
->* Fix clicking slot outside main panel toss the item by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/33
->* Sync upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/35
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.13-1.7.10...2.2.14-1.7.10
->
-
-## *2.2.13-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.13-1.7.10 -->
->
->## What's Changed
->* Fix Nei Search Double Delete by @slprime in https://github.com/GTNewHorizons/ModularUI2/pull/32
->
->## New Contributors
->* @slprime made their first contribution in https://github.com/GTNewHorizons/ModularUI2/pull/32
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.12-1.7.10...2.2.13-1.7.10
->
-
-## *2.2.12-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.12-1.7.10 -->
->
->## What's Changed
->* Sync with upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/31
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.11-1.7.10...2.2.12-1.7.10
->
-
-## *2.2.11-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.11-1.7.10 -->
->
->## What's Changed
->* Fix crash when NEI is not yet available by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/30
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.10-1.7.10...2.2.11-1.7.10
->
-
-## *2.2.10-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.10-1.7.10 -->
->
->## What's Changed
->* Remove unused long slot support by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/28
->* Sync with upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/29
->
->## New Contributors
->* @brachy84 made their first contribution in https://github.com/GTNewHorizons/ModularUI2/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.9-1.7.10...2.2.10-1.7.10
->
-
-## *2.2.9-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.9-1.7.10 -->
->
->## What's Changed
->* Fix shift click a ModularSlot with ignoreMaxStackSize=true void items by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/25
->* Fix Widget listener merge by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/26
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/ModularUI2/pull/25
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.8-1.7.10...2.2.9-1.7.10
->
-
-## *2.2.8-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.8-1.7.10 -->
->
->## What's Changed
->* rework number formatter to be more modular and better by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/24
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.7-1.7.10...2.2.8-1.7.10
->
-
-## *2.2.7-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.7-1.7.10 -->
->
->## What's Changed
->* Add ItemStackGuiFactory by @FourIsTheNumber in https://github.com/GTNewHorizons/ModularUI2/pull/23
->
->## New Contributors
->* @FourIsTheNumber made their first contribution in https://github.com/GTNewHorizons/ModularUI2/pull/23
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.6-1.7.10...2.2.7-1.7.10
->
-
-## *2.2.6-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.6-1.7.10 -->
->
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.5-1.7.10...2.2.6-1.7.10
->
-
-## *2.2.5-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.5-1.7.10 -->
->
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.4-1.7.10...2.2.5-1.7.10
->
-
-## *2.2.4-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.4-1.7.10 -->
->
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.3-1.7.10...2.2.4-1.7.10
->
-
-## *2.2.3-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.3-1.7.10 -->
->
->## What's Changed
->* Add back GlStateManager by @miozune in https://github.com/GTNewHorizons/ModularUI2/pull/22
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.2-1.7.10...2.2.3-1.7.10
->
-
-## *2.2.2-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.2-1.7.10 -->
->
->## What's Changed
->* Shadow mXparser so we don't need to distribute it as a separate file by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/21
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.1-1.7.10...2.2.2-1.7.10
->
-
-## *2.2.1-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.1-1.7.10 -->
->
->## What's Changed
->* January upstream catchup. WIP by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/20
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.2.0-1.7.10...2.2.1-1.7.10
->
-
-## *2.2.0-1.7.10*
-><!-- Release notes generated using configuration in .github/release.yml at 2.2.0-1.7.10 -->
->
->## What's Changed
->* Catch up to upstream by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/19
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/ModularUI2/pull/19
->
->**Full Changelog**: https://github.com/GTNewHorizons/ModularUI2/compare/2.1.16-1.7.10...2.2.0-1.7.10
->
+## What's Changed:
+>* Add grouping support to number text fields by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/34 (2.2.15-1.7.10)
+>* Fix clicking slot outside main panel toss the item by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/33 (2.2.14-1.7.10)
+>* Sync upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/35 (2.2.14-1.7.10)
+>* Fix Nei Search Double Delete by @slprime in https://github.com/GTNewHorizons/ModularUI2/pull/32 (2.2.13-1.7.10)
+>* Sync with upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/31 (2.2.12-1.7.10)
+>* Fix crash when NEI is not yet available by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/30 (2.2.11-1.7.10)
+>* Remove unused long slot support by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/28 (2.2.10-1.7.10)
+>* Sync with upstream by @brachy84 in https://github.com/GTNewHorizons/ModularUI2/pull/29 (2.2.10-1.7.10)
+>* Fix shift click a ModularSlot with ignoreMaxStackSize=true void items by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/25 (2.2.9-1.7.10)
+>* Fix Widget listener merge by @zyf051520 in https://github.com/GTNewHorizons/ModularUI2/pull/26 (2.2.9-1.7.10)
+>* rework number formatter to be more modular and better by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/24 (2.2.8-1.7.10)
+>* Add ItemStackGuiFactory by @FourIsTheNumber in https://github.com/GTNewHorizons/ModularUI2/pull/23 (2.2.7-1.7.10)
+>* Add back GlStateManager by @miozune in https://github.com/GTNewHorizons/ModularUI2/pull/22 (2.2.3-1.7.10)
+>* Shadow mXparser so we don't need to distribute it as a separate file by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/21 (2.2.2-1.7.10)
+>* January upstream catchup. WIP by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/20 (2.2.1-1.7.10)
+>* Catch up to upstream by @YannickMG in https://github.com/GTNewHorizons/ModularUI2/pull/19 (2.2.0-1.7.10)
 
 # Updated - MrTJPCore - 1.2.1 --> 1.3.0
-## *1.3.0*
->**Full Changelog**: https://github.com/GTNewHorizons/MrTJPCore/compare/1.2.1...1.3.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/MrTJPCore/compare/1.2.1...1.3.0
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - NEI-Integration - 1.4.0 --> 1.5.0
-## *1.5.0*
->## What's Changed
->* Change NEIHandler Tooltip Position by @slprime in https://github.com/GTNewHorizons/NEI-Integration/pull/10
->
->## New Contributors
->* @slprime made their first contribution in https://github.com/GTNewHorizons/NEI-Integration/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/NEI-Integration/compare/1.4.0...1.5.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/NEI-Integration/compare/1.4.0...1.5.0
+
+## What's Changed:
+>* Change NEIHandler Tooltip Position by @slprime in https://github.com/GTNewHorizons/NEI-Integration/pull/10 (1.5.0)
 
 # Updated - Natura - 2.7.6 --> 2.8.8
-## *2.8.8*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Natura/pull/32
->* Update redwood sapling texture by @MalTeeez in https://github.com/GTNewHorizons/Natura/pull/33
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Natura/pull/32
->* @MalTeeez made their first contribution in https://github.com/GTNewHorizons/Natura/pull/33
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.8.7...2.8.8
->
+**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.7.6...2.8.8
 
-## *2.8.7*
->## What's Changed
->* improve redwood tree generation by @leumasme in https://github.com/GTNewHorizons/Natura/pull/31
->
->## New Contributors
->* @leumasme made their first contribution in https://github.com/GTNewHorizons/Natura/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.8.5...2.8.7
->
-
-## *2.8.5*
->## What's Changed
->* Generate Saguaro Cactus in more desert biomes by @Vlamonster in https://github.com/GTNewHorizons/Natura/pull/30
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/Natura/pull/30
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.8.2...2.8.5
->
-
-## *2.8.2*
->## What's Changed
->* Slab Refactor, Leaf Refactor, and Everything Burns by @Ruling-0 in https://github.com/GTNewHorizons/Natura/pull/29
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/Natura/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.8.1...2.8.2
->
-
-## *2.8.1*
->## What's Changed
->* use mc fuel calculation to fix issue with some fuels not being picked up by @MissBismuth in https://github.com/GTNewHorizons/Natura/pull/28
->
->## New Contributors
->* @MissBismuth made their first contribution in https://github.com/GTNewHorizons/Natura/pull/28
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.8.0...2.8.1
->
-
-## *2.8.0*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Natura/pull/27
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/Natura/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/Natura/compare/2.7.5...2.8.0
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Natura/pull/32 (2.8.8)
+>* Update redwood sapling texture by @MalTeeez in https://github.com/GTNewHorizons/Natura/pull/33 (2.8.8)
+>* improve redwood tree generation by @leumasme in https://github.com/GTNewHorizons/Natura/pull/31 (2.8.7)
+>* Generate Saguaro Cactus in more desert biomes by @Vlamonster in https://github.com/GTNewHorizons/Natura/pull/30 (2.8.5)
+>* Slab Refactor, Leaf Refactor, and Everything Burns by @Ruling-0 in https://github.com/GTNewHorizons/Natura/pull/29 (2.8.2)
+>* use mc fuel calculation to fix issue with some fuels not being picked up by @MissBismuth in https://github.com/GTNewHorizons/Natura/pull/28 (2.8.1)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Natura/pull/27 (2.8.0)
 
 # Updated - Navigator - 1.0.15 --> 1.0.16
-## *1.0.16*
->## What's Changed
->* Add support for in-map search bars by @Lyfts in https://github.com/GTNewHorizons/Navigator/pull/11
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Navigator/compare/1.0.15...1.0.16
->
+**Full Changelog**: https://github.com/GTNewHorizons/Navigator/compare/1.0.15...1.0.16
+
+## What's Changed:
+>* Add support for in-map search bars by @Lyfts in https://github.com/GTNewHorizons/Navigator/pull/11 (1.0.16)
 
 # Updated - NetherPortalFix - 1.3.0 --> 1.4.0
-## *1.4.0*
->## What's Changed
->* Add image of BlayTheNinth giving permission to continue development by @koolkrafter5 in https://github.com/GTNewHorizons/NetherPortalFix/pull/2
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/NetherPortalFix/pull/2
->
->**Full Changelog**: https://github.com/GTNewHorizons/NetherPortalFix/compare/1.3.0...1.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/NetherPortalFix/compare/1.3.0...1.4.0
+
+## What's Changed:
+>* Add image of BlayTheNinth giving permission to continue development by @koolkrafter5 in https://github.com/GTNewHorizons/NetherPortalFix/pull/2 (1.4.0)
 
 # Updated - NewHorizonsCoreMod - 2.6.101 --> 2.7.220
-## *2.7.220*
->## What's Changed
->* Hardcode own mod ID by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1299
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.217...2.7.220
->
-
-## *2.7.217*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.216...2.7.217
->
-
-## *2.7.216*
->## What's Changed
->* Add Missing Recipes for Computronics Floppy Disks + Portable Tape Drive by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1297
->* Remove reference to deleted IGTMod interface by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1298
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.215...2.7.216
->
-
-## *2.7.215*
->## What's Changed
->* Remove access to GTMod isclient methods by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1296
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.213...2.7.215
->
-
-## *2.7.213*
->## What's Changed
->* Add recipe for ME throughput monitor by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1294
->* Add backhand compat for pizza gloves by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1295
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.211...2.7.213
->
-
-## *2.7.211*
->## What's Changed
->* Move Custom1-5 Aspect creation to GT5U by @OmdaCZ in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1291
->* Make crafting table recipe shaped by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1293
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.210...2.7.211
->
-
-## *2.7.210*
->## What's Changed
->* Add a few misc recipes by @RecursivePineapple in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1289
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.209...2.7.210
->
-
-## *2.7.209*
->## What's Changed
->* Replace Mica Insulator with Naquarite by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1261
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.204...2.7.209
->
-
-## *2.7.204*
->## What's Changed
->* Add Quarried Stone Maceration Recipe by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1287
->* Adds raven feather recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1288
->* Hellish blood recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1286
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.202...2.7.204
->
-
-## *2.7.202*
->## What's Changed
->* Fix forbidden ismodloaded/getmoditem checks by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1282
->* remove error stack by @boubou19 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1283
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.200...2.7.202
->
-
-## *2.7.200*
->## What's Changed
->* Achievement Fixes by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1281
->* Add SC2 Electric Engine Recipes by @hpotter02 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1279
->* Nerf amount of calcite obtained from geodes by @WanderingHero in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1280
->* Add recipes for new blocks by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1268
->* Add a way to obtain BOP natura, mixing magic and machines by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1270
->* Yipiii... another batch of recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1228
->* Add craft and researchs for Shulkers, Elytra and Netherite gear by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1221
->* Qol recipes and decorative stuff by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1227
->
->## New Contributors
->* @hpotter02 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1279
->* @WanderingHero made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1280
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.196...2.7.200
->
-
-## *2.7.196*
->## What's Changed
->* Change T1 air filter controller recipe to use proper casing by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1278
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.194...2.7.196
->
-
-## *2.7.194*
->## What's Changed
->* Remove old recipe for Infused Quantum Chestplate by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1277
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.192...2.7.194
->
-
-## *2.7.192*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.190...2.7.192
->
-
-## *2.7.190*
->## What's Changed
->* Update metadata of EBF gas recipes by @HoleFish in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1242
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.189...2.7.190
->
-
-## *2.7.189*
->## What's Changed
->* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1267
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.187...2.7.189
->
-
-## *2.7.187*
->## What's Changed
->* remove Sodium Aluminate recipe with Obzinite by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1274
->* Add comparator compatibility to Baby Chest by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1275
->* Reduce Crafting time of lootbag conversion by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1276
->* Re-Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/1896 by @v3ect0rgames in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1269
->* Don't try to remove null items. by @mitchej123 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1266
->
->## New Contributors
->* @v3ect0rgames made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1269
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.186...2.7.187
->
-
-## *2.7.186*
->## What's Changed
->* More info about what's invalid by @mitchej123 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1265
->* Fix the armor stand recipe collision by @Taskeren in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1271
->* Fix bituminous peat recipe from water propolis by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1272
->* Add recipe to switch input/output steam bus by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1273
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.182...2.7.186
->
-
-## *2.7.182*
->## What's Changed
->* Revert the UHT Mesh recipe to the old one by @srdr2k3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1263
->* Added "Don't Show Again!" button to Confirm Exit by @Taskeren in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1244
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1264
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1244
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.180...2.7.182
->
-
-## *2.7.180*
->## What's Changed
->* Remove recipe for gravisuite's vajra, vajra core and magnetron by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1249
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.178...2.7.180
->
-
-## *2.7.178*
->## What's Changed
->* Remove superfluous enchantment recipes by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1248
->* Buff the Recipe for the Incense Altar by @srdr2k3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1262
->
->## New Contributors
->* @srdr2k3 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1262
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.175...2.7.178
->
-
-## *2.7.175*
->## What's Changed
->* Don't use experimental EFR features by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1257
->* switch GalaxySpace addShapedRecipe to GTModHandler.addCraftingRecipe by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1258
->* Ic2 furnace replace by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1260
->* Fix OpenPrinters ink cartridges by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1251
->* add recipe to clear storage bus NBT by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1255
->* Add uncompressed coal variants to forge hammer recipes by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1256
->* update dtpf infinity circuit to not share circuit with cosmicneut by @istreee in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1259
->* Add Concrete Clay Bucket & a fuel value for the Creosote Clay Bucket by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1247
->* Reduce Excessive AL Recipe Times by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1250
->* Add botania into inf gear recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1190
->* Add adv network switch recipe by @RecursivePineapple in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1230
->
->## New Contributors
->* @istreee made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1259
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.172...2.7.175
->
-
-## *2.7.172*
->## What's Changed
->* Netherite by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1220
->* fix ritual of Unbinding (Blood Magic) by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1254
->
->## New Contributors
->* @NeOzay made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1254
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.171...2.7.172
->
-
-## *2.7.171*
->## What's Changed
->* Fix EV Battery Buffer 16-slot assembler recipe by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1252
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.169...2.7.171
->
-
-## *2.7.169*
->## What's Changed
->* Revert Oredict call on Electron-Permeable glass recipe by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1246
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.166...2.7.169
->
-
-## *2.7.166*
->## What's Changed
->* New Botania blocks + Tuff Dust by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1243
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.164...2.7.166
->
-
-## *2.7.164*
->## What's Changed
->* Fixes for GTNH-Intergalactic being merged into GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1240
->* Improve forbidden isModLoaded and getModItem scripts by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1241
->* Fusion Recipe Threshold Changes by @Impos913 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1219
->* Intergalactic post merge cleanup by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1245
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.160...2.7.164
->
-
-## *2.7.160*
->## What's Changed
->* Add ITM dependency to ITM script by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1235
->* update irontanks and iron tank minecarts dependency by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1236
->* Fix MagicBees frame descriptions by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1239
->* remove woodRail deletion by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1237
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.156...2.7.160
->
-
-## *2.7.156*
->## What's Changed
->* Add Iron Tank Minecarts and unify Tank Cart recipes by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1234
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1234
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.154...2.7.156
->
-
-## *2.7.154*
->## What's Changed
->* Adding missing Assembler recipes for transformers by @CrystieColon3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1229
->* Move rocket recycling recipes to recycling category by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1231
->* Adjust GalaxySpace Lead Battery lead amount in recipe by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1232
->* Fix recipe inconsistencies with Quicksilver Drop by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1233
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.149...2.7.154
->
-
-## *2.7.149*
->## What's Changed
->* Remove BWGlassAdder by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1216
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.146...2.7.149
->
-
-## *2.7.146*
->## What's Changed
->* Hotfix: Reflect change to GT Hazard API by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1226
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.141...2.7.146
->
-
-## *2.7.141*
->## What's Changed
->* Create new crafting recipes for upgrading transposers with Fluid Regulators by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1212
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.139...2.7.141
->
-
-## *2.7.139*
->## What's Changed
->* pedestal recipe fix by @ihfuhgljclhflhc in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1224
->* replace BG2 diamond dagger in sac dagger recipe by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1222
->* Add iron barrel + upgrade recipes by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1223
->* Fix iron and copper barrel upgrades by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1225
->
->## New Contributors
->* @ihfuhgljclhflhc made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1224
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.133...2.7.139
->
-
-## *2.7.133*
->## What's Changed
->* Add recipe for creative ME controller by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1217
->* Travellers Gear Removal - Should only be merged when the mod is removed by @Ethryan in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1115
->* Add Recipe for Solar Factory by @purebluez in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1120
->
->## New Contributors
->* @purebluez made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1120
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.130...2.7.133
->
-
-## *2.7.130*
->## What's Changed
->* Move item pipes to GT by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1215
->* Fix fusion threshold values by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1218
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.127...2.7.130
->
-
-## *2.7.127*
->## What's Changed
->* Merge itemstacks in some assline recipes 2/3 by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1214
->* New batch ( and I think last one of simple recipes) by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1213
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.124...2.7.127
->
-
-## *2.7.124*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.121...2.7.124
->
-
-## *2.7.121*
->## What's Changed
->* fix wrong recipes in circuit assemblers for preconfigured storage buses by @boubou19 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1211
->* Adapt to pipe rename by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1210
->* Coremod updates for Refactoring GT++ 2025-02-19 by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1208
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.119...2.7.121
->
-
-## *2.7.119*
->## What's Changed
->* Add back electric hoe recipe by @Impos913 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1209
->
->## New Contributors
->* @Impos913 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1209
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.117...2.7.119
->
-
-## *2.7.117*
->## What's Changed
->* RC Firestone for LV Age by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1207
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.114...2.7.117
->
-
-## *2.7.114*
->## What's Changed
->* Move matter manipulator recipes to coremod by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1205
->* Reduce Obsidian Processing from 9 per block to 2 per block by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1206
->* Coremod updates for Refactoring GT++ 2025-02-17 by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1204
->* New batch of EFR recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1185
->* Qol recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1201
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.110...2.7.114
->
-
-## *2.7.110*
->## What's Changed
->* Now you can't craft mince meat out of mince meat by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1203
->* Fix toxic everglades references by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1199
->* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1200
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.108...2.7.110
->
-
-## *2.7.108*
->## What's Changed
->* Buff neutronium and Cosmic Neutronium smelting times by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1198
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.105...2.7.108
->
-
-## *2.7.105*
->## What's Changed
->* Fix some references to GT++ items by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1196
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.103...2.7.105
->
-
-## *2.7.103*
->## What's Changed
->* Recipe adjustment for the bulk catalyst housing by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1197
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.98...2.7.103
->
-
-## *2.7.98*
->## What's Changed
->* add glasspane ore dict tag to Tico glasspane by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1195
->* Add fluid heater recipes for pam's hearvestcraft fresh milk by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1193
->
->## New Contributors
->* @FrostyFire1 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1193
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.95...2.7.98
->
-
-## *2.7.95*
->## What's Changed
->* Move fish trap recipe from gt++ to coremod by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1192
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.92...2.7.95
->
-
-## *2.7.92*
->## What's Changed
->* Add recipe for black hole utility hatch by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1191
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.90...2.7.92
->
-
-## *2.7.90*
->## What's Changed
->* Fix items needed to create a Mothership by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1189
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.88...2.7.90
->
-
-## *2.7.88*
->## What's Changed
->* Add missing dependency to ScriptAvaritiaAddons by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1188
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.86...2.7.88
->
-
-## *2.7.86*
->## What's Changed
->* Fix some amunra recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1187
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.83...2.7.86
->
-
-## *2.7.83*
->## What's Changed
->* Chest upgrades by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1184
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.79...2.7.83
->
-
-## *2.7.79*
->## What's Changed
->* Don't assume block and item IDs don't change at map load by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1183
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.77...2.7.79
->
-
-## *2.7.77*
->## What's Changed
->* Replace Aluminum Gravel Ore with Zinc Gravel Ore, and deal with the consequences by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1181
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.75...2.7.77
->
-
-## *2.7.75*
->## What's Changed
->* Asgardandelion 2.0 by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1179
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.72...2.7.75
->
-
-## *2.7.72*
->## What's Changed
->* Bunch of QoL recipes from an old issue by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1180
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.70...2.7.72
->
-
-## *2.7.70*
->## What's Changed
->* Magnet Dislocator recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1178
->* Batch of Efr recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1177
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.66...2.7.70
->
-
-## *2.7.66*
->## What's Changed
->* Fix duplicate solar conversion by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1176
->* Replace direct references to IC2 item casings with calls to GTOreDictUnificator by @C0bra5 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1175
->* Fix loop between Optical Processor and Tier 3.5 Memory by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1174
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.64...2.7.66
->
-
-## *2.7.64*
->## What's Changed
->* Make the dust > dye recipes shaped by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1171
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1171
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.62...2.7.64
->
-
-## *2.7.62*
->## What's Changed
->* Enhanced the confirmation for exiting the game by @paulzzh in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1160
->* Make superchest recipes plate usage consistent by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1169
->* New ae2 content recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1167
->* Use quadruple plate over triple for super chests by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1170
->
->## New Contributors
->* @paulzzh made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1160
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.60...2.7.62
->
-
-## *2.7.60*
->## What's Changed
->* Remove map recipe from crafting and recipe removal logic by @SarcasticMax in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1168
->
->## New Contributors
->* @SarcasticMax made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1168
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.57...2.7.60
->
-
-## *2.7.57*
->## What's Changed
->* Remove iridium plate recipe from double ingot by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1166
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.55...2.7.57
->
-
-## *2.7.55*
->## What's Changed
->* Add Assembler Recipes to GTPP Bee Frames by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1165
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.53...2.7.55
->
-
-## *2.7.53*
->## What's Changed
->* Add Chromatic Glass Crystal by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1149
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.52...2.7.53
->
-
-## *2.7.52*
->## What's Changed
->* Migrate to new way of specifying QFT catalyst by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1163
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.51...2.7.52
->
-
-## *2.7.51*
->## What's Changed
->* Order DTPF Recipes by Catalyst Tier by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1158
->* Convert solar panel recipes by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1161
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1158
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.50...2.7.51
->
-
-## *2.7.50*
->## What's Changed
->* Streamline smeltery melting recipes by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1159
->* More EFR recipe work by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1162
->* Retier CRIB, proxy, adv stocking hatch by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1144
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.49...2.7.50
->
-
-## *2.7.49*
->## What's Changed
->* Remove hot mv sc circuit 1 by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1155
->* fix recipe of Logistics Disk by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1154
->* GCPlanets recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1151
->* Add NC hatch recipes by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1152
->* Switch space assembler module tier to metadata by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1157
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.47...2.7.49
->
-
-## *2.7.47*
->## What's Changed
->* Natura Wood crafting recipes use all saws now by @MissBismuth in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1153
->* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1150
->
->## New Contributors
->* @MissBismuth made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1153
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.45...2.7.47
->
-
-## *2.7.45*
->## What's Changed
->* remove ic2 valuable ore compat, ic2 miner, and ic2 scanners by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1148
->* Fix coremod biofluids by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1147
->* Change Bio Vat Recipes to use new metadata by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1129
->* Rebalance scanning times by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1141
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.43...2.7.45
->
-
-## *2.7.43*
->## What's Changed
->* Add assembler recipes for steam hulls by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1146
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.41...2.7.43
->
-
-## *2.7.41*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.40...2.7.41
->
-
-## *2.7.40*
->## What's Changed
->* Fix artificial universe cell by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1142
->* GS script recipes fixes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1140
->* More gt recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1143
->* Migrate coremod machines to GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1145
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.38...2.7.40
->
-
-## *2.7.38*
->## What's Changed
->* change circuits of froth recycling with Combs by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1139
->* Add flat dual interface assembler recipe by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1138
->* fix HV tank recipes  by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1137
->* Migrate coremod casings to GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1130
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.36...2.7.38
->
-
-## *2.7.36*
->## What's Changed
->* GCcore recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1136
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.34...2.7.36
->
-
-## *2.7.34*
->## What's Changed
->* remove recipe because turbine is not generated since the cut off is 25k by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1133
->* Fix Ultra High Strength Concrete Floor Receipe by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1134
->* Gravel ore no longer needs manual recipe registration by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1135
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.31...2.7.34
->
-
-## *2.7.31*
->## What's Changed
->* Hatch/bus type change shaped to shapeless by @Pxx500 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1132
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.29...2.7.31
->
-
-## *2.7.29*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.27...2.7.29
->
-
-## *2.7.27*
->## What's Changed
->* First round of EFR recipe integration by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1121
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.26...2.7.27
->
-
-## *2.7.26*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1131
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.24...2.7.26
->
-
-## *2.7.24*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.22...2.7.24
->
-
-## *2.7.22*
->## What's Changed
->* Fix DS Parts Recipes by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1128
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.20...2.7.22
->
-
-## *2.7.20*
->## What's Changed
->* Fix UEV+ casing and hull recycling recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1127
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.18...2.7.20
->
-
-## *2.7.18*
->## What's Changed
->* fix all the rocket controller recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1123
->* Project red tinker fix by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1124
->* remove vanilla stone tools by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1126
->* Color upgrade recipe change by @Eldrinn-Elantey in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1125
->* Add recipe for Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1057
->
->## New Contributors
->* @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1125
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.16...2.7.18
->
-
-## *2.7.16*
->## What's Changed
->* fix electric scanner recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1122
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.14...2.7.16
->
-
-## *2.7.14*
->## What's Changed
->* Clean up coremod MTEs before merging them into GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1117
->* Migrate Dyson from GalaxySpace to Intergalactic by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1116
->* Don't allow railcraft crowbars in crafting by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1119
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.12...2.7.14
->
-
-## *2.7.12*
->## What's Changed
->* Fix artificial universe cell recipes by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1118
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.8...2.7.12
->
-
-## *2.7.8*
->## What's Changed
->* Nerf glass loop  by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1113
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.6...2.7.8
->
-
-## *2.7.6*
->## What's Changed
->* fix 2 Coolant Cells in same Slot for LuV Solenoid by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1112
->* Add recipes for preconfigured p2ps by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1109
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.5...2.7.6
->
-
-## *2.7.5*
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.4...2.7.5
->
-
-## *2.7.4*
->## What's Changed
->* Added assembler recipes for all missing transformers by @CrystieColon3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1091
->* Add new recipe for asgardandelion by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1108
->* priest trade improvements by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1111
->
->## New Contributors
->* @CrystieColon3 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1091
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.3...2.7.4
->
-
-## *2.7.3*
->## What's Changed
->* Add ME output hatches+singularity cell recipe by @HoleFish in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1090
->* stop Luv solenoid being gated ZPM by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1107
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1107
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.2...2.7.3
->
-
-## *2.7.2*
->## What's Changed
->* Fix avaritia tool recipes in NEI by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1106
->* Add more recycling recipes by @Ableytner in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1096
->* Added recipes in oreder to get currently unobtainable foods by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1105
->* migrate air filter to use new style turbine rendering by @Glease in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1099
->* Wire rebalance part 2, electric bugaloo or whatever by @LazyFleshWasTaken in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1085
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.1...2.7.2
->
-
-## *2.7.1*
->## What's Changed
->* Fix custom drops chances by @kuba6000 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1103
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.7.0...2.7.1
->
-
-## *2.7.0*
->## What's Changed
->* Remove tools by @Connor-Colenso in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1101
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.6.88...2.7.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/NewHorizonsCoreMod/compare/2.6.101...2.7.220
+
+## What's Changed:
+>* Hardcode own mod ID by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1299 (2.7.220)
+>* Add Missing Recipes for Computronics Floppy Disks + Portable Tape Drive by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1297 (2.7.216)
+>* Remove reference to deleted IGTMod interface by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1298 (2.7.216)
+>* Remove access to GTMod isclient methods by @Alexdoru in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1296 (2.7.215)
+>* Add recipe for ME throughput monitor by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1294 (2.7.213)
+>* Add backhand compat for pizza gloves by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1295 (2.7.213)
+>* Move Custom1-5 Aspect creation to GT5U by @OmdaCZ in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1291 (2.7.211)
+>* Make crafting table recipe shaped by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1293 (2.7.211)
+>* Add a few misc recipes by @RecursivePineapple in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1289 (2.7.210)
+>* Replace Mica Insulator with Naquarite by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1261 (2.7.209)
+>* Add Quarried Stone Maceration Recipe by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1287 (2.7.204)
+>* Adds raven feather recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1288 (2.7.204)
+>* Hellish blood recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1286 (2.7.204)
+>* Fix forbidden ismodloaded/getmoditem checks by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1282 (2.7.202)
+>* remove error stack by @boubou19 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1283 (2.7.202)
+>* Achievement Fixes by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1281 (2.7.200)
+>* Add SC2 Electric Engine Recipes by @hpotter02 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1279 (2.7.200)
+>* Nerf amount of calcite obtained from geodes by @WanderingHero in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1280 (2.7.200)
+>* Add recipes for new blocks by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1268 (2.7.200)
+>* Add a way to obtain BOP natura, mixing magic and machines by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1270 (2.7.200)
+>* Yipiii... another batch of recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1228 (2.7.200)
+>* Add craft and researchs for Shulkers, Elytra and Netherite gear by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1221 (2.7.200)
+>* Qol recipes and decorative stuff by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1227 (2.7.200)
+>* Change T1 air filter controller recipe to use proper casing by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1278 (2.7.196)
+>* Remove old recipe for Infused Quantum Chestplate by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1277 (2.7.194)
+>* Update metadata of EBF gas recipes by @HoleFish in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1242 (2.7.190)
+>* Update uses of crafting tools by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1267 (2.7.189)
+>* remove Sodium Aluminate recipe with Obzinite by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1274 (2.7.187)
+>* Add comparator compatibility to Baby Chest by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1275 (2.7.187)
+>* Reduce Crafting time of lootbag conversion by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1276 (2.7.187)
+>* Re-Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/1896 by @v3ect0rgames in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1269 (2.7.187)
+>* Don't try to remove null items. by @mitchej123 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1266 (2.7.187)
+>* More info about what's invalid by @mitchej123 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1265 (2.7.186)
+>* Fix the armor stand recipe collision by @Taskeren in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1271 (2.7.186)
+>* Fix bituminous peat recipe from water propolis by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1272 (2.7.186)
+>* Add recipe to switch input/output steam bus by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1273 (2.7.186)
+>* Revert the UHT Mesh recipe to the old one by @srdr2k3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1263 (2.7.182)
+>* Added "Don't Show Again!" button to Confirm Exit by @Taskeren in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1244 (2.7.182)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1264 (2.7.182)
+>* Remove recipe for gravisuite's vajra, vajra core and magnetron by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1249 (2.7.180)
+>* Remove superfluous enchantment recipes by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1248 (2.7.178)
+>* Buff the Recipe for the Incense Altar by @srdr2k3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1262 (2.7.178)
+>* Don't use experimental EFR features by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1257 (2.7.175)
+>* switch GalaxySpace addShapedRecipe to GTModHandler.addCraftingRecipe by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1258 (2.7.175)
+>* Ic2 furnace replace by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1260 (2.7.175)
+>* Fix OpenPrinters ink cartridges by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1251 (2.7.175)
+>* add recipe to clear storage bus NBT by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1255 (2.7.175)
+>* Add uncompressed coal variants to forge hammer recipes by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1256 (2.7.175)
+>* update dtpf infinity circuit to not share circuit with cosmicneut by @istreee in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1259 (2.7.175)
+>* Add Concrete Clay Bucket & a fuel value for the Creosote Clay Bucket by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1247 (2.7.175)
+>* Reduce Excessive AL Recipe Times by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1250 (2.7.175)
+>* Add botania into inf gear recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1190 (2.7.175)
+>* Add adv network switch recipe by @RecursivePineapple in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1230 (2.7.175)
+>* Netherite by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1220 (2.7.172)
+>* fix ritual of Unbinding (Blood Magic) by @NeOzay in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1254 (2.7.172)
+>* Fix EV Battery Buffer 16-slot assembler recipe by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1252 (2.7.171)
+>* Revert Oredict call on Electron-Permeable glass recipe by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1246 (2.7.169)
+>* New Botania blocks + Tuff Dust by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1243 (2.7.166)
+>* Fixes for GTNH-Intergalactic being merged into GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1240 (2.7.164)
+>* Improve forbidden isModLoaded and getModItem scripts by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1241 (2.7.164)
+>* Fusion Recipe Threshold Changes by @Impos913 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1219 (2.7.164)
+>* Intergalactic post merge cleanup by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1245 (2.7.164)
+>* Add ITM dependency to ITM script by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1235 (2.7.160)
+>* update irontanks and iron tank minecarts dependency by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1236 (2.7.160)
+>* Fix MagicBees frame descriptions by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1239 (2.7.160)
+>* remove woodRail deletion by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1237 (2.7.160)
+>* Add Iron Tank Minecarts and unify Tank Cart recipes by @2ndDerivative in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1234 (2.7.156)
+>* Adding missing Assembler recipes for transformers by @CrystieColon3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1229 (2.7.154)
+>* Move rocket recycling recipes to recycling category by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1231 (2.7.154)
+>* Adjust GalaxySpace Lead Battery lead amount in recipe by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1232 (2.7.154)
+>* Fix recipe inconsistencies with Quicksilver Drop by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1233 (2.7.154)
+>* Remove BWGlassAdder by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1216 (2.7.149)
+>* Hotfix: Reflect change to GT Hazard API by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1226 (2.7.146)
+>* Create new crafting recipes for upgrading transposers with Fluid Regulators by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1212 (2.7.141)
+>* pedestal recipe fix by @ihfuhgljclhflhc in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1224 (2.7.139)
+>* replace BG2 diamond dagger in sac dagger recipe by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1222 (2.7.139)
+>* Add iron barrel + upgrade recipes by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1223 (2.7.139)
+>* Fix iron and copper barrel upgrades by @Caedis in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1225 (2.7.139)
+>* Add recipe for creative ME controller by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1217 (2.7.133)
+>* Travellers Gear Removal - Should only be merged when the mod is removed by @Ethryan in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1115 (2.7.133)
+>* Add Recipe for Solar Factory by @purebluez in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1120 (2.7.133)
+>* Move item pipes to GT by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1215 (2.7.130)
+>* Fix fusion threshold values by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1218 (2.7.130)
+>* Merge itemstacks in some assline recipes 2/3 by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1214 (2.7.127)
+>* New batch ( and I think last one of simple recipes) by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1213 (2.7.127)
+>* fix wrong recipes in circuit assemblers for preconfigured storage buses by @boubou19 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1211 (2.7.121)
+>* Adapt to pipe rename by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1210 (2.7.121)
+>* Coremod updates for Refactoring GT++ 2025-02-19 by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1208 (2.7.121)
+>* Add back electric hoe recipe by @Impos913 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1209 (2.7.119)
+>* RC Firestone for LV Age by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1207 (2.7.117)
+>* Move matter manipulator recipes to coremod by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1205 (2.7.114)
+>* Reduce Obsidian Processing from 9 per block to 2 per block by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1206 (2.7.114)
+>* Coremod updates for Refactoring GT++ 2025-02-17 by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1204 (2.7.114)
+>* New batch of EFR recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1185 (2.7.114)
+>* Qol recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1201 (2.7.114)
+>* Now you can't craft mince meat out of mince meat by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1203 (2.7.110)
+>* Fix toxic everglades references by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1199 (2.7.110)
+>* Remove recipe optimization by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1200 (2.7.110)
+>* Buff neutronium and Cosmic Neutronium smelting times by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1198 (2.7.108)
+>* Fix some references to GT++ items by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1196 (2.7.105)
+>* Recipe adjustment for the bulk catalyst housing by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1197 (2.7.103)
+>* add glasspane ore dict tag to Tico glasspane by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1195 (2.7.98)
+>* Add fluid heater recipes for pam's hearvestcraft fresh milk by @FrostyFire1 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1193 (2.7.98)
+>* Move fish trap recipe from gt++ to coremod by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1192 (2.7.95)
+>* Add recipe for black hole utility hatch by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1191 (2.7.92)
+>* Fix items needed to create a Mothership by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1189 (2.7.90)
+>* Add missing dependency to ScriptAvaritiaAddons by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1188 (2.7.88)
+>* Fix some amunra recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1187 (2.7.86)
+>* Chest upgrades by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1184 (2.7.83)
+>* Don't assume block and item IDs don't change at map load by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1183 (2.7.79)
+>* Replace Aluminum Gravel Ore with Zinc Gravel Ore, and deal with the consequences by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1181 (2.7.77)
+>* Asgardandelion 2.0 by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1179 (2.7.75)
+>* Bunch of QoL recipes from an old issue by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1180 (2.7.72)
+>* Magnet Dislocator recipe by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1178 (2.7.70)
+>* Batch of Efr recipes by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1177 (2.7.70)
+>* Fix duplicate solar conversion by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1176 (2.7.66)
+>* Replace direct references to IC2 item casings with calls to GTOreDictUnificator by @C0bra5 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1175 (2.7.66)
+>* Fix loop between Optical Processor and Tier 3.5 Memory by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1174 (2.7.66)
+>* Make the dust > dye recipes shaped by @Ruling-0 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1171 (2.7.64)
+>* Enhanced the confirmation for exiting the game by @paulzzh in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1160 (2.7.62)
+>* Make superchest recipes plate usage consistent by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1169 (2.7.62)
+>* New ae2 content recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1167 (2.7.62)
+>* Use quadruple plate over triple for super chests by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1170 (2.7.62)
+>* Remove map recipe from crafting and recipe removal logic by @SarcasticMax in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1168 (2.7.60)
+>* Remove iridium plate recipe from double ingot by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1166 (2.7.57)
+>* Add Assembler Recipes to GTPP Bee Frames by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1165 (2.7.55)
+>* Add Chromatic Glass Crystal by @Nockyx in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1149 (2.7.53)
+>* Migrate to new way of specifying QFT catalyst by @miozune in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1163 (2.7.52)
+>* Order DTPF Recipes by Catalyst Tier by @Vlamonster in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1158 (2.7.51)
+>* Convert solar panel recipes by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1161 (2.7.51)
+>* Streamline smeltery melting recipes by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1159 (2.7.50)
+>* More EFR recipe work by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1162 (2.7.50)
+>* Retier CRIB, proxy, adv stocking hatch by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1144 (2.7.50)
+>* Remove hot mv sc circuit 1 by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1155 (2.7.49)
+>* fix recipe of Logistics Disk by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1154 (2.7.49)
+>* GCPlanets recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1151 (2.7.49)
+>* Add NC hatch recipes by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1152 (2.7.49)
+>* Switch space assembler module tier to metadata by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1157 (2.7.49)
+>* Natura Wood crafting recipes use all saws now by @MissBismuth in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1153 (2.7.47)
+>* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1150 (2.7.47)
+>* remove ic2 valuable ore compat, ic2 miner, and ic2 scanners by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1148 (2.7.45)
+>* Fix coremod biofluids by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1147 (2.7.45)
+>* Change Bio Vat Recipes to use new metadata by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1129 (2.7.45)
+>* Rebalance scanning times by @StaffiX in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1141 (2.7.45)
+>* Add assembler recipes for steam hulls by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1146 (2.7.43)
+>* Fix artificial universe cell by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1142 (2.7.40)
+>* GS script recipes fixes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1140 (2.7.40)
+>* More gt recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1143 (2.7.40)
+>* Migrate coremod machines to GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1145 (2.7.40)
+>* change circuits of froth recycling with Combs by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1139 (2.7.38)
+>* Add flat dual interface assembler recipe by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1138 (2.7.38)
+>* fix HV tank recipes  by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1137 (2.7.38)
+>* Migrate coremod casings to GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1130 (2.7.38)
+>* GCcore recipe cleanup by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1136 (2.7.36)
+>* remove recipe because turbine is not generated since the cut off is 25k by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1133 (2.7.34)
+>* Fix Ultra High Strength Concrete Floor Receipe by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1134 (2.7.34)
+>* Gravel ore no longer needs manual recipe registration by @YannickMG in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1135 (2.7.34)
+>* Hatch/bus type change shaped to shapeless by @Pxx500 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1132 (2.7.31)
+>* First round of EFR recipe integration by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1121 (2.7.27)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1131 (2.7.26)
+>* Fix DS Parts Recipes by @glowredman in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1128 (2.7.22)
+>* Fix UEV+ casing and hull recycling recipes by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1127 (2.7.20)
+>* fix all the rocket controller recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1123 (2.7.18)
+>* Project red tinker fix by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1124 (2.7.18)
+>* remove vanilla stone tools by @Dream-Master in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1126 (2.7.18)
+>* Color upgrade recipe change by @Eldrinn-Elantey in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1125 (2.7.18)
+>* Add recipe for Fluid Void Cell by @lordIcocain in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1057 (2.7.18)
+>* fix electric scanner recipes by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1122 (2.7.16)
+>* Clean up coremod MTEs before merging them into GT5u by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1117 (2.7.14)
+>* Migrate Dyson from GalaxySpace to Intergalactic by @serenibyss in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1116 (2.7.14)
+>* Don't allow railcraft crowbars in crafting by @FourIsTheNumber in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1119 (2.7.14)
+>* Fix artificial universe cell recipes by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1118 (2.7.12)
+>* Nerf glass loop  by @GDCloudstrike in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1113 (2.7.8)
+>* fix 2 Coolant Cells in same Slot for LuV Solenoid by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1112 (2.7.6)
+>* Add recipes for preconfigured p2ps by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1109 (2.7.6)
+>* Added assembler recipes for all missing transformers by @CrystieColon3 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1091 (2.7.4)
+>* Add new recipe for asgardandelion by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1108 (2.7.4)
+>* priest trade improvements by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1111 (2.7.4)
+>* Add ME output hatches+singularity cell recipe by @HoleFish in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1090 (2.7.3)
+>* stop Luv solenoid being gated ZPM by @Yoshy2002 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1107 (2.7.3)
+>* Fix avaritia tool recipes in NEI by @chochem in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1106 (2.7.2)
+>* Add more recycling recipes by @Ableytner in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1096 (2.7.2)
+>* Added recipes in oreder to get currently unobtainable foods by @EnderProyects in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1105 (2.7.2)
+>* migrate air filter to use new style turbine rendering by @Glease in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1099 (2.7.2)
+>* Wire rebalance part 2, electric bugaloo or whatever by @LazyFleshWasTaken in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1085 (2.7.2)
+>* Fix custom drops chances by @kuba6000 in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1103 (2.7.1)
+>* Remove tools by @Connor-Colenso in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1101 (2.7.0)
 
 # Updated - Nodal-Mechanics - 1.3.0-GTNH --> 1.3.1-GTNH
-## *1.3.1-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/11
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nodal-Mechanics/compare/1.3.0-GTNH...1.3.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Nodal-Mechanics/compare/1.3.0-GTNH...1.3.1-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Nodal-Mechanics/pull/11 (1.3.1-GTNH)
 
 # Updated - NotEnoughEnergistics - 1.7.0 --> 1.7.6
-## *1.7.6*
->## What's Changed
->* Optional Wirelesscraftingterminal by @slprime in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/45
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughEnergistics/compare/1.7.5...1.7.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughEnergistics/compare/1.7.0...1.7.6
 
-## *1.7.5*
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughEnergistics/compare/1.7.4...1.7.5
->
-
-## *1.7.4*
->## What's Changed
->* ME, FC, WC Terminals by @slprime in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/42
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughEnergistics/compare/1.7.0...1.7.4
->
+## What's Changed:
+>* Optional Wirelesscraftingterminal by @slprime in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/45 (1.7.6)
+>* ME, FC, WC Terminals by @slprime in https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/42 (1.7.4)
 
 # Updated - NotEnoughIds - 2.1.6 --> 2.1.10
-## *2.1.10*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/NotEnoughIds/pull/28
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughIds/compare/2.1.9...2.1.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughIds/compare/2.1.6...2.1.10
 
-## *2.1.9*
->## What's Changed
->* Client block transformer by @RecursivePineapple in https://github.com/GTNewHorizons/NotEnoughIds/pull/26
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/NotEnoughIds/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughIds/compare/2.1.7...2.1.9
->
-
-## *2.1.7*
->## What's Changed
->* Switch to GTNHLib mixin utilities by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/25
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughIds/compare/2.1.6...2.1.7
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/NotEnoughIds/pull/28 (2.1.10)
+>* Client block transformer by @RecursivePineapple in https://github.com/GTNewHorizons/NotEnoughIds/pull/26 (2.1.9)
+>* Switch to GTNHLib mixin utilities by @Cleptomania in https://github.com/GTNewHorizons/NotEnoughIds/pull/25 (2.1.7)
 
 # Updated - NotEnoughItems - 2.6.54-GTNH --> 2.7.64-GTNH
-## *2.7.64-GTNH*
->## What's Changed
->* Bookmarks Chains Math: fix infinity loop by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/662
->* Bookmarks Hotkeys: optimization thaumcraft recipes by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/663
->* Bookmarks Chains: Optimize GTTools by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/667
->* Bookmarks Chains: Use active Item as preferred if exists by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/664
->* Correctly used tools in favorites by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/670
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.62-GTNH...2.7.64-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.6.54-GTNH...2.7.64-GTNH
 
-## *2.7.62-GTNH*
->## What's Changed
->* Disable play sound when crafting with gt tools by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/659
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.60-GTNH...2.7.62-GTNH
->
-
-## *2.7.60-GTNH*
->## What's Changed
->* Update Bookmark Chain Tooltip Cache by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/657
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.59-GTNH...2.7.60-GTNH
->
-
-## *2.7.59-GTNH*
->## What's Changed
->* Autocrafting Improvement by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/655
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.58-GTNH...2.7.59-GTNH
->
-
-## *2.7.58-GTNH*
->## What's Changed
->* Tools in autocrafting by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/653
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.57-GTNH...2.7.58-GTNH
->
-
-## *2.7.57-GTNH*
->## What's Changed
->* Fix Item Tooltip by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/651
->* Clear Crafting Grid after autocrafting by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/652
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.56-GTNH...2.7.57-GTNH
->
-
-## *2.7.56-GTNH*
->## What's Changed
->* Fix WorldClient leak in ItemModSpawner by @Alexdoru in https://github.com/GTNewHorizons/NotEnoughItems/pull/637
->* Add Autocrafting Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/649
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.54-GTNH...2.7.56-GTNH
->
-
-## *2.7.54-GTNH*
->## What's Changed
->* Add Bookmark items with recipe Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/644
->* Fix Paged Tooltip with Line Handler by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/645
->* Set Minimum Zoom Size by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/648
->* Add Translation to Item Count Details by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/647
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.52-GTNH...2.7.54-GTNH
->
-
-## *2.7.52-GTNH*
->## What's Changed
->* allow setOverrideName to remove name overrides by @FalsePattern in https://github.com/GTNewHorizons/NotEnoughItems/pull/643
->
->## New Contributors
->* @FalsePattern made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/643
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.51-GTNH...2.7.52-GTNH
->
-
-## *2.7.51-GTNH*
->## What's Changed
->* Too Many (Hidden) Items by @koolkrafter5 in https://github.com/GTNewHorizons/NotEnoughItems/pull/641
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.50-GTNH...2.7.51-GTNH
->
-
-## *2.7.50-GTNH*
->## What's Changed
->* Fix Incorrect `handleDragNDrop` Implementation by @abel1502 in https://github.com/GTNewHorizons/NotEnoughItems/pull/639
->
->## New Contributors
->* @abel1502 made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/639
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.49-GTNH...2.7.50-GTNH
->
-
-## *2.7.49-GTNH*
->## What's Changed
->* Update JarJar detection so it works when jarjar is loaded but rfb is not setup properly. by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/636
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.48-GTNH...2.7.49-GTNH
->
-
-## *2.7.48-GTNH*
->## What's Changed
->* Ignore prefix when SearchMode is ALWAYS by @Kogepan229 in https://github.com/GTNewHorizons/NotEnoughItems/pull/635
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.46-GTNH...2.7.48-GTNH
->
-
-## *2.7.46-GTNH*
->## What's Changed
->* Don't exclude locals/frames when transforming. by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/632
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.45-GTNH...2.7.46-GTNH
->
-
-## *2.7.45-GTNH*
->## What's Changed
->* Add Settings: Dynamic Font Size by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/631
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.44-GTNH...2.7.45-GTNH
->
-
-## *2.7.44-GTNH*
->## What's Changed
->* Subset: Memory Optimization by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/626
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.43-GTNH...2.7.44-GTNH
->
-
-## *2.7.43-GTNH*
->## What's Changed
->* Filtering the input in the ItemQuantityField by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/623
->* Make the "Accepts following:" tooltip work for otherStacks by @koolkrafter5 in https://github.com/GTNewHorizons/NotEnoughItems/pull/625
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/625
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.40-GTNH...2.7.43-GTNH
->
-
-## *2.7.40-GTNH*
->## What's Changed
->* Create Favorites Widget; More hotkeys; More Tooltips; by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/617
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.38-GTNH...2.7.40-GTNH
->
-
-## *2.7.38-GTNH*
->## What's Changed
->* Add AE2 Cell View handlers by @Kogepan229 in https://github.com/GTNewHorizons/NotEnoughItems/pull/621
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/621
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.34-GTNH...2.7.38-GTNH
->
-
-## *2.7.34-GTNH*
->## What's Changed
->* prevent empty pages from being produced by @Glease in https://github.com/GTNewHorizons/NotEnoughItems/pull/615
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.33-GTNH...2.7.34-GTNH
->
-
-## *2.7.33-GTNH*
->## What's Changed
->* Add Hotkeys Widget Settings by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/613
->* Add option to adjust FPS rendering of items by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/612
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.31-GTNH...2.7.33-GTNH
->
-
-## *2.7.31-GTNH*
->## What's Changed
->* Implement Forge Essentials Permission Checking by @spacebuilder2020 in https://github.com/GTNewHorizons/NotEnoughItems/pull/611
->
->## New Contributors
->* @spacebuilder2020 made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/611
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.30-GTNH...2.7.31-GTNH
->
-
-## *2.7.30-GTNH*
->## What's Changed
->* Use the updated ASMDataTable (with interfaces) when JarJar is present by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/608
->* feature: Overlays Settings GUI (Keep overlays through dimensions) by @AzodFR in https://github.com/GTNewHorizons/NotEnoughItems/pull/610
->
->## New Contributors
->* @AzodFR made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/610
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.29-GTNH...2.7.30-GTNH
->
-
-## *2.7.29-GTNH*
->## What's Changed
->* Fix NC marker in recipe after fluid pattern terminal by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/603
->* Add loadPluginsInParallel Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/604
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.28-GTNH...2.7.29-GTNH
->
-
-## *2.7.28-GTNH*
->## What's Changed
->* Added hotkey utils methods by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/599
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.27-GTNH...2.7.28-GTNH
->
-
-## *2.7.27-GTNH*
->## What's Changed
->* Change Permutation Filter by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/598
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.25-GTNH...2.7.27-GTNH
->
-
-## *2.7.27*
->## What's Changed
->* Change Permutation Filter by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/598
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.25-GTNH...2.7.27
->
-
-## *2.7.25-GTNH*
->## What's Changed
->* Restore Issue 583 by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/593
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.23-GTNH...2.7.25-GTNH
->
-
-## *2.7.23-GTNH*
->## What's Changed
->* Update Render Cache after window resize by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/592
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.22-GTNH...2.7.23-GTNH
->
-
-## *2.7.22-GTNH*
->## What's Changed
->* Subset Widget Improvement by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/577
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.20-GTNH...2.7.22-GTNH
->
-
-## *2.7.20-GTNH*
->## What's Changed
->* Created Grid Rendering Cache Mode by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/573
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.18-GTNH...2.7.20-GTNH
->
-
-## *2.7.18-GTNH*
->## What's Changed
->* Fix NPE in ItemsTooltipLineHandler by @Caedis in https://github.com/GTNewHorizons/NotEnoughItems/pull/589
->* fix memory leak fixes not working for MP by @Glease in https://github.com/GTNewHorizons/NotEnoughItems/pull/590
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.15-GTNH...2.7.18-GTNH
->
-
-## *2.7.15-GTNH*
->## What's Changed
->* Add mod handlers for mods in Per Fabrica Ad Astra modpack by @ChrisJStone in https://github.com/GTNewHorizons/NotEnoughItems/pull/587
->* Add 'Hide Item List Until Searching' option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/572
->
->## New Contributors
->* @ChrisJStone made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/587
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.13-GTNH...2.7.15-GTNH
->
-
-## *2.7.13-GTNH*
->## What's Changed
->* Item List Sort: Ensure access to shared private field is atomic by @lailani-f in https://github.com/GTNewHorizons/NotEnoughItems/pull/584
->
->## New Contributors
->* @lailani-f made their first contribution in https://github.com/GTNewHorizons/NotEnoughItems/pull/584
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.11-GTNH...2.7.13-GTNH
->
-
-## *2.7.11-GTNH*
->## What's Changed
->* Fixed NEI reload when changing dimension by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/583
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.8-GTNH...2.7.11-GTNH
->
-
-## *2.7.8-GTNH*
->## What's Changed
->* Change OptionIntegerField Width by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/575
->* Add RenderTooltipEvent Compat by @glowredman in https://github.com/GTNewHorizons/NotEnoughItems/pull/574
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.4-GTNH...2.7.8-GTNH
->
-
-## *2.7.4-GTNH*
->## What's Changed
->* Add Space Mode Settings to Search by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/571
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.2-GTNH...2.7.4-GTNH
->
-
-## *2.7.2-GTNH*
->## What's Changed
->* Fix Accept Folowing for custom recipe handlers by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/570
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.7.0-GTNH...2.7.2-GTNH
->
-
-## *2.7.0-GTNH*
->## What's Changed
->* Clear Search Filter Cache after Change Settings by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/569
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/NotEnoughItems/compare/2.6.51-GTNH...2.7.0-GTNH
->
+## What's Changed:
+>* Bookmarks Chains Math: fix infinity loop by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/662 (2.7.64-GTNH)
+>* Bookmarks Hotkeys: optimization thaumcraft recipes by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/663 (2.7.64-GTNH)
+>* Bookmarks Chains: Optimize GTTools by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/667 (2.7.64-GTNH)
+>* Bookmarks Chains: Use active Item as preferred if exists by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/664 (2.7.64-GTNH)
+>* Correctly used tools in favorites by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/670 (2.7.64-GTNH)
+>* Disable play sound when crafting with gt tools by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/659 (2.7.62-GTNH)
+>* Update Bookmark Chain Tooltip Cache by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/657 (2.7.60-GTNH)
+>* Autocrafting Improvement by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/655 (2.7.59-GTNH)
+>* Tools in autocrafting by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/653 (2.7.58-GTNH)
+>* Fix Item Tooltip by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/651 (2.7.57-GTNH)
+>* Clear Crafting Grid after autocrafting by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/652 (2.7.57-GTNH)
+>* Fix WorldClient leak in ItemModSpawner by @Alexdoru in https://github.com/GTNewHorizons/NotEnoughItems/pull/637 (2.7.56-GTNH)
+>* Add Autocrafting Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/649 (2.7.56-GTNH)
+>* Add Bookmark items with recipe Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/644 (2.7.54-GTNH)
+>* Fix Paged Tooltip with Line Handler by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/645 (2.7.54-GTNH)
+>* Set Minimum Zoom Size by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/648 (2.7.54-GTNH)
+>* Add Translation to Item Count Details by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/647 (2.7.54-GTNH)
+>* allow setOverrideName to remove name overrides by @FalsePattern in https://github.com/GTNewHorizons/NotEnoughItems/pull/643 (2.7.52-GTNH)
+>* Too Many (Hidden) Items by @koolkrafter5 in https://github.com/GTNewHorizons/NotEnoughItems/pull/641 (2.7.51-GTNH)
+>* Fix Incorrect `handleDragNDrop` Implementation by @abel1502 in https://github.com/GTNewHorizons/NotEnoughItems/pull/639 (2.7.50-GTNH)
+>* Update JarJar detection so it works when jarjar is loaded but rfb is not setup properly. by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/636 (2.7.49-GTNH)
+>* Ignore prefix when SearchMode is ALWAYS by @Kogepan229 in https://github.com/GTNewHorizons/NotEnoughItems/pull/635 (2.7.48-GTNH)
+>* Don't exclude locals/frames when transforming. by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/632 (2.7.46-GTNH)
+>* Add Settings: Dynamic Font Size by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/631 (2.7.45-GTNH)
+>* Subset: Memory Optimization by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/626 (2.7.44-GTNH)
+>* Filtering the input in the ItemQuantityField by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/623 (2.7.43-GTNH)
+>* Make the "Accepts following:" tooltip work for otherStacks by @koolkrafter5 in https://github.com/GTNewHorizons/NotEnoughItems/pull/625 (2.7.43-GTNH)
+>* Create Favorites Widget; More hotkeys; More Tooltips; by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/617 (2.7.40-GTNH)
+>* Add AE2 Cell View handlers by @Kogepan229 in https://github.com/GTNewHorizons/NotEnoughItems/pull/621 (2.7.38-GTNH)
+>* prevent empty pages from being produced by @Glease in https://github.com/GTNewHorizons/NotEnoughItems/pull/615 (2.7.34-GTNH)
+>* Add Hotkeys Widget Settings by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/613 (2.7.33-GTNH)
+>* Add option to adjust FPS rendering of items by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/612 (2.7.33-GTNH)
+>* Implement Forge Essentials Permission Checking by @spacebuilder2020 in https://github.com/GTNewHorizons/NotEnoughItems/pull/611 (2.7.31-GTNH)
+>* Use the updated ASMDataTable (with interfaces) when JarJar is present by @mitchej123 in https://github.com/GTNewHorizons/NotEnoughItems/pull/608 (2.7.30-GTNH)
+>* feature: Overlays Settings GUI (Keep overlays through dimensions) by @AzodFR in https://github.com/GTNewHorizons/NotEnoughItems/pull/610 (2.7.30-GTNH)
+>* Fix NC marker in recipe after fluid pattern terminal by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/603 (2.7.29-GTNH)
+>* Add loadPluginsInParallel Option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/604 (2.7.29-GTNH)
+>* Added hotkey utils methods by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/599 (2.7.28-GTNH)
+>* Change Permutation Filter by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/598 (2.7.27-GTNH)
+>* Change Permutation Filter by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/598 (2.7.27)
+>* Restore Issue 583 by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/593 (2.7.25-GTNH)
+>* Update Render Cache after window resize by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/592 (2.7.23-GTNH)
+>* Subset Widget Improvement by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/577 (2.7.22-GTNH)
+>* Created Grid Rendering Cache Mode by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/573 (2.7.20-GTNH)
+>* Fix NPE in ItemsTooltipLineHandler by @Caedis in https://github.com/GTNewHorizons/NotEnoughItems/pull/589 (2.7.18-GTNH)
+>* fix memory leak fixes not working for MP by @Glease in https://github.com/GTNewHorizons/NotEnoughItems/pull/590 (2.7.18-GTNH)
+>* Add mod handlers for mods in Per Fabrica Ad Astra modpack by @ChrisJStone in https://github.com/GTNewHorizons/NotEnoughItems/pull/587 (2.7.15-GTNH)
+>* Add 'Hide Item List Until Searching' option by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/572 (2.7.15-GTNH)
+>* Item List Sort: Ensure access to shared private field is atomic by @lailani-f in https://github.com/GTNewHorizons/NotEnoughItems/pull/584 (2.7.13-GTNH)
+>* Fixed NEI reload when changing dimension by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/583 (2.7.11-GTNH)
+>* Change OptionIntegerField Width by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/575 (2.7.8-GTNH)
+>* Add RenderTooltipEvent Compat by @glowredman in https://github.com/GTNewHorizons/NotEnoughItems/pull/574 (2.7.8-GTNH)
+>* Add Space Mode Settings to Search by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/571 (2.7.4-GTNH)
+>* Fix Accept Folowing for custom recipe handlers by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/570 (2.7.2-GTNH)
+>* Clear Search Filter Cache after Change Settings by @slprime in https://github.com/GTNewHorizons/NotEnoughItems/pull/569 (2.7.0-GTNH)
 
 # Updated - Nuclear-Control - 2.6.7 --> 2.6.17
-## *2.6.17*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Nuclear-Control/pull/27
->* (adv.) Info panel rework by @guid118 in https://github.com/GTNewHorizons/Nuclear-Control/pull/24
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.6.12...2.6.17
->
+**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.6.7...2.6.17
 
-## *2.6.12*
->## What's Changed
->* Add Factorio rocket silo alarm sound by @2ndDerivative in https://github.com/GTNewHorizons/Nuclear-Control/pull/26
->* Fixed (adv.) InfoPanel GUI when there are a large amount of info lines. by @guid118 in https://github.com/GTNewHorizons/Nuclear-Control/pull/23
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/26
->* @guid118 made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/23
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.6.9...2.6.12
->
-
-## *2.6.9*
->## What's Changed
->* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/Nuclear-Control/pull/25
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Nuclear-Control/pull/25
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nuclear-Control/compare/2.6.7...2.6.9
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Nuclear-Control/pull/27 (2.6.17)
+>* (adv.) Info panel rework by @guid118 in https://github.com/GTNewHorizons/Nuclear-Control/pull/24 (2.6.17)
+>* Add Factorio rocket silo alarm sound by @2ndDerivative in https://github.com/GTNewHorizons/Nuclear-Control/pull/26 (2.6.12)
+>* Fixed (adv.) InfoPanel GUI when there are a large amount of info lines. by @guid118 in https://github.com/GTNewHorizons/Nuclear-Control/pull/23 (2.6.12)
+>* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/Nuclear-Control/pull/25 (2.6.9)
 
 # Updated - Nutrition - 0.0.13 --> 0.1.3
-## *0.1.3*
->**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.1.2...0.1.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.0.13...0.1.3
 
-## *0.1.2*
->## What's Changed
->* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/Nutrition/pull/27
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.1.1...0.1.2
->
-
-## *0.1.1*
->## What's Changed
->* add moceatures ratburger to grains by @xronin01 in https://github.com/GTNewHorizons/Nutrition/pull/26
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.1.0...0.1.1
->
-
-## *0.1.0*
->## What's Changed
->* Fix MoCreatures and add etfutrum by @xronin01 in https://github.com/GTNewHorizons/Nutrition/pull/25
->
->## New Contributors
->* @xronin01 made their first contribution in https://github.com/GTNewHorizons/Nutrition/pull/25
->
->**Full Changelog**: https://github.com/GTNewHorizons/Nutrition/compare/0.0.13...0.1.0
->
+## What's Changed:
+>* unbind keybind by default by @Alexdoru in https://github.com/GTNewHorizons/Nutrition/pull/27 (0.1.2)
+>* add moceatures ratburger to grains by @xronin01 in https://github.com/GTNewHorizons/Nutrition/pull/26 (0.1.1)
+>* Fix MoCreatures and add etfutrum by @xronin01 in https://github.com/GTNewHorizons/Nutrition/pull/25 (0.1.0)
 
 # Updated - OCGlasses - 1.5.1-GTNH --> 1.6.1-GTNH
-## *1.6.1-GTNH*
->## What's Changed
->* Add lua documentation to OC callbacks by @serenibyss in https://github.com/GTNewHorizons/OCGlasses/pull/19
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/OCGlasses/pull/19
->
->**Full Changelog**: https://github.com/GTNewHorizons/OCGlasses/compare/1.6.0-GTNH...1.6.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/OCGlasses/compare/1.5.1-GTNH...1.6.1-GTNH
 
-## *1.6.0-GTNH*
->## What's Changed
->* Исправлена проверка в lua функции SetItem \ Fixed check in lua function SetItem by @Viptunbeqwfwew in https://github.com/GTNewHorizons/OCGlasses/pull/18
->
->## New Contributors
->* @Viptunbeqwfwew made their first contribution in https://github.com/GTNewHorizons/OCGlasses/pull/18
->
->**Full Changelog**: https://github.com/GTNewHorizons/OCGlasses/compare/1.5.0-GTNH...1.6.0-GTNH
->
+## What's Changed:
+>* Add lua documentation to OC callbacks by @serenibyss in https://github.com/GTNewHorizons/OCGlasses/pull/19 (1.6.1-GTNH)
+>*    lua  SetItem \ Fixed check in lua function SetItem by @Viptunbeqwfwew in https://github.com/GTNewHorizons/OCGlasses/pull/18 (1.6.0-GTNH)
 
 # Updated - OpenBlocks - 1.11.3-GTNH --> 1.11.6-GTNH
-## *1.11.6-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/OpenBlocks/pull/31
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.11.5-GTNH...1.11.6-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.11.3-GTNH...1.11.6-GTNH
 
-## *1.11.5-GTNH*
->## What's Changed
->* localization of map tooltip by @Discreater in https://github.com/GTNewHorizons/OpenBlocks/pull/29
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/OpenBlocks/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenBlocks/compare/1.11.3-GTNH...1.11.5-GTNH
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/OpenBlocks/pull/31 (1.11.6-GTNH)
+>* localization of map tooltip by @Discreater in https://github.com/GTNewHorizons/OpenBlocks/pull/29 (1.11.5-GTNH)
 
 # Updated - OpenComputers - 1.10.30-GTNH --> 1.11.16-GTNH
-## *1.11.16-GTNH*
->## What's Changed
->* Update to upstream 1.8.9a by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/154
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.15-GTNH...1.11.16-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.10.30-GTNH...1.11.16-GTNH
 
-## *1.11.15-GTNH*
->## What's Changed
->* Fix ME Upgrades tiers 1 and 3 being swapped by @IntQuant in https://github.com/GTNewHorizons/OpenComputers/pull/153
->
->## New Contributors
->* @IntQuant made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/153
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.13-GTNH...1.11.15-GTNH
->
-
-## *1.11.13-GTNH*
->## What's Changed
->* Sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/152
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.12-GTNH...1.11.13-GTNH
->
-
-## *1.11.12-GTNH*
->## What's Changed
->* Extend OpenComputers Transposers to support fluid transfer rate upgrades by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/150
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.10-GTNH...1.11.12-GTNH
->
-
-## *1.11.10-GTNH*
->## What's Changed
->* Accept capability for IBasicEnergyContainer & IGregTechDeviceInformation by @miozune in https://github.com/GTNewHorizons/OpenComputers/pull/151
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.9-GTNH...1.11.10-GTNH
->
-
-## *1.11.9-GTNH*
->## What's Changed
->* Fix GT integration not working by @miozune in https://github.com/GTNewHorizons/OpenComputers/pull/149
->
->## New Contributors
->* @miozune made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/149
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.8-GTNH...1.11.9-GTNH
->
-
-## *1.11.8-GTNH*
->## What's Changed
->* Implement `getItemInNetwork`  by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/147
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.7-GTNH...1.11.8-GTNH
->
-
-## *1.11.7-GTNH*
->## What's Changed
->* Fix overflow for large stack sizes in `storeInterfacePattern` by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/146
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.6-GTNH...1.11.7-GTNH
->
-
-## *1.11.6-GTNH*
->## What's Changed
->* Remove old dependency. by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/145
->* Fix settings. by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/144
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.5-GTNH...1.11.6-GTNH
->
-
-## *1.11.5-GTNH*
->## What's Changed
->* Add Integration for AE2FC Fluid Storage Cells by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/143
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.4-GTNH...1.11.5-GTNH
->
-
-## *1.11.4-GTNH*
->## What's Changed
->* fix client side memory leak on anything RedstoneAware by @Glease in https://github.com/GTNewHorizons/OpenComputers/pull/142
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.3-GTNH...1.11.4-GTNH
->
-
-## *1.11.3-GTNH*
->## What's Changed
->* sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/140
->* sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/141
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.2-GTNH...1.11.3-GTNH
->
-
-## *1.11.2-GTNH*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/OpenComputers/pull/139
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.1-GTNH...1.11.2-GTNH
->
-
-## *1.11.1-GTNH*
->## What's Changed
->* NEI manual offset fix by @YannickMG in https://github.com/GTNewHorizons/OpenComputers/pull/138
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/138
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.11.0-GTNH...1.11.1-GTNH
->
-
-## *1.11.0-GTNH*
->## What's Changed
->* use buffer in LuaStateFactory file comparison by @charagarlnad in https://github.com/GTNewHorizons/OpenComputers/pull/137
->
->## New Contributors
->* @charagarlnad made their first contribution in https://github.com/GTNewHorizons/OpenComputers/pull/137
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenComputers/compare/1.10.27-GTNH...1.11.0-GTNH
->
+## What's Changed:
+>* Update to upstream 1.8.9a by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/154 (1.11.16-GTNH)
+>* Fix ME Upgrades tiers 1 and 3 being swapped by @IntQuant in https://github.com/GTNewHorizons/OpenComputers/pull/153 (1.11.15-GTNH)
+>* Sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/152 (1.11.13-GTNH)
+>* Extend OpenComputers Transposers to support fluid transfer rate upgrades by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/150 (1.11.12-GTNH)
+>* Accept capability for IBasicEnergyContainer & IGregTechDeviceInformation by @miozune in https://github.com/GTNewHorizons/OpenComputers/pull/151 (1.11.10-GTNH)
+>* Fix GT integration not working by @miozune in https://github.com/GTNewHorizons/OpenComputers/pull/149 (1.11.9-GTNH)
+>* Implement `getItemInNetwork`  by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/147 (1.11.8-GTNH)
+>* Fix overflow for large stack sizes in `storeInterfacePattern` by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/146 (1.11.7-GTNH)
+>* Remove old dependency. by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/145 (1.11.6-GTNH)
+>* Fix settings. by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/144 (1.11.6-GTNH)
+>* Add Integration for AE2FC Fluid Storage Cells by @Vlamonster in https://github.com/GTNewHorizons/OpenComputers/pull/143 (1.11.5-GTNH)
+>* fix client side memory leak on anything RedstoneAware by @Glease in https://github.com/GTNewHorizons/OpenComputers/pull/142 (1.11.4-GTNH)
+>* sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/140 (1.11.3-GTNH)
+>* sync with upstream by @asiekierka in https://github.com/GTNewHorizons/OpenComputers/pull/141 (1.11.3-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/OpenComputers/pull/139 (1.11.2-GTNH)
+>* NEI manual offset fix by @YannickMG in https://github.com/GTNewHorizons/OpenComputers/pull/138 (1.11.1-GTNH)
+>* use buffer in LuaStateFactory file comparison by @charagarlnad in https://github.com/GTNewHorizons/OpenComputers/pull/137 (1.11.0-GTNH)
 
 # Updated - OpenModsLib - 0.10.9 --> 0.10.10
-## *0.10.10*
->**Full Changelog**: https://github.com/GTNewHorizons/OpenModsLib/compare/0.10.9...0.10.10
->
+**Full Changelog**: https://github.com/GTNewHorizons/OpenModsLib/compare/0.10.9...0.10.10
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - OpenModularTurrets - 2.3.7 --> 2.4.3
-## *2.4.3*
->## What's Changed
->* Add Kill Count Tracking and GUI Updates for TurretBase by @mak8427 in https://github.com/GTNewHorizons/OpenModularTurrets/pull/9
->
->## New Contributors
->* @mak8427 made their first contribution in https://github.com/GTNewHorizons/OpenModularTurrets/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.4.2...2.4.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.3.7...2.4.3
 
-## *2.4.2*
->## What's Changed
->* improve targeting by reworking onImpact for projectiles by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/8
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.4.1...2.4.2
->
-
-## *2.4.1*
->## What's Changed
->* change targeting to use height/2 instead of getEyeHeight() of entities. by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/7
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.4.0...2.4.1
->
-
-## *2.4.0*
->## What's Changed
->* Updates for powering Turret Bases, no more IC2, but GT5 by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/6
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/OpenModularTurrets/compare/2.3.6...2.4.0
->
+## What's Changed:
+>* Add Kill Count Tracking and GUI Updates for TurretBase by @mak8427 in https://github.com/GTNewHorizons/OpenModularTurrets/pull/9 (2.4.3)
+>* improve targeting by reworking onImpact for projectiles by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/8 (2.4.2)
+>* change targeting to use height/2 instead of getEyeHeight() of entities. by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/7 (2.4.1)
+>* Updates for powering Turret Bases, no more IC2, but GT5 by @Keridos in https://github.com/GTNewHorizons/OpenModularTurrets/pull/6 (2.4.0)
 
 # Updated - Opis - 1.4.5-mapless --> 1.4.6-mapless
-## *1.4.6-mapless*
->**Full Changelog**: https://github.com/GTNewHorizons/Opis/compare/1.4.5-mapless...1.4.6-mapless
->
+**Full Changelog**: https://github.com/GTNewHorizons/Opis/compare/1.4.5-mapless...1.4.6-mapless
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - PersonalSpace - 1.0.32 --> 1.0.33
-## *1.0.33*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/PersonalSpace/pull/32
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/PersonalSpace/compare/1.0.32...1.0.33
->
+**Full Changelog**: https://github.com/GTNewHorizons/PersonalSpace/compare/1.0.32...1.0.33
+
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/PersonalSpace/pull/32 (1.0.33)
 
 # Updated - Postea - 1.0.13 --> 1.1.2
-## *1.1.2*
->## What's Changed
->* Fix falsepattern maven repo inclusion by @Cleptomania in https://github.com/GTNewHorizons/Postea/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Postea/compare/1.1.1...1.1.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/Postea/compare/1.0.13...1.1.2
 
-## *1.1.1*
->**Full Changelog**: https://github.com/GTNewHorizons/Postea/compare/1.1.0...1.1.1
->
-
-## *1.1.0*
->## What's Changed
->* Add nhlib explicit dep and stop using Tags.MODID/MODNAME by @mitchej123 in https://github.com/GTNewHorizons/Postea/pull/11
->* Compat patches for Vanilla/ChunkAPI/EndlessIDs by @FalsePattern in https://github.com/GTNewHorizons/Postea/pull/8
->
->## New Contributors
->* @FalsePattern made their first contribution in https://github.com/GTNewHorizons/Postea/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/Postea/compare/1.0.14...1.1.0
->
-
-## *1.0.14*
->## What's Changed
->* Significantly reduce Integer.valueOf() allocation spam by @mitchej123 in https://github.com/GTNewHorizons/Postea/pull/9
->
->## New Contributors
->* @mitchej123 made their first contribution in https://github.com/GTNewHorizons/Postea/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/Postea/compare/1.0.13...1.0.14
->
+## What's Changed:
+>* Fix falsepattern maven repo inclusion by @Cleptomania in https://github.com/GTNewHorizons/Postea/pull/12 (1.1.2)
+>* Add nhlib explicit dep and stop using Tags.MODID/MODNAME by @mitchej123 in https://github.com/GTNewHorizons/Postea/pull/11 (1.1.0)
+>* Compat patches for Vanilla/ChunkAPI/EndlessIDs by @FalsePattern in https://github.com/GTNewHorizons/Postea/pull/8 (1.1.0)
+>* Significantly reduce Integer.valueOf() allocation spam by @mitchej123 in https://github.com/GTNewHorizons/Postea/pull/9 (1.0.14)
 
 # Updated - ProjectRed - 4.11.0-GTNH --> 4.11.5-GTNH
-## *4.11.5-GTNH*
->## What's Changed
->* Add missing equals sign to `en_US.lang` by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ProjectRed/pull/44
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/44
->
->**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.11.4-GTNH...4.11.5-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.11.0-GTNH...4.11.5-GTNH
 
-## *4.11.4-GTNH*
->## What's Changed
->* Improve collision boxes for wires by @Vlamonster in https://github.com/GTNewHorizons/ProjectRed/pull/42
->
->## New Contributors
->* @Vlamonster made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/42
->
->**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.11.3-GTNH...4.11.4-GTNH
->
-
-## *4.11.3-GTNH*
->## What's Changed
->* Issue 19357. Fix integration PR and drawers by @qqqqqq452 in https://github.com/GTNewHorizons/ProjectRed/pull/41
->
->## New Contributors
->* @qqqqqq452 made their first contribution in https://github.com/GTNewHorizons/ProjectRed/pull/41
->
->**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.11.1-GTNH...4.11.3-GTNH
->
-
-## *4.11.1-GTNH*
->## What's Changed
->* Configs to Disable Modules by @DrParadox7 in https://github.com/GTNewHorizons/ProjectRed/pull/39
->* Undo config to disable entire Fabrication module by @DrParadox7 in https://github.com/GTNewHorizons/ProjectRed/pull/40
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ProjectRed/compare/4.11.0-GTNH...4.11.1-GTNH
->
+## What's Changed:
+>* Add missing equals sign to `en_US.lang` by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ProjectRed/pull/44 (4.11.5-GTNH)
+>* Improve collision boxes for wires by @Vlamonster in https://github.com/GTNewHorizons/ProjectRed/pull/42 (4.11.4-GTNH)
+>* Issue 19357. Fix integration PR and drawers by @qqqqqq452 in https://github.com/GTNewHorizons/ProjectRed/pull/41 (4.11.3-GTNH)
+>* Configs to Disable Modules by @DrParadox7 in https://github.com/GTNewHorizons/ProjectRed/pull/39 (4.11.1-GTNH)
+>* Undo config to disable entire Fabrication module by @DrParadox7 in https://github.com/GTNewHorizons/ProjectRed/pull/40 (4.11.1-GTNH)
 
 # Updated - Railcraft - 9.15.17 --> 9.16.30
-## *9.16.30*
->## What's Changed
->* add WDMLA plugin by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/89
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.28...9.16.30
->
+**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.15.17...9.16.30
 
-## *9.16.28*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/96
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.26...9.16.28
->
-
-## *9.16.26*
->## What's Changed
->* add Gregtech electricity info to Energy Loader and Energy Feeder by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/94
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.23...9.16.26
->
-
-## *9.16.23*
->## What's Changed
->* Rework block breaking to fix anchors not storing their time by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/93
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.21...9.16.23
->
-
-## *9.16.21*
->## What's Changed
->* Change `gregtech` optional decorator modid to `gregtech_nh` for GT6 compat by @felixfour in https://github.com/GTNewHorizons/Railcraft/pull/91
->* Fix null pointer itemStack crash by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/92
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/91
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.20...9.16.21
->
-
-## *9.16.20*
->## What's Changed
->* Only use Gregtech hazard functionality if the Gregtech module is enabled by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/88
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.19...9.16.20
->
-
-## *9.16.19*
->## What's Changed
->* Render gases in tanks by transparency instead of level by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/86
->* Fix unnecessary Math.max() from tank render by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/87
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.18...9.16.19
->
-
-## *9.16.18*
->## What's Changed
->* add support for IronTank upgrades by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/83
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.16...9.16.18
->
-
-## *9.16.16*
->## What's Changed
->* Add superclass function for IronTanks tank type by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/84
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.15...9.16.16
->
-
-## *9.16.15*
->## What's Changed
->* add Engineer'Overall API/Move engineer's overall into GregTech hazard system if gregtech is installed by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/73
->* add Steam trap protection to players wearing gas and heat hazmat by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/80
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.13...9.16.15
->
-
-## *9.16.13*
->## What's Changed
->* Tankcart access by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/82
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.11...9.16.13
->
-
-## *9.16.11*
->## What's Changed
->* Firestone burn API by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/76
->* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/Railcraft/pull/77
->* add GregTech energy net compatibility for the Electric Feeder and Energy Loader by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/74
->* Add config option to disable firestone igniting blocks around the player by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/78
->* Fix railcraft help command by @serenibyss in https://github.com/GTNewHorizons/Railcraft/pull/79
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/77
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.7...9.16.11
->
-
-## *9.16.7*
->## What's Changed
->* Add goggle aura API by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/72
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/72
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.4...9.16.7
->
-
-## *9.16.4*
->## What's Changed
->* Fix Water Tank string when using a Crafting Station by @Maratons4 in https://github.com/GTNewHorizons/Railcraft/pull/71
->
->## New Contributors
->* @Maratons4 made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/71
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.3...9.16.4
->
-
-## *9.16.3*
->## What's Changed
->* Adjust harvest level for water tank and coke oven brick by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/69
->* Adjust harvest level for water tank and coke oven brick pt 2 by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/70
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Railcraft/pull/69
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.2...9.16.3
->
-
-## *9.16.2*
->## What's Changed
->* Fix a trivial emerald loop by @chochem in https://github.com/GTNewHorizons/Railcraft/pull/67
->* dont remove coke trade in the last PR by @chochem in https://github.com/GTNewHorizons/Railcraft/pull/68
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.1...9.16.2
->
-
-## *9.16.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Railcraft/pull/66
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.16.0...9.16.1
->
-
-## *9.16.0*
->## What's Changed
->* Use a hand-harvestable material for Railcraft machines to reflect their harvesting behavior by @YannickMG in https://github.com/GTNewHorizons/Railcraft/pull/65
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Railcraft/compare/9.15.15...9.16.0
->
+## What's Changed:
+>* add WDMLA plugin by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/89 (9.16.30)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/96 (9.16.28)
+>* add Gregtech electricity info to Energy Loader and Energy Feeder by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/94 (9.16.26)
+>* Rework block breaking to fix anchors not storing their time by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/93 (9.16.23)
+>* Change `gregtech` optional decorator modid to `gregtech_nh` for GT6 compat by @felixfour in https://github.com/GTNewHorizons/Railcraft/pull/91 (9.16.21)
+>* Fix null pointer itemStack crash by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/92 (9.16.21)
+>* Only use Gregtech hazard functionality if the Gregtech module is enabled by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/88 (9.16.20)
+>* Render gases in tanks by transparency instead of level by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/86 (9.16.19)
+>* Fix unnecessary Math.max() from tank render by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/87 (9.16.19)
+>* add support for IronTank upgrades by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/83 (9.16.18)
+>* Add superclass function for IronTanks tank type by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/84 (9.16.16)
+>* add Engineer'Overall API/Move engineer's overall into GregTech hazard system if gregtech is installed by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/73 (9.16.15)
+>* add Steam trap protection to players wearing gas and heat hazmat by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/80 (9.16.15)
+>* Tankcart access by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/82 (9.16.13)
+>* Firestone burn API by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/76 (9.16.11)
+>* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/Railcraft/pull/77 (9.16.11)
+>* add GregTech energy net compatibility for the Electric Feeder and Energy Loader by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/74 (9.16.11)
+>* Add config option to disable firestone igniting blocks around the player by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/78 (9.16.11)
+>* Fix railcraft help command by @serenibyss in https://github.com/GTNewHorizons/Railcraft/pull/79 (9.16.11)
+>* Add goggle aura API by @2ndDerivative in https://github.com/GTNewHorizons/Railcraft/pull/72 (9.16.7)
+>* Fix Water Tank string when using a Crafting Station by @Maratons4 in https://github.com/GTNewHorizons/Railcraft/pull/71 (9.16.4)
+>* Adjust harvest level for water tank and coke oven brick by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/69 (9.16.3)
+>* Adjust harvest level for water tank and coke oven brick pt 2 by @Caedis in https://github.com/GTNewHorizons/Railcraft/pull/70 (9.16.3)
+>* Fix a trivial emerald loop by @chochem in https://github.com/GTNewHorizons/Railcraft/pull/67 (9.16.2)
+>* dont remove coke trade in the last PR by @chochem in https://github.com/GTNewHorizons/Railcraft/pull/68 (9.16.2)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/Railcraft/pull/66 (9.16.1)
+>* Use a hand-harvestable material for Railcraft machines to reflect their harvesting behavior by @YannickMG in https://github.com/GTNewHorizons/Railcraft/pull/65 (9.16.0)
 
 # Updated - Random-Things - 2.6.0 --> 2.6.5
-## *2.6.5*
->**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.4...2.6.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.0...2.6.5
 
-## *2.6.4*
->## What's Changed
->* Delete access transformer file by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/11
->* Optimize bloodmoon spawning algorithm and entity NBT access by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/10
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.3...2.6.4
->
-
-## *2.6.3*
->## What's Changed
->* Fix bloodmoon not checking gamerule by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/12
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.2...2.6.3
->
-
-## *2.6.2*
->## What's Changed
->* Fix bloodmoon code running in peaceful by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/9
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.1...2.6.2
->
-
-## *2.6.1*
->## What's Changed
->* Patch Misc Issue by @Connor-Colenso in https://github.com/GTNewHorizons/Random-Things/pull/8
->
->## New Contributors
->* @Connor-Colenso made their first contribution in https://github.com/GTNewHorizons/Random-Things/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/Random-Things/compare/2.6.0...2.6.1
->
+## What's Changed:
+>* Delete access transformer file by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/11 (2.6.4)
+>* Optimize bloodmoon spawning algorithm and entity NBT access by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/10 (2.6.4)
+>* Fix bloodmoon not checking gamerule by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/12 (2.6.3)
+>* Fix bloodmoon code running in peaceful by @Alexdoru in https://github.com/GTNewHorizons/Random-Things/pull/9 (2.6.2)
+>* Patch Misc Issue by @Connor-Colenso in https://github.com/GTNewHorizons/Random-Things/pull/8 (2.6.1)
 
 # Updated - RemoteIO - 2.7.4 --> 2.7.6
-## *2.7.6*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/RemoteIO/pull/24
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/RemoteIO/pull/24
->
->**Full Changelog**: https://github.com/GTNewHorizons/RemoteIO/compare/2.7.5...2.7.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/RemoteIO/compare/2.7.4...2.7.6
 
-## *2.7.5*
->## What's Changed
->* Remove unused contents by @zyf051520 in https://github.com/GTNewHorizons/RemoteIO/pull/23
->
->## New Contributors
->* @zyf051520 made their first contribution in https://github.com/GTNewHorizons/RemoteIO/pull/23
->
->**Full Changelog**: https://github.com/GTNewHorizons/RemoteIO/compare/2.7.4...2.7.5
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/RemoteIO/pull/24 (2.7.6)
+>* Remove unused contents by @zyf051520 in https://github.com/GTNewHorizons/RemoteIO/pull/23 (2.7.5)
 
 # Updated - Roguelike-Dungeons - 1.6.0-GTNH --> 1.6.6-GTNH
-## *1.6.6-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/8
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.6.5-GTNH...1.6.6-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.6.0-GTNH...1.6.6-GTNH
 
-## *1.6.5-GTNH*
->## What's Changed
->* Load dungeon settings in dependency order by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/7
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.6.3-GTNH...1.6.5-GTNH
->
-
-## *1.6.3-GTNH*
->## What's Changed
->* Allow spreading loot rules to multiple loot pools by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/6
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.6.2-GTNH...1.6.3-GTNH
->
-
-## *1.6.2-GTNH*
->## What's Changed
->* Support MC NBT strings by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/5
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/Roguelike-Dungeons/compare/1.6.0-GTNH...1.6.2-GTNH
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/8 (1.6.6-GTNH)
+>* Load dungeon settings in dependency order by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/7 (1.6.5-GTNH)
+>* Allow spreading loot rules to multiple loot pools by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/6 (1.6.3-GTNH)
+>* Support MC NBT strings by @YannickMG in https://github.com/GTNewHorizons/Roguelike-Dungeons/pull/5 (1.6.2-GTNH)
 
 # Updated - SC2 - 2.3.0 --> 2.3.11
-## *2.3.11*
->## What's Changed
->* Fix localization missing = by @Yoshy2002 in https://github.com/GTNewHorizons/SC2/pull/14
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/SC2/pull/14
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.10...2.3.11
->
+**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.0...2.3.11
 
-## *2.3.10*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/SC2/pull/13
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/SC2/pull/13
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.9...2.3.10
->
-
-## *2.3.9*
->## What's Changed
->* Add missing equals signs. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/SC2/pull/12
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/SC2/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.8...2.3.9
->
-
-## *2.3.8*
->## What's Changed
->* Added Support for IC2 Crops by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/10
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.6...2.3.8
->
-
-## *2.3.6*
->## What's Changed
->* Don't crash when Railcraft isn't loaded by @YannickMG in https://github.com/GTNewHorizons/SC2/pull/11
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/SC2/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.3...2.3.6
->
-
-## *2.3.3*
->## What's Changed
->* Added Electric Engines and Engine Tiers by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/9
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.1...2.3.3
->
-
-## *2.3.1*
->## What's Changed
->* Add Train Connector Module by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/8
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/SC2/compare/2.3.0...2.3.1
->
+## What's Changed:
+>* Fix localization missing = by @Yoshy2002 in https://github.com/GTNewHorizons/SC2/pull/14 (2.3.11)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/SC2/pull/13 (2.3.10)
+>* Add missing equals signs. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/SC2/pull/12 (2.3.9)
+>* Added Support for IC2 Crops by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/10 (2.3.8)
+>* Don't crash when Railcraft isn't loaded by @YannickMG in https://github.com/GTNewHorizons/SC2/pull/11 (2.3.6)
+>* Added Electric Engines and Engine Tiers by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/9 (2.3.3)
+>* Add Train Connector Module by @hpotter02 in https://github.com/GTNewHorizons/SC2/pull/8 (2.3.1)
 
 # New Mod - Salis-Arcana:1.1.22-GTNH
-## *1.1.22-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.21-GTNH...1.1.22-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.2-GTNH...1.1.22-GTNH
 
-## *1.1.21-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.20-GTNH...1.1.21-GTNH
->
-
-## *1.1.20-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.19-GTNH...1.1.20-GTNH
->
-
-## *1.1.19-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.18-GTNH...1.1.19-GTNH
->
-
-## *1.1.18-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.17-GTNH...1.1.18-GTNH
->
-
-## *1.1.17-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.16-GTNH...1.1.17-GTNH
->
-
-## *1.1.16-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.15-GTNH...1.1.16-GTNH
->
-
-## *1.1.15-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.14-GTNH...1.1.15-GTNH
->
-
-## *1.1.14-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.13-GTNH...1.1.14-GTNH
->
-
-## *1.1.13-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.12-GTNH...1.1.13-GTNH
->
-
-## *1.1.12-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.11-GTNH...1.1.12-GTNH
->
-
-## *1.1.11-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.10-GTNH...1.1.11-GTNH
->
-
-## *1.1.10-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.9-GTNH-pre...1.1.10-GTNH
->
-
-## *1.1.7-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.5-GTNH...1.1.7-GTNH
->
-
-## *1.1.5-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.4-GTNH...1.1.5-GTNH
->
-
-## *1.1.4-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.3-GTNH...1.1.4-GTNH
->
-
-## *1.1.3-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/compare/1.1.2-GTNH...1.1.3-GTNH
->
-
-## *1.1.2-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Salis-Arcana/commits/1.1.2-GTNH
->
-
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - Schematica - 1.12.2-GTNH --> 1.12.6-GTNH
 Mod is client-side only.
-## *1.12.6-GTNH*
->## What's Changed
->* Adding flipping for schematics by @Cardinalstars in https://github.com/GTNewHorizons/Schematica/pull/26
->
->## New Contributors
->* @Cardinalstars made their first contribution in https://github.com/GTNewHorizons/Schematica/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/Schematica/compare/1.12.4-GTNH...1.12.6-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Schematica/compare/1.12.2-GTNH...1.12.6-GTNH
 
-## *1.12.4-GTNH*
->## What's Changed
->* increased supported blockids to 65792 by @Fabboz in https://github.com/GTNewHorizons/Schematica/pull/25
->
->## New Contributors
->* @Fabboz made their first contribution in https://github.com/GTNewHorizons/Schematica/pull/25
->
->**Full Changelog**: https://github.com/GTNewHorizons/Schematica/compare/1.12.2-GTNH...1.12.4-GTNH
->
+## What's Changed:
+>* Adding flipping for schematics by @Cardinalstars in https://github.com/GTNewHorizons/Schematica/pull/26 (1.12.6-GTNH)
+>* increased supported blockids to 65792 by @Fabboz in https://github.com/GTNewHorizons/Schematica/pull/25 (1.12.4-GTNH)
 
 # Updated - ServerUtilities - 2.1.40 --> 5.1.55
-## *5.1.55*
->## What's Changed
->* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/ServerUtilities/pull/220
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/220
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.54...5.1.55
->
+**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.40...5.1.55
 
-## *2.1.54*
->## What's Changed
->* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/ServerUtilities/pull/217
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/217
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.52...2.1.54
->
-
-## *2.1.52*
->## What's Changed
->* Seek block command by @Connor-Colenso in https://github.com/GTNewHorizons/ServerUtilities/pull/198
->* Enderman Griefing by @koolkrafter5 in https://github.com/GTNewHorizons/ServerUtilities/pull/215
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/215
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.48...2.1.52
->
-
-## *2.1.48*
->## What's Changed
->* Don't leak WorldServer by @DarkShadow44 in https://github.com/GTNewHorizons/ServerUtilities/pull/213
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.46...2.1.48
->
-
-## *2.1.46*
->## What's Changed
->* Add config for pregeneration speed by @ah-OOG-ah in https://github.com/GTNewHorizons/ServerUtilities/pull/214
->* Fix player sleeping message by @xgpjun in https://github.com/GTNewHorizons/ServerUtilities/pull/212
->
->## New Contributors
->* @ah-OOG-ah made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/214
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.44...2.1.46
->
-
-## *2.1.44*
->## What's Changed
->* Optimize getTeamChunks() to not go through all claimed chunks by @Georggi in https://github.com/GTNewHorizons/ServerUtilities/pull/209
->* Replace server pausing "oneshot" feature with a mask by @nshepperd in https://github.com/GTNewHorizons/ServerUtilities/pull/208
->* Fix crash in Thermos server by @xgpjun in https://github.com/GTNewHorizons/ServerUtilities/pull/210
->
->## New Contributors
->* @Georggi made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/209
->* @nshepperd made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/208
->* @xgpjun made their first contribution in https://github.com/GTNewHorizons/ServerUtilities/pull/210
->
->**Full Changelog**: https://github.com/GTNewHorizons/ServerUtilities/compare/2.1.40...2.1.44
->
+## What's Changed:
+>* Convert to new IMixins and MixinsBuilder system by @Alexdoru in https://github.com/GTNewHorizons/ServerUtilities/pull/220 (5.1.55)
+>* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/ServerUtilities/pull/217 (2.1.54)
+>* Seek block command by @Connor-Colenso in https://github.com/GTNewHorizons/ServerUtilities/pull/198 (2.1.52)
+>* Enderman Griefing by @koolkrafter5 in https://github.com/GTNewHorizons/ServerUtilities/pull/215 (2.1.52)
+>* Don't leak WorldServer by @DarkShadow44 in https://github.com/GTNewHorizons/ServerUtilities/pull/213 (2.1.48)
+>* Add config for pregeneration speed by @ah-OOG-ah in https://github.com/GTNewHorizons/ServerUtilities/pull/214 (2.1.46)
+>* Fix player sleeping message by @xgpjun in https://github.com/GTNewHorizons/ServerUtilities/pull/212 (2.1.46)
+>* Optimize getTeamChunks() to not go through all claimed chunks by @Georggi in https://github.com/GTNewHorizons/ServerUtilities/pull/209 (2.1.44)
+>* Replace server pausing "oneshot" feature with a mask by @nshepperd in https://github.com/GTNewHorizons/ServerUtilities/pull/208 (2.1.44)
+>* Fix crash in Thermos server by @xgpjun in https://github.com/GTNewHorizons/ServerUtilities/pull/210 (2.1.44)
 
 # Updated - SpecialMobs - 3.6.2 --> 3.7.0
-## *3.7.0*
->## What's Changed
->* Notify forge event bus of dark creeper explosion by @dibbydoda in https://github.com/GTNewHorizons/SpecialMobs/pull/27
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/SpecialMobs/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/SpecialMobs/compare/3.6.2...3.7.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/SpecialMobs/compare/3.6.2...3.7.0
+
+## What's Changed:
+>* Notify forge event bus of dark creeper explosion by @dibbydoda in https://github.com/GTNewHorizons/SpecialMobs/pull/27 (3.7.0)
 
 # Updated - SpiceOfLife - 2.1.12-carrot --> 2.2.1-carrot
-## *2.2.1-carrot*
->## What's Changed
->* Fix fatal NPE by @ChromaPIE in https://github.com/GTNewHorizons/SpiceOfLife/pull/44
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/SpiceOfLife/compare/2.2.0-carrot...2.2.1-carrot
->
+**Full Changelog**: https://github.com/GTNewHorizons/SpiceOfLife/compare/2.1.12-carrot...2.2.1-carrot
 
-## *2.2.0-carrot*
->## What's Changed
->* Supplement locale by @ChromaPIE in https://github.com/GTNewHorizons/SpiceOfLife/pull/43
->
->## New Contributors
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/SpiceOfLife/pull/43
->
->**Full Changelog**: https://github.com/GTNewHorizons/SpiceOfLife/compare/2.1.12-carrot...2.2.0-carrot
->
+## What's Changed:
+>* Fix fatal NPE by @ChromaPIE in https://github.com/GTNewHorizons/SpiceOfLife/pull/44 (2.2.1-carrot)
+>* Supplement locale by @ChromaPIE in https://github.com/GTNewHorizons/SpiceOfLife/pull/43 (2.2.0-carrot)
 
 # Updated - Steve-s-Factory-Manager - 1.3.2-GTNH --> 1.3.4-GTNH
-## *1.3.4-GTNH*
->## What's Changed
->* Fix crash when component name contains non ASCII/Latin-1 characters by @reobf in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/16
->
->## New Contributors
->* @reobf made their first contribution in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/16
->
->**Full Changelog**: https://github.com/GTNewHorizons/Steve-s-Factory-Manager/compare/1.3.2-GTNH...1.3.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Steve-s-Factory-Manager/compare/1.3.2-GTNH...1.3.4-GTNH
+
+## What's Changed:
+>* Fix crash when component name contains non ASCII/Latin-1 characters by @reobf in https://github.com/GTNewHorizons/Steve-s-Factory-Manager/pull/16 (1.3.4-GTNH)
 
 # Updated - StevesAddons - 0.14.1 --> 0.14.2
-## *0.14.2*
->**Full Changelog**: https://github.com/GTNewHorizons/StevesAddons/compare/0.14.1...0.14.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/StevesAddons/compare/0.14.1...0.14.2
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - StorageDrawers - 2.1.0-GTNH --> 2.1.5-GTNH
-## *2.1.5-GTNH*
->## What's Changed
->* Impr(client): cache EntityItem in renderFancyItem for Fancy Rendering by @leagris in https://github.com/GTNewHorizons/StorageDrawers/pull/44
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/2.1.4-GTNH...2.1.5-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/2.1.0-GTNH...2.1.5-GTNH
 
-## *2.1.4-GTNH*
->## What's Changed
->* Cleanup drawer item dropping code and add new "mixed" behavior by @Alexdoru in https://github.com/GTNewHorizons/StorageDrawers/pull/42
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/2.1.3-GTNH...2.1.4-GTNH
->
-
-## *2.1.3-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/StorageDrawers/pull/41
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/StorageDrawers/pull/41
->
->**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/2.1.2-GTNH...2.1.3-GTNH
->
-
-## *2.1.2-GTNH*
->## What's Changed
->* Quantity key implementation by @cargocats in https://github.com/GTNewHorizons/StorageDrawers/pull/40
->
->## New Contributors
->* @cargocats made their first contribution in https://github.com/GTNewHorizons/StorageDrawers/pull/40
->
->**Full Changelog**: https://github.com/GTNewHorizons/StorageDrawers/compare/2.1.0-GTNH...2.1.2-GTNH
->
+## What's Changed:
+>* Impr(client): cache EntityItem in renderFancyItem for Fancy Rendering by @leagris in https://github.com/GTNewHorizons/StorageDrawers/pull/44 (2.1.5-GTNH)
+>* Cleanup drawer item dropping code and add new "mixed" behavior by @Alexdoru in https://github.com/GTNewHorizons/StorageDrawers/pull/42 (2.1.4-GTNH)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/StorageDrawers/pull/41 (2.1.3-GTNH)
+>* Quantity key implementation by @cargocats in https://github.com/GTNewHorizons/StorageDrawers/pull/40 (2.1.2-GTNH)
 
 # Updated - StructureCompat - 0.6.5 --> 0.7.2
-## *0.7.2*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/StructureCompat/pull/11
->* Update WCT by @Caedis in https://github.com/GTNewHorizons/StructureCompat/pull/12
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/StructureCompat/pull/11
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureCompat/compare/0.7.1...0.7.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/StructureCompat/compare/0.6.5...0.7.2
 
-## *0.7.1*
->## What's Changed
->* Remove BM compat by @koolkrafter5 in https://github.com/GTNewHorizons/StructureCompat/pull/10
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/StructureCompat/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureCompat/compare/0.7.0...0.7.1
->
-
-## *0.7.0*
->**Full Changelog**: https://github.com/GTNewHorizons/StructureCompat/compare/0.6.5...0.7.0
->
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/StructureCompat/pull/11 (0.7.2)
+>* Update WCT by @Caedis in https://github.com/GTNewHorizons/StructureCompat/pull/12 (0.7.2)
+>* Remove BM compat by @koolkrafter5 in https://github.com/GTNewHorizons/StructureCompat/pull/10 (0.7.1)
 
 # Updated - StructureLib - 1.3.6 --> 1.4.15
-## *1.4.15*
->## What's Changed
->* Delete overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/StructureLib/pull/44
->
->## New Contributors
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/StructureLib/pull/44
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.12...1.4.15
->
+**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.3.6...1.4.15
 
-## *1.4.12*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/StructureLib/pull/41
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/StructureLib/pull/41
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.10...1.4.12
->
-
-## *1.4.10*
->## What's Changed
->* add channel desc and channel indicator item by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/39
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.6...1.4.10
->
-
-## *1.4.6*
->## What's Changed
->* channel configure ui tweaks by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/35
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.4...1.4.6
->
-
-## *1.4.4*
->## What's Changed
->* fix unbreakable warded glass by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/37
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.2...1.4.4
->
-
-## *1.4.2*
->## What's Changed
->* Add Localization by @glowredman in https://github.com/GTNewHorizons/StructureLib/pull/36
->
->## New Contributors
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/StructureLib/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.4.0...1.4.2
->
-
-## *1.4.0*
->## What's Changed
->* Add error hint when block is invalid by @kstvr32 in https://github.com/GTNewHorizons/StructureLib/pull/31
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/StructureLib/compare/1.3.6...1.4.0
->
+## What's Changed:
+>* Delete overkill mixin registration system by @Alexdoru in https://github.com/GTNewHorizons/StructureLib/pull/44 (1.4.15)
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/StructureLib/pull/41 (1.4.12)
+>* add channel desc and channel indicator item by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/39 (1.4.10)
+>* channel configure ui tweaks by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/35 (1.4.6)
+>* fix unbreakable warded glass by @Glease in https://github.com/GTNewHorizons/StructureLib/pull/37 (1.4.4)
+>* Add Localization by @glowredman in https://github.com/GTNewHorizons/StructureLib/pull/36 (1.4.2)
+>* Add error hint when block is invalid by @kstvr32 in https://github.com/GTNewHorizons/StructureLib/pull/31 (1.4.0)
 
 # Updated - Super-TiC - 1.4.0 --> 1.5.0
-## *1.5.0*
->## What's Changed
->* Replace Baubles with Baubles-Expanded by @Caedis in https://github.com/GTNewHorizons/Super-TiC/pull/9
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Super-TiC/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/Super-TiC/compare/1.4.0...1.5.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/Super-TiC/compare/1.4.0...1.5.0
 
+## What's Changed:
+>* Replace Baubles with Baubles-Expanded by @Caedis in https://github.com/GTNewHorizons/Super-TiC/pull/9 (1.5.0)
+
+# Updated - TC-4-Tweaks - 1.5.28 --> 1.5.35
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - TCNEIAdditions - 1.4.8 --> 1.5.0
 Mod side changed from on both sides to client-side only.
-## *1.5.0*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/TCNEIAdditions/pull/30
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TCNEIAdditions/compare/1.4.8...1.5.0
->
+Mod is client-side only.
+**Full Changelog**: https://github.com/GTNewHorizons/TCNEIAdditions/compare/1.4.8...1.5.0
+
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/TCNEIAdditions/pull/30 (1.5.0)
 
 # Updated - TCNodeTracker - 1.3.2 --> 1.4.0
 Mod is client-side only.
-## *1.4.0*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TCNodeTracker/pull/12
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/TCNodeTracker/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/TCNodeTracker/compare/1.3.2...1.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/TCNodeTracker/compare/1.3.2...1.4.0
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TCNodeTracker/pull/12 (1.4.0)
 
 # Updated - TX-Loader - 1.7.3 --> 1.8.5
 Mod is client-side only.
-## *1.8.5*
->**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.8.4...1.8.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.7.3...1.8.5
 
-## *1.8.4*
->## What's Changed
->* Load `en_US.lang` Files on the Server by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/17
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.8.2...1.8.4
->
-
-## *1.8.2*
->## What's Changed
->* Add Logo and `mcmod.info` by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/15
->* Fix Metadata not working outside of the Development Environment by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/16
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.7.3...1.8.2
->
-
-## *1.8.0*
->**Full Changelog**: https://github.com/GTNewHorizons/TX-Loader/compare/1.7.2...1.8.0
->
+## What's Changed:
+>* Load `en_US.lang` Files on the Server by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/17 (1.8.4)
+>* Add Logo and `mcmod.info` by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/15 (1.8.2)
+>* Fix Metadata not working outside of the Development Environment by @glowredman in https://github.com/GTNewHorizons/TX-Loader/pull/16 (1.8.2)
 
 # Updated - Tainted-Magic - 7.6.15-GTNH --> 7.6.19-GTNH
-## *7.6.19-GTNH*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Tainted-Magic/pull/34
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/Tainted-Magic/pull/34
->
->**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.18-GTNH...7.6.19-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.15-GTNH...7.6.19-GTNH
 
-## *7.6.18-GTNH*
->## What's Changed
->* Change optional decorators' modid `gregtech` to `gregtech_nh` for gt6 compat by @felixfour in https://github.com/GTNewHorizons/Tainted-Magic/pull/33
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/Tainted-Magic/pull/33
->
->**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.17-GTNH...7.6.18-GTNH
->
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/Tainted-Magic/pull/34 (7.6.19-GTNH)
+>* Change optional decorators' modid `gregtech` to `gregtech_nh` for gt6 compat by @felixfour in https://github.com/GTNewHorizons/Tainted-Magic/pull/33 (7.6.18-GTNH)
+>* Change 'Voidmetal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/Tainted-Magic/pull/32 (7.6.17-GTNH)
+>* Add Hazard API onto Hazmat-capable armor pieces by @2ndDerivative in https://github.com/GTNewHorizons/Tainted-Magic/pull/31 (7.6.16-GTNH)
 
-## *7.6.17-GTNH*
->## What's Changed
->* Change 'Voidmetal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/Tainted-Magic/pull/32
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/Tainted-Magic/pull/32
->
->**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.16-GTNH...7.6.17-GTNH
->
-
-## *7.6.16-GTNH*
->## What's Changed
->* Add Hazard API onto Hazmat-capable armor pieces by @2ndDerivative in https://github.com/GTNewHorizons/Tainted-Magic/pull/31
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/Tainted-Magic/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/Tainted-Magic/compare/7.6.15-GTNH...7.6.16-GTNH
->
-
+# Updated - Thaumcraft NEI Plugin - 1.7a --> 1.7a
+Mod side changed from on both sides to client-side only.
+Mod is client-side only.
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - ThaumcraftMobAspects - 1.1.2-GTNH --> 1.2.0-GTNH
-## *1.2.0-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/5
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumcraftMobAspects/compare/1.1.2-GTNH...1.2.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumcraftMobAspects/compare/1.1.2-GTNH...1.2.0-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumcraftMobAspects/pull/5 (1.2.0-GTNH)
 
 # Updated - ThaumicBases - 1.7.8 --> 1.8.11
-## *1.8.11*
->## What's Changed
->* Refactor Leaves by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicBases/pull/52
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.9...1.8.11
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.7.8...1.8.11
 
-## *1.8.9*
->## What's Changed
->* Enable Jabel and generic injection by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicBases/pull/51
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/51
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.8...1.8.9
->
-
-## *1.8.8*
->## What's Changed
->* implement right click for Briar Crop by @Yoshy2002 in https://github.com/GTNewHorizons/ThaumicBases/pull/50
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.7...1.8.8
->
-
-## *1.8.7*
->## What's Changed
->* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/ThaumicBases/pull/49
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/49
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.6...1.8.7
->
-
-## *1.8.6*
->## What's Changed
->* node manipulator fix by @giantcavespider in https://github.com/GTNewHorizons/ThaumicBases/pull/48
->* fix rosehip syrup crash by @giantcavespider in https://github.com/GTNewHorizons/ThaumicBases/pull/47
->
->## New Contributors
->* @giantcavespider made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/48
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.3...1.8.6
->
-
-## *1.8.3*
->## What's Changed
->* Rename Rainbow Cacti to Rainbow Cactus by @OmdaCZ in https://github.com/GTNewHorizons/ThaumicBases/pull/46
->
->## New Contributors
->* @OmdaCZ made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/46
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.2...1.8.3
->
-
-## *1.8.2*
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.1...1.8.2
->
-
-## *1.8.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicBases/pull/45
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.8.0...1.8.1
->
-
-## *1.8.0*
->## What's Changed
->* Change primal shrooms behaviour by @Yoshy2002 in https://github.com/GTNewHorizons/ThaumicBases/pull/44
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/ThaumicBases/pull/44
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBases/compare/1.7.7...1.8.0
->
+## What's Changed:
+>* Refactor Leaves by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicBases/pull/52 (1.8.11)
+>* Enable Jabel and generic injection by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicBases/pull/51 (1.8.9)
+>* implement right click for Briar Crop by @Yoshy2002 in https://github.com/GTNewHorizons/ThaumicBases/pull/50 (1.8.8)
+>* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/ThaumicBases/pull/49 (1.8.7)
+>* node manipulator fix by @giantcavespider in https://github.com/GTNewHorizons/ThaumicBases/pull/48 (1.8.6)
+>* fix rosehip syrup crash by @giantcavespider in https://github.com/GTNewHorizons/ThaumicBases/pull/47 (1.8.6)
+>* Rename Rainbow Cacti to Rainbow Cactus by @OmdaCZ in https://github.com/GTNewHorizons/ThaumicBases/pull/46 (1.8.3)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicBases/pull/45 (1.8.1)
+>* Change primal shrooms behaviour by @Yoshy2002 in https://github.com/GTNewHorizons/ThaumicBases/pull/44 (1.8.0)
 
 # Updated - ThaumicBoots - 1.3.10 --> 1.4.7
-## *1.4.7*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/ThaumicBoots/pull/38
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/38
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.4.6...1.4.7
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.3.10...1.4.7
 
-## *1.4.6*
->## What's Changed
->* Change optional decorators' modid `gregtech` to `gregtech_nh` for compat by @felixfour in https://github.com/GTNewHorizons/ThaumicBoots/pull/37
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/37
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.4.5...1.4.6
->
-
-## *1.4.5*
->## What's Changed
->* support GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/ThaumicBoots/pull/36
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/36
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.4.4...1.4.5
->
-
-## *1.4.4*
->## What's Changed
->* Small refactor, add in support for the nanochestplate for thaumic boots by @Keridos in https://github.com/GTNewHorizons/ThaumicBoots/pull/35
->
->## New Contributors
->* @Keridos made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/35
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.4.2...1.4.4
->
-
-## *1.4.2*
->## What's Changed
->* Hotkey Updates by @Akeianova in https://github.com/GTNewHorizons/ThaumicBoots/pull/34
->
->## New Contributors
->* @Akeianova made their first contribution in https://github.com/GTNewHorizons/ThaumicBoots/pull/34
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.4.0...1.4.2
->
-
-## *1.4.0*
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicBoots/compare/1.3.10...1.4.0
->
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/ThaumicBoots/pull/38 (1.4.7)
+>* Change optional decorators' modid `gregtech` to `gregtech_nh` for compat by @felixfour in https://github.com/GTNewHorizons/ThaumicBoots/pull/37 (1.4.6)
+>* support GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/ThaumicBoots/pull/36 (1.4.5)
+>* Small refactor, add in support for the nanochestplate for thaumic boots by @Keridos in https://github.com/GTNewHorizons/ThaumicBoots/pull/35 (1.4.4)
+>* Hotkey Updates by @Akeianova in https://github.com/GTNewHorizons/ThaumicBoots/pull/34 (1.4.2)
 
 # Updated - ThaumicEnergistics - 1.6.27-GTNH --> 1.7.9-GTNH
-## *1.7.9-GTNH*
->## What's Changed
->* ui: improve Storage Cell tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/86
->* correct english localization spelling by @flamingowrangler2869 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/88
->
->## New Contributors
->* @Eldrinn-Elantey made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/86
->* @flamingowrangler2869 made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/88
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.8-GTNH...1.7.9-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.6.27-GTNH...1.7.9-GTNH
 
-## *1.7.8-GTNH*
->## What's Changed
->* Fix KekzTech jars not working with Essentia Export Buses by @ctrlaltmilk in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/85
->
->## New Contributors
->* @ctrlaltmilk made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/85
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.7-GTNH...1.7.8-GTNH
->
-
-## *1.7.7-GTNH*
->## What's Changed
->* Adapt to AE2 changes by @Kogepan229 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/84
->
->## New Contributors
->* @Kogepan229 made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/84
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.6-GTNH...1.7.7-GTNH
->
-
-## *1.7.6-GTNH*
->## What's Changed
->* Pre-partition creative essentia cell to every aspect by @FrostyFire1 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/83
->
->## New Contributors
->* @FrostyFire1 made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/83
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.5-GTNH...1.7.6-GTNH
->
-
-## *1.7.5-GTNH*
->## What's Changed
->* Void overflow and Distribution and Sticky card support for essentia cells by @lordIcocain in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/82
->
->## New Contributors
->* @lordIcocain made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/82
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.4-GTNH...1.7.5-GTNH
->
-
-## *1.7.4-GTNH*
->## What's Changed
->* Added cleanup for the fake essentia items by @RecursivePineapple in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/80
->
->## New Contributors
->* @RecursivePineapple made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/80
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.2-GTNH...1.7.4-GTNH
->
-
-## *1.7.2-GTNH*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/81
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.7.0-GTNH...1.7.2-GTNH
->
-
-## *1.7.0-GTNH*
->## What's Changed
->* Correct the spelling of matrixs to matrices and counting of them for the Infusion Provider by @Worive in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/79
->
->## New Contributors
->* @Worive made their first contribution in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/79
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicEnergistics/compare/1.6.27-GTNH...1.7.0-GTNH
->
+## What's Changed:
+>* ui: improve Storage Cell tooltip readability by @Eldrinn-Elantey in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/86 (1.7.9-GTNH)
+>* correct english localization spelling by @flamingowrangler2869 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/88 (1.7.9-GTNH)
+>* Fix KekzTech jars not working with Essentia Export Buses by @ctrlaltmilk in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/85 (1.7.8-GTNH)
+>* Adapt to AE2 changes by @Kogepan229 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/84 (1.7.7-GTNH)
+>* Pre-partition creative essentia cell to every aspect by @FrostyFire1 in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/83 (1.7.6-GTNH)
+>* Void overflow and Distribution and Sticky card support for essentia cells by @lordIcocain in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/82 (1.7.5-GTNH)
+>* Added cleanup for the fake essentia items by @RecursivePineapple in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/80 (1.7.4-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/81 (1.7.2-GTNH)
+>* Correct the spelling of matrixs to matrices and counting of them for the Infusion Provider by @Worive in https://github.com/GTNewHorizons/ThaumicEnergistics/pull/79 (1.7.0-GTNH)
 
 # Updated - ThaumicHorizons - 1.7.0 --> 1.7.5
-## *1.7.5*
->## What's Changed
->* Fix Illumine Lens interaction with other sources of night vision. by @AbdielKavash in https://github.com/GTNewHorizons/ThaumicHorizons/pull/91
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.7.4...1.7.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.7.0...1.7.5
 
-## *1.7.4*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/ThaumicHorizons/pull/86
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/ThaumicHorizons/pull/86
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.7.3...1.7.4
->
-
-## *1.7.3*
->## What's Changed
->* fix missing draw call and missing texture bind by @Glease in https://github.com/GTNewHorizons/ThaumicHorizons/pull/84
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.7.1...1.7.3
->
-
-## *1.7.1*
->## What's Changed
->* Fixes Liquefaction Focus by @DrParadox7 in https://github.com/GTNewHorizons/ThaumicHorizons/pull/72
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicHorizons/compare/1.7.0...1.7.1
->
+## What's Changed:
+>* Fix Illumine Lens interaction with other sources of night vision. by @AbdielKavash in https://github.com/GTNewHorizons/ThaumicHorizons/pull/91 (1.7.5)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/ThaumicHorizons/pull/86 (1.7.4)
+>* fix missing draw call and missing texture bind by @Glease in https://github.com/GTNewHorizons/ThaumicHorizons/pull/84 (1.7.3)
+>* Fixes Liquefaction Focus by @DrParadox7 in https://github.com/GTNewHorizons/ThaumicHorizons/pull/72 (1.7.1)
 
 # Updated - ThaumicTinkerer - 2.10.2 --> 2.11.15
-## *2.11.15*
->## What's Changed
->* Added functions into kami boots by @Coffee-beans-Pi in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/57
->
->## New Contributors
->* @Coffee-beans-Pi made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/57
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.13...2.11.15
->
+**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.10.2...2.11.15
 
-## *2.11.13*
->## What's Changed
->* Fix lang file problem with lang key by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/56
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/56
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.12...2.11.13
->
-
-## *2.11.12*
->## What's Changed
->* Fixed Wand Focus: Dislocation issue by @ABKQPO in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/55
->
->## New Contributors
->* @ABKQPO made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/55
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.11...2.11.12
->
-
-## *2.11.11*
->## What's Changed
->* delete gaia missile instead of repath it by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/54
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.10...2.11.11
->
-
-## *2.11.10*
->## What's Changed
->* Change optional decorators modid `gregtech` to `gregtech_nh` for compat by @felixfour in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/53
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/53
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.9...2.11.10
->
-
-## *2.11.9*
->## What's Changed
->* fix ichor pouch by @RubilaxXxx in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/52
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.8...2.11.9
->
-
-## *2.11.8*
->## What's Changed
->* cleanse the mod of its ae2 dep. by @RubilaxXxx in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/51
->* Move Awakened Kami Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/49
->
->## New Contributors
->* @RubilaxXxx made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/51
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/49
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.7...2.11.8
->
-
-## *2.11.7*
->## What's Changed
->* fix celestial gateway button render by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/46
->* make more resilient checks against existing blocks by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/47
->* try to fix gaia server hang by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/48
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.4...2.11.7
->
-
-## *2.11.4*
->## What's Changed
->* close container if parent item is gone by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/45
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.2...2.11.4
->
-
-## *2.11.2*
->## What's Changed
->* Essentia Funnel Bugfix by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/44
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/44
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.1...2.11.2
->
-
-## *2.11.1*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/43
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.11.0...2.11.1
->
-
-## *2.11.0*
->## What's Changed
->* Fixed crashes upon harvesting of Praecantatio Infused Seeds by @ClassixX in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/42
->
->## New Contributors
->* @ClassixX made their first contribution in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/42
->
->**Full Changelog**: https://github.com/GTNewHorizons/ThaumicTinkerer/compare/2.10.2...2.11.0
->
+## What's Changed:
+>* Added functions into kami boots by @Coffee-beans-Pi in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/57 (2.11.15)
+>* Fix lang file problem with lang key by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/56 (2.11.13)
+>* Fixed Wand Focus: Dislocation issue by @ABKQPO in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/55 (2.11.12)
+>* delete gaia missile instead of repath it by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/54 (2.11.11)
+>* Change optional decorators modid `gregtech` to `gregtech_nh` for compat by @felixfour in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/53 (2.11.10)
+>* fix ichor pouch by @RubilaxXxx in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/52 (2.11.9)
+>* cleanse the mod of its ae2 dep. by @RubilaxXxx in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/51 (2.11.8)
+>* Move Awakened Kami Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/49 (2.11.8)
+>* fix celestial gateway button render by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/46 (2.11.7)
+>* make more resilient checks against existing blocks by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/47 (2.11.7)
+>* try to fix gaia server hang by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/48 (2.11.7)
+>* close container if parent item is gone by @Glease in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/45 (2.11.4)
+>* Essentia Funnel Bugfix by @koolkrafter5 in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/44 (2.11.2)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/43 (2.11.1)
+>* Fixed crashes upon harvesting of Praecantatio Infused Seeds by @ClassixX in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/42 (2.11.0)
 
 # Updated - Thaumic_Exploration - 1.4.0-GTNH --> 1.4.2-GTNH
-## *1.4.2-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/Thaumic_Exploration/compare/1.4.0-GTNH...1.4.2-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/Thaumic_Exploration/compare/1.4.0-GTNH...1.4.2-GTNH
 
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - TiC-Tooltips - 1.3.1 --> 1.4.0
 Mod is client-side only.
-## *1.4.0*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TiC-Tooltips/pull/8
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/TiC-Tooltips/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/TiC-Tooltips/compare/1.3.1...1.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/TiC-Tooltips/compare/1.3.1...1.4.0
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TiC-Tooltips/pull/8 (1.4.0)
 
 # Updated - Tinkers-Defense - 1.3.1 --> 1.3.2
-## *1.3.2*
->## What's Changed
->* Fix shield tooltip formatting by @ChenMoFeiJin in https://github.com/GTNewHorizons/Tinkers-Defense/pull/6
->
->## New Contributors
->* @ChenMoFeiJin made their first contribution in https://github.com/GTNewHorizons/Tinkers-Defense/pull/6
->
->**Full Changelog**: https://github.com/GTNewHorizons/Tinkers-Defense/compare/1.3.1...1.3.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/Tinkers-Defense/compare/1.3.1...1.3.2
+
+## What's Changed:
+>* Fix shield tooltip formatting by @ChenMoFeiJin in https://github.com/GTNewHorizons/Tinkers-Defense/pull/6 (1.3.2)
 
 # Updated - TinkersConstruct - 1.12.18-GTNH --> 1.13.40-GTNH
-## *1.13.40-GTNH*
->## What's Changed
->* Add Autocrafting to Crafting Station by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/185
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.38-GTNH...1.13.40-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.12.18-GTNH...1.13.40-GTNH
 
-## *1.13.38-GTNH*
->## What's Changed
->* Fix health bar rendering broken above 120 hearts by @gaseet in https://github.com/GTNewHorizons/TinkersConstruct/pull/181
->
->## New Contributors
->* @gaseet made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/181
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.37-GTNH...1.13.38-GTNH
->
-
-## *1.13.37-GTNH*
->## What's Changed
->* Fix Bricks Diverting Redstone by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/184
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.35-GTNH...1.13.37-GTNH
->
-
-## *1.13.35-GTNH*
->## What's Changed
->* Fix the ender pearl clay gem pattern casting recipe by @Maratons4 in https://github.com/GTNewHorizons/TinkersConstruct/pull/183
->
->## New Contributors
->* @Maratons4 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/183
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.33-GTNH...1.13.35-GTNH
->
-
-## *1.13.33-GTNH*
->## What's Changed
->* Add missing equals sign. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/TinkersConstruct/pull/182
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/182
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.32-GTNH...1.13.33-GTNH
->
-
-## *1.13.32-GTNH*
->## What's Changed
->* Move clay quartz bucket resources to iguana tweaks by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/180
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.31-GTNH...1.13.32-GTNH
->
-
-## *1.13.31-GTNH*
->## What's Changed
->* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/178
->* Casting Table/Basin Facing Directions by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/177
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.28-GTNH...1.13.31-GTNH
->
-
-## *1.13.28-GTNH*
->## What's Changed
->* Add check for getCrop() being null by @cargocats in https://github.com/GTNewHorizons/TinkersConstruct/pull/176
->
->## New Contributors
->* @cargocats made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/176
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.27-GTNH...1.13.28-GTNH
->
-
-## *1.13.27-GTNH*
->## What's Changed
->* fix: tools registered to NEI that shouldn't has display NBT by @riggzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/173
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.25-GTNH...1.13.27-GTNH
->
-
-## *1.13.25-GTNH*
->## What's Changed
->* Restore the wooden rail by @AnrDaemon in https://github.com/GTNewHorizons/TinkersConstruct/pull/171
->
->## New Contributors
->* @AnrDaemon made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/171
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.23-GTNH...1.13.25-GTNH
->
-
-## *1.13.23-GTNH*
->## What's Changed
->* fix colored health bar not showing if disableAllRecipes is enabled by @felixfour in https://github.com/GTNewHorizons/TinkersConstruct/pull/174
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.21-GTNH...1.13.23-GTNH
->
-
-## *1.13.21-GTNH*
->## What's Changed
->* Add "Disable All Recipes" config option by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/TinkersConstruct/pull/169
->
->## New Contributors
->* @48a3efa65c881ef567345b17f3910e06 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/169
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.20-GTNH...1.13.21-GTNH
->
-
-## *1.13.20-GTNH*
->## What's Changed
->* delete old unfinished and unused minecart code by @2ndDerivative in https://github.com/GTNewHorizons/TinkersConstruct/pull/163
->* Fluids use still texture as fallback when flowing texture is missing by @Quarri6343 in https://github.com/GTNewHorizons/TinkersConstruct/pull/168
->* infinite loop fix & tool localization optimization by @riggzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/167
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/163
->* @Quarri6343 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/168
->* @riggzh made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/167
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.18-GTNH...1.13.20-GTNH
->
-
-## *1.13.18-GTNH*
->## What's Changed
->* Make the Scythe AOE harvest ability compatible with EnderCore by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/162
->* Only check for entities to damage if the structure is valid by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/161
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.16-GTNH...1.13.18-GTNH
->
-
-## *1.13.16-GTNH*
->## What's Changed
->* Prevent wasting bone meal on slimy saplings in survival. by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/160
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/160
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.15-GTNH...1.13.16-GTNH
->
-
-## *1.13.15-GTNH*
->## What's Changed
->* Allow the Scythe to harvest crops in an AOE by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/159
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.13-GTNH...1.13.15-GTNH
->
-
-## *1.13.13-GTNH*
->## What's Changed
->* Localization of drying rack nei recipe handler by @Discreater in https://github.com/GTNewHorizons/TinkersConstruct/pull/156
->* Change Rank Duration Localization key by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/157
->* Normalize Berry Bush rarity behavior by @MathiasDeWeerdt in https://github.com/GTNewHorizons/TinkersConstruct/pull/154
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/156
->* @MathiasDeWeerdt made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/154
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.10-GTNH...1.13.13-GTNH
->
-
-## *1.13.10-GTNH*
->## What's Changed
->* Set tinker tool pickup delay to standard 10 ticks by @serenibyss in https://github.com/GTNewHorizons/TinkersConstruct/pull/153
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/153
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.9-GTNH...1.13.10-GTNH
->
-
-## *1.13.9-GTNH*
->## What's Changed
->* Improve localization for tools by @ChromaPIE in https://github.com/GTNewHorizons/TinkersConstruct/pull/151
->
->## New Contributors
->* @ChromaPIE made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/151
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.8-GTNH...1.13.9-GTNH
->
-
-## *1.13.8-GTNH*
->## What's Changed
->* Don't display "Fuel" instead of the liquid's name when holding shift in the Smeltery UI by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/148
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.7-GTNH...1.13.8-GTNH
->
-
-## *1.13.7-GTNH*
->## What's Changed
->* Allow overriding AluminumBrass as the metal pattern material by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/147
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.4-GTNH...1.13.7-GTNH
->
-
-## *1.13.4-GTNH*
->## What's Changed
->* Fix blue slime spawn  by @paulzzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/146
->
->## New Contributors
->* @paulzzh made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/146
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.3-GTNH...1.13.4-GTNH
->
-
-## *1.13.3-GTNH*
->## What's Changed
->* check against `isSurfaceWorld()` instead of `dimensionId == 0` by @Pilzinsel64 in https://github.com/GTNewHorizons/TinkersConstruct/pull/145
->
->## New Contributors
->* @Pilzinsel64 made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/145
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.2-GTNH...1.13.3-GTNH
->
-
-## *1.13.2-GTNH*
->## What's Changed
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/TinkersConstruct/pull/144
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.1-GTNH...1.13.2-GTNH
->
-
-## *1.13.1-GTNH*
->## What's Changed
->* fix crash in AlloyMix.java by @iamcsharper in https://github.com/GTNewHorizons/TinkersConstruct/pull/141
->
->## New Contributors
->* @iamcsharper made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/141
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.13.0-GTNH...1.13.1-GTNH
->
-
-## *1.13.0-GTNH*
->## What's Changed
->* Ammo reinforced modifier support by @Akeianova in https://github.com/GTNewHorizons/TinkersConstruct/pull/140
->
->## New Contributors
->* @Akeianova made their first contribution in https://github.com/GTNewHorizons/TinkersConstruct/pull/140
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersConstruct/compare/1.12.16-GTNH...1.13.0-GTNH
->
+## What's Changed:
+>* Add Autocrafting to Crafting Station by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/185 (1.13.40-GTNH)
+>* Fix health bar rendering broken above 120 hearts by @gaseet in https://github.com/GTNewHorizons/TinkersConstruct/pull/181 (1.13.38-GTNH)
+>* Fix Bricks Diverting Redstone by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/184 (1.13.37-GTNH)
+>* Fix the ender pearl clay gem pattern casting recipe by @Maratons4 in https://github.com/GTNewHorizons/TinkersConstruct/pull/183 (1.13.35-GTNH)
+>* Add missing equals sign. by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/TinkersConstruct/pull/182 (1.13.33-GTNH)
+>* Move clay quartz bucket resources to iguana tweaks by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/180 (1.13.32-GTNH)
+>* Battlegear 2 for Backhand compat by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/178 (1.13.31-GTNH)
+>* Casting Table/Basin Facing Directions by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/177 (1.13.31-GTNH)
+>* Add check for getCrop() being null by @cargocats in https://github.com/GTNewHorizons/TinkersConstruct/pull/176 (1.13.28-GTNH)
+>* fix: tools registered to NEI that shouldn't has display NBT by @riggzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/173 (1.13.27-GTNH)
+>* Restore the wooden rail by @AnrDaemon in https://github.com/GTNewHorizons/TinkersConstruct/pull/171 (1.13.25-GTNH)
+>* fix colored health bar not showing if disableAllRecipes is enabled by @felixfour in https://github.com/GTNewHorizons/TinkersConstruct/pull/174 (1.13.23-GTNH)
+>* Add "Disable All Recipes" config option by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/TinkersConstruct/pull/169 (1.13.21-GTNH)
+>* delete old unfinished and unused minecart code by @2ndDerivative in https://github.com/GTNewHorizons/TinkersConstruct/pull/163 (1.13.20-GTNH)
+>* Fluids use still texture as fallback when flowing texture is missing by @Quarri6343 in https://github.com/GTNewHorizons/TinkersConstruct/pull/168 (1.13.20-GTNH)
+>* infinite loop fix & tool localization optimization by @riggzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/167 (1.13.20-GTNH)
+>* Make the Scythe AOE harvest ability compatible with EnderCore by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/162 (1.13.18-GTNH)
+>* Only check for entities to damage if the structure is valid by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/161 (1.13.18-GTNH)
+>* Prevent wasting bone meal on slimy saplings in survival. by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersConstruct/pull/160 (1.13.16-GTNH)
+>* Allow the Scythe to harvest crops in an AOE by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/159 (1.13.15-GTNH)
+>* Localization of drying rack nei recipe handler by @Discreater in https://github.com/GTNewHorizons/TinkersConstruct/pull/156 (1.13.13-GTNH)
+>* Change Rank Duration Localization key by @slprime in https://github.com/GTNewHorizons/TinkersConstruct/pull/157 (1.13.13-GTNH)
+>* Normalize Berry Bush rarity behavior by @MathiasDeWeerdt in https://github.com/GTNewHorizons/TinkersConstruct/pull/154 (1.13.13-GTNH)
+>* Set tinker tool pickup delay to standard 10 ticks by @serenibyss in https://github.com/GTNewHorizons/TinkersConstruct/pull/153 (1.13.10-GTNH)
+>* Improve localization for tools by @ChromaPIE in https://github.com/GTNewHorizons/TinkersConstruct/pull/151 (1.13.9-GTNH)
+>* Don't display "Fuel" instead of the liquid's name when holding shift in the Smeltery UI by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/148 (1.13.8-GTNH)
+>* Allow overriding AluminumBrass as the metal pattern material by @YannickMG in https://github.com/GTNewHorizons/TinkersConstruct/pull/147 (1.13.7-GTNH)
+>* Fix blue slime spawn  by @paulzzh in https://github.com/GTNewHorizons/TinkersConstruct/pull/146 (1.13.4-GTNH)
+>* check against `isSurfaceWorld()` instead of `dimensionId == 0` by @Pilzinsel64 in https://github.com/GTNewHorizons/TinkersConstruct/pull/145 (1.13.3-GTNH)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/TinkersConstruct/pull/144 (1.13.2-GTNH)
+>* fix crash in AlloyMix.java by @iamcsharper in https://github.com/GTNewHorizons/TinkersConstruct/pull/141 (1.13.1-GTNH)
+>* Ammo reinforced modifier support by @Akeianova in https://github.com/GTNewHorizons/TinkersConstruct/pull/140 (1.13.0-GTNH)
 
 # Updated - TinkersMechworks - 0.4.0 --> 0.4.1
-## *0.4.1*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersMechworks/pull/8
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/TinkersMechworks/pull/8
->
->**Full Changelog**: https://github.com/GTNewHorizons/TinkersMechworks/compare/0.4.0...0.4.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/TinkersMechworks/compare/0.4.0...0.4.1
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TinkersMechworks/pull/8 (0.4.1)
 
 # Updated - TooMuchLoot - 4.2.0-GTNH --> 4.3.0-GTNH
-## *4.3.0-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TooMuchLoot/pull/2
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/TooMuchLoot/pull/2
->
->**Full Changelog**: https://github.com/GTNewHorizons/TooMuchLoot/compare/4.2.0-GTNH...4.3.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/TooMuchLoot/compare/4.2.0-GTNH...4.3.0-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/TooMuchLoot/pull/2 (4.3.0-GTNH)
 
 # Updated - ToroHealth - 1.1.0 --> 1.2.0
 Mod is client-side only.
-## *1.2.0*
->## What's Changed
->* Fix 2 minor bugs by @Alexdoru in https://github.com/GTNewHorizons/ToroHealth/pull/4
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ToroHealth/compare/1.1.0...1.2.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/ToroHealth/compare/1.1.0...1.2.0
 
+## What's Changed:
+>* Fix 2 minor bugs by @Alexdoru in https://github.com/GTNewHorizons/ToroHealth/pull/4 (1.2.0)
+
+# Updated - UniLib - 1.0.5 --> 1.1.0
+Mod is client-side only.
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
+# Updated - UniMixins - 0.1.19 --> 0.1.22
+## What's Changed:
+DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.
 # Updated - Universal-Singularities - 8.9.0 --> 8.10.0
-## *8.10.0*
->## What's Changed
->* Add Rose Gold singularity, intended to replace Aluminum Brass singularity in recipes. by @YannickMG in https://github.com/GTNewHorizons/Universal-Singularities/pull/12
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/Universal-Singularities/pull/12
->
->**Full Changelog**: https://github.com/GTNewHorizons/Universal-Singularities/compare/8.9.0...8.10.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/Universal-Singularities/compare/8.9.0...8.10.0
+
+## What's Changed:
+>* Add Rose Gold singularity, intended to replace Aluminum Brass singularity in recipes. by @YannickMG in https://github.com/GTNewHorizons/Universal-Singularities/pull/12 (8.10.0)
 
 # Updated - VisualProspecting - 1.3.28 --> 1.4.3
-## *1.4.3*
->## What's Changed
->* Remove old GT5 compat by @serenibyss in https://github.com/GTNewHorizons/VisualProspecting/pull/67
->* Add search bar for highlighting veins/fluids in map ui by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/66
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/VisualProspecting/pull/67
->
->**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.4.2...1.4.3
->
+**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.3.28...1.4.3
 
-## *1.4.2*
->## What's Changed
->* Highlight searched underground fluids by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/64
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.4.0...1.4.2
->
-
-## *1.4.0*
->## What's Changed
->* Save vein cache using IO thread by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/63
->* Save ore veins with their string id by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/62
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/VisualProspecting/compare/1.3.28...1.4.0
->
+## What's Changed:
+>* Remove old GT5 compat by @serenibyss in https://github.com/GTNewHorizons/VisualProspecting/pull/67 (1.4.3)
+>* Add search bar for highlighting veins/fluids in map ui by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/66 (1.4.3)
+>* Highlight searched underground fluids by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/64 (1.4.2)
+>* Save vein cache using IO thread by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/63 (1.4.0)
+>* Save ore veins with their string id by @Lyfts in https://github.com/GTNewHorizons/VisualProspecting/pull/62 (1.4.0)
 
 # Updated - WAILAPlugins - 0.5.2 --> 0.6.0
-## *0.6.0*
->## What's Changed
->* Fix typo in lang file for Forestry apiaries by @koolkrafter5 in https://github.com/GTNewHorizons/WAILAPlugins/pull/19
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/WAILAPlugins/pull/19
->
->**Full Changelog**: https://github.com/GTNewHorizons/WAILAPlugins/compare/0.5.1...0.6.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/WAILAPlugins/compare/0.5.2...0.6.0
+
+## What's Changed:
+>* Fix typo in lang file for Forestry apiaries by @koolkrafter5 in https://github.com/GTNewHorizons/WAILAPlugins/pull/19 (0.6.0)
 
 # Updated - WAWLA - 1.3.0-GTNH --> 1.3.1-GTNH
-## *1.3.1-GTNH*
->## What's Changed
->* Remove erroneous newline by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/WAWLA/pull/7
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/WAWLA/pull/7
->
->**Full Changelog**: https://github.com/GTNewHorizons/WAWLA/compare/1.3.0-GTNH...1.3.1-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/WAWLA/compare/1.3.0-GTNH...1.3.1-GTNH
+
+## What's Changed:
+>* Remove erroneous newline by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/WAWLA/pull/7 (1.3.1-GTNH)
 
 # Updated - WailaHarvestability - 1.3.2-GTNH --> 1.3.4-GTNH
-## *1.3.4-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WailaHarvestability/pull/10
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/WailaHarvestability/pull/10
->
->**Full Changelog**: https://github.com/GTNewHorizons/WailaHarvestability/compare/1.3.3-GTNH...1.3.4-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/WailaHarvestability/compare/1.3.2-GTNH...1.3.4-GTNH
 
-## *1.3.3-GTNH*
->## What's Changed
->* fix loader check to not crash other GT versions by @felixfour in https://github.com/GTNewHorizons/WailaHarvestability/pull/9
->
->## New Contributors
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/WailaHarvestability/pull/9
->
->**Full Changelog**: https://github.com/GTNewHorizons/WailaHarvestability/compare/1.3.2-GTNH...1.3.3-GTNH
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WailaHarvestability/pull/10 (1.3.4-GTNH)
+>* fix loader check to not crash other GT versions by @felixfour in https://github.com/GTNewHorizons/WailaHarvestability/pull/9 (1.3.3-GTNH)
 
 # Updated - WanionLib - 1.9.0 --> 1.10.0
-## *1.10.0*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WanionLib/pull/3
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/WanionLib/pull/3
->
->**Full Changelog**: https://github.com/GTNewHorizons/WanionLib/compare/1.9.0...1.10.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/WanionLib/compare/1.9.0...1.10.0
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WanionLib/pull/3 (1.10.0)
 
 # Updated - WarpTheory - 1.4.3-GTNH --> 1.5.0-GTNH
-## *1.5.0-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WarpTheory/pull/45
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/WarpTheory/pull/45
->
->**Full Changelog**: https://github.com/GTNewHorizons/WarpTheory/compare/1.4.3-GTNH...1.5.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/WarpTheory/compare/1.4.3-GTNH...1.5.0-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/WarpTheory/pull/45 (1.5.0-GTNH)
 
 # Updated - WirelessCraftingTerminal - 1.11.7 --> 1.12.6
-## *1.12.6*
->## What's Changed
->* Added the Wireless Terminal to the new Baubles Terminal Slot. by @Ethryan in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/41
->
->## New Contributors
->* @Ethryan made their first contribution in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/41
->
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.12.4...1.12.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.11.7...1.12.6
 
-## *1.12.4*
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.12.3...1.12.4
->
-
-## *1.12.3*
->## What's Changed
->* make baubles optional  by @lordIcocain in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/40
->
->## New Contributors
->* @lordIcocain made their first contribution in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/40
->
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.12.2...1.12.3
->
-
-## *1.12.2*
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.12.1...1.12.2
->
-
-## *1.12.1*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/38
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/38
->
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.12.0...1.12.1
->
-
-## *1.12.0*
->## What's Changed
->* [Feature] Shift to pause wireless crafting terminal item movement by @michaeldoylecs in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/37
->
->## New Contributors
->* @michaeldoylecs made their first contribution in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/37
->
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessCraftingTerminal/compare/1.11.7...1.12.0
->
+## What's Changed:
+>* Added the Wireless Terminal to the new Baubles Terminal Slot. by @Ethryan in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/41 (1.12.6)
+>* make baubles optional  by @lordIcocain in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/40 (1.12.3)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/38 (1.12.1)
+>* [Feature] Shift to pause wireless crafting terminal item movement by @michaeldoylecs in https://github.com/GTNewHorizons/WirelessCraftingTerminal/pull/37 (1.12.0)
 
 # Updated - WirelessRedstone-CBE - 1.7.0 --> 1.7.1
-## *1.7.1*
->## What's Changed
->* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/WirelessRedstone-CBE/pull/13
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/WirelessRedstone-CBE/pull/13
->
->**Full Changelog**: https://github.com/GTNewHorizons/WirelessRedstone-CBE/compare/1.7.0...1.7.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/WirelessRedstone-CBE/compare/1.7.0...1.7.1
+
+## What's Changed:
+>* Add missing equals sign by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/WirelessRedstone-CBE/pull/13 (1.7.1)
 
 # Updated - WitchingGadgets - 1.5.17-GTNH --> 1.7.10-GTNH
-## *1.7.10-GTNH*
->## What's Changed
->* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
->
->## New Contributors
->* @ChibiChoko made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.9-GTNH...1.7.10-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.5.17-GTNH...1.7.10-GTNH
 
-## *1.7.10*
->## What's Changed
->* +fixed an issure where ruby ore will be converted into useless cluster by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/1
->* + added Coal Sifter boost by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/2
->* +added a catch by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/3
->* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/4
->* Reorder checks by @TechnicianLP in https://github.com/GTNewHorizons/WitchingGadgets/pull/5
->* Update TileEntitySpinningWheel.java by @jahtim in https://github.com/GTNewHorizons/WitchingGadgets/pull/7
->* Infernal blast furnace fix by @TimeConqueror in https://github.com/GTNewHorizons/WitchingGadgets/pull/9
->* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/10
->* Fixing stove by @ElNounch in https://github.com/GTNewHorizons/WitchingGadgets/pull/11
->* Make recipe oredict aware by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/12
->* Fix Mantle Of The Raven on ladders by @Sonnicon in https://github.com/GTNewHorizons/WitchingGadgets/pull/14
->* Fix fluid capsule bug by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/15
->* Add license by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/16
->* fix oilsand cluster returning wrong oil kind by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/17
->* Avoid pedantic warnings on ASM alterations by @ElNounch in https://github.com/GTNewHorizons/WitchingGadgets/pull/18
->* Fix cluster recipe hash collision by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/19
->* Migrated to unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/WitchingGadgets/pull/20
->* Create ru_RU.lang by @Quetz4l in https://github.com/GTNewHorizons/WitchingGadgets/pull/21
->* buff stone and snow by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/22
->* Add an ice solidifier that makes ice by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/23
->* Fix scribing tools recharge by @repo-alt in https://github.com/GTNewHorizons/WitchingGadgets/pull/24
->* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/25
->* LGPL-3.0 by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/26
->* Clarify license by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/27
->* fix an issue recipes disappeared when not in English by @iouter in https://github.com/GTNewHorizons/WitchingGadgets/pull/28
->* Fix lighting glitches when photo plates and others are put into item frames by @eigenraven in https://github.com/GTNewHorizons/WitchingGadgets/pull/29
->* Add shift-click interaction and quick label cleaning to the Aspect Li… by @YannickMG in https://github.com/GTNewHorizons/WitchingGadgets/pull/30
->* Workspace Fix for magic bees by @Shibva in https://github.com/GTNewHorizons/WitchingGadgets/pull/33
->* Update ContainerCuttingTable.java by @Shibva in https://github.com/GTNewHorizons/WitchingGadgets/pull/35
->* Fix flight by @Quetz4l in https://github.com/GTNewHorizons/WitchingGadgets/pull/34
->* Set coremod as childmod by @glowredman in https://github.com/GTNewHorizons/WitchingGadgets/pull/36
->* Keybinds by @Alexdoru in https://github.com/GTNewHorizons/WitchingGadgets/pull/37
->* Transfer coremod from ASM to Mixins by @Alexdoru in https://github.com/GTNewHorizons/WitchingGadgets/pull/38
->* Fix item equality check by @D-Cysteine in https://github.com/GTNewHorizons/WitchingGadgets/pull/39
->* Dev by @Dream-Master in https://github.com/GTNewHorizons/WitchingGadgets/pull/41
->* Fix terra primordial regen by @chochem in https://github.com/GTNewHorizons/WitchingGadgets/pull/42
->* Primordial Armor's repairing Fix & Buff by @Sheodar in https://github.com/GTNewHorizons/WitchingGadgets/pull/40
->* Fix Bewitched Robe hood rendering by @kumquat-ir in https://github.com/GTNewHorizons/WitchingGadgets/pull/43
->* Updates by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/44
->* remove ic2 maven by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/45
->* fix mistaken MCVersion warning from FML by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/46
->* [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/47
->* Remove lead from smeltery by @chochem in https://github.com/GTNewHorizons/WitchingGadgets/pull/48
->* Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/WitchingGadgets/pull/49
->* Fix Gauntlet container lock by @cons-tan-tan in https://github.com/GTNewHorizons/WitchingGadgets/pull/50
->* Make Vambraces of Steady Progression not push the player up/down when the player is flying by @norbby42 in https://github.com/GTNewHorizons/WitchingGadgets/pull/51
->* allow infernal blast furnace to drain essentia via mirrors by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/52
->* Fixed sync issue with Raven Kama glide toggle by @des-cuddlebat in https://github.com/GTNewHorizons/WitchingGadgets/pull/53
->* Raw ore support + recipe registration split by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/54
->* Fix bag slot handling by @Lyfts in https://github.com/GTNewHorizons/WitchingGadgets/pull/55
->* Cleanup by @Lyfts in https://github.com/GTNewHorizons/WitchingGadgets/pull/56
->* Infused Gem: Fixed too much durability use on blinding by @WaterShuriken in https://github.com/GTNewHorizons/WitchingGadgets/pull/57
->* Fix the Ageing stone by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/58
->* Fix the Ore Clusters only working for Stone ores by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/59
->* renaming by @NotAPenguin0 in https://github.com/GTNewHorizons/WitchingGadgets/pull/60
->* Fix stone ores to clusters (and NEI, thaumonomicon, etc) by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/61
->* Blacklist Thaumcraft clusters + made the file more readable by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/63
->* Thaumic boots dep + compat by @Nockyx in https://github.com/GTNewHorizons/WitchingGadgets/pull/65
->* Add Localizations by @glowredman in https://github.com/GTNewHorizons/WitchingGadgets/pull/68
->* Trying to get away from Travellers Gear by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/62
->* Move Primordial Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/WitchingGadgets/pull/69
->* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/WitchingGadgets/pull/71
->* Made most deps optional by @JackOfNoneTrades in https://github.com/GTNewHorizons/WitchingGadgets/pull/70
->* fix cloak issue by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/72
->* Change `gregtech` in decorator for hazmat method to `gregtech_nh` for better compat by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/73
->* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/75
->* add back the vis discount tooltip. by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/77
->* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
->* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
->
->## New Contributors
->* @bartimaeusnek made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/1
->* @Kiwi233 made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/4
->* @TechnicianLP made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/5
->* @jahtim made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/7
->* @TimeConqueror made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/9
->* @ElNounch made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/11
->* @Glease made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/12
->* @Sonnicon made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/14
->* @mitchej123 made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/16
->* @SinTh0r4s made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/20
->* @Quetz4l made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/21
->* @bombcar made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/22
->* @repo-alt made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/24
->* @iouter made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/28
->* @eigenraven made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/29
->* @Shibva made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/33
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/36
->* @Alexdoru made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/37
->* @D-Cysteine made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/39
->* @Dream-Master made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/41
->* @chochem made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/42
->* @Sheodar made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/40
->* @kumquat-ir made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/43
->* @kamenskyi made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/49
->* @cons-tan-tan made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/50
->* @norbby42 made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/51
->* @des-cuddlebat made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/53
->* @Ethryan made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/54
->* @Lyfts made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/55
->* @WaterShuriken made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/57
->* @felixfour made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/59
->* @NotAPenguin0 made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/60
->* @Nockyx made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/65
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/69
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/71
->* @JackOfNoneTrades made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/70
->* @RubilaxXxx made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/72
->* @70000hp made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
->* @ChibiChoko made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.2.7...1.7.10
->
-
-## *1.7.9-GTNH*
->## What's Changed
->* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
->
->## New Contributors
->* @70000hp made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.7-GTNH...1.7.9-GTNH
->
-
-## *1.7.7-GTNH*
->## What's Changed
->* add back the vis discount tooltip. by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/77
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.6-GTNH...1.7.7-GTNH
->
-
-## *1.7.6-GTNH*
->## What's Changed
->* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/75
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.5-GTNH...1.7.6-GTNH
->
-
-## *1.7.5-GTNH*
->## What's Changed
->* Change `gregtech` in decorator for hazmat method to `gregtech_nh` for better compat by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/73
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.4-GTNH...1.7.5-GTNH
->
-
-## *1.7.4-GTNH*
->## What's Changed
->* fix cloak issue by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/72
->
->## New Contributors
->* @RubilaxXxx made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/72
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.2-GTNH...1.7.4-GTNH
->
-
-## *1.7.2-GTNH*
->## What's Changed
->* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/WitchingGadgets/pull/71
->* Made most deps optional by @JackOfNoneTrades in https://github.com/GTNewHorizons/WitchingGadgets/pull/70
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/71
->* @JackOfNoneTrades made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/70
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.1-GTNH...1.7.2-GTNH
->
-
-## *1.7.1-GTNH*
->## What's Changed
->* Move Primordial Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/WitchingGadgets/pull/69
->
->## New Contributors
->* @2ndDerivative made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/69
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.0-GTNH...1.7.1-GTNH
->
-
-## *1.7.0-GTNH*
->## What's Changed
->* Trying to get away from Travellers Gear by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/62
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.6.0-GTNH...1.7.0-GTNH
->
-
-## *1.6.0-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.5.17-GTNH...1.6.0-GTNH
->
-
-## *1.5.21-GTNH.pre*
->## What's Changed
->* Fix Vambraces of Steady Progression by @YannickMG in https://github.com/GTNewHorizons/WitchingGadgets/pull/67
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.5.19-GTNH-pre...1.5.21-GTNH.pre
->
+## What's Changed:
+>* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78 (1.7.10-GTNH)
+>* +fixed an issure where ruby ore will be converted into useless cluster by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/1 (1.7.10)
+>* + added Coal Sifter boost by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/2 (1.7.10)
+>* +added a catch by @bartimaeusnek in https://github.com/GTNewHorizons/WitchingGadgets/pull/3 (1.7.10)
+>* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/4 (1.7.10)
+>* Reorder checks by @TechnicianLP in https://github.com/GTNewHorizons/WitchingGadgets/pull/5 (1.7.10)
+>* Update TileEntitySpinningWheel.java by @jahtim in https://github.com/GTNewHorizons/WitchingGadgets/pull/7 (1.7.10)
+>* Infernal blast furnace fix by @TimeConqueror in https://github.com/GTNewHorizons/WitchingGadgets/pull/9 (1.7.10)
+>* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/10 (1.7.10)
+>* Fixing stove by @ElNounch in https://github.com/GTNewHorizons/WitchingGadgets/pull/11 (1.7.10)
+>* Make recipe oredict aware by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/12 (1.7.10)
+>* Fix Mantle Of The Raven on ladders by @Sonnicon in https://github.com/GTNewHorizons/WitchingGadgets/pull/14 (1.7.10)
+>* Fix fluid capsule bug by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/15 (1.7.10)
+>* Add license by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/16 (1.7.10)
+>* fix oilsand cluster returning wrong oil kind by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/17 (1.7.10)
+>* Avoid pedantic warnings on ASM alterations by @ElNounch in https://github.com/GTNewHorizons/WitchingGadgets/pull/18 (1.7.10)
+>* Fix cluster recipe hash collision by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/19 (1.7.10)
+>* Migrated to unified build script by @SinTh0r4s in https://github.com/GTNewHorizons/WitchingGadgets/pull/20 (1.7.10)
+>* Create ru_RU.lang by @Quetz4l in https://github.com/GTNewHorizons/WitchingGadgets/pull/21 (1.7.10)
+>* buff stone and snow by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/22 (1.7.10)
+>* Add an ice solidifier that makes ice by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/23 (1.7.10)
+>* Fix scribing tools recharge by @repo-alt in https://github.com/GTNewHorizons/WitchingGadgets/pull/24 (1.7.10)
+>* Update zh_CN.lang by @Kiwi233 in https://github.com/GTNewHorizons/WitchingGadgets/pull/25 (1.7.10)
+>* LGPL-3.0 by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/26 (1.7.10)
+>* Clarify license by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/27 (1.7.10)
+>* fix an issue recipes disappeared when not in English by @iouter in https://github.com/GTNewHorizons/WitchingGadgets/pull/28 (1.7.10)
+>* Fix lighting glitches when photo plates and others are put into item frames by @eigenraven in https://github.com/GTNewHorizons/WitchingGadgets/pull/29 (1.7.10)
+>* Add shift-click interaction and quick label cleaning to the Aspect Li� by @YannickMG in https://github.com/GTNewHorizons/WitchingGadgets/pull/30 (1.7.10)
+>* Workspace Fix for magic bees by @Shibva in https://github.com/GTNewHorizons/WitchingGadgets/pull/33 (1.7.10)
+>* Update ContainerCuttingTable.java by @Shibva in https://github.com/GTNewHorizons/WitchingGadgets/pull/35 (1.7.10)
+>* Fix flight by @Quetz4l in https://github.com/GTNewHorizons/WitchingGadgets/pull/34 (1.7.10)
+>* Set coremod as childmod by @glowredman in https://github.com/GTNewHorizons/WitchingGadgets/pull/36 (1.7.10)
+>* Keybinds by @Alexdoru in https://github.com/GTNewHorizons/WitchingGadgets/pull/37 (1.7.10)
+>* Transfer coremod from ASM to Mixins by @Alexdoru in https://github.com/GTNewHorizons/WitchingGadgets/pull/38 (1.7.10)
+>* Fix item equality check by @D-Cysteine in https://github.com/GTNewHorizons/WitchingGadgets/pull/39 (1.7.10)
+>* Dev by @Dream-Master in https://github.com/GTNewHorizons/WitchingGadgets/pull/41 (1.7.10)
+>* Fix terra primordial regen by @chochem in https://github.com/GTNewHorizons/WitchingGadgets/pull/42 (1.7.10)
+>* Primordial Armor's repairing Fix & Buff by @Sheodar in https://github.com/GTNewHorizons/WitchingGadgets/pull/40 (1.7.10)
+>* Fix Bewitched Robe hood rendering by @kumquat-ir in https://github.com/GTNewHorizons/WitchingGadgets/pull/43 (1.7.10)
+>* Updates by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/44 (1.7.10)
+>* remove ic2 maven by @mitchej123 in https://github.com/GTNewHorizons/WitchingGadgets/pull/45 (1.7.10)
+>* fix mistaken MCVersion warning from FML by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/46 (1.7.10)
+>* [bs] fix buildscripts for jenkins by @bombcar in https://github.com/GTNewHorizons/WitchingGadgets/pull/47 (1.7.10)
+>* Remove lead from smeltery by @chochem in https://github.com/GTNewHorizons/WitchingGadgets/pull/48 (1.7.10)
+>* Update ru_RU.lang by @kamenskyi in https://github.com/GTNewHorizons/WitchingGadgets/pull/49 (1.7.10)
+>* Fix Gauntlet container lock by @cons-tan-tan in https://github.com/GTNewHorizons/WitchingGadgets/pull/50 (1.7.10)
+>* Make Vambraces of Steady Progression not push the player up/down when the player is flying by @norbby42 in https://github.com/GTNewHorizons/WitchingGadgets/pull/51 (1.7.10)
+>* allow infernal blast furnace to drain essentia via mirrors by @Glease in https://github.com/GTNewHorizons/WitchingGadgets/pull/52 (1.7.10)
+>* Fixed sync issue with Raven Kama glide toggle by @des-cuddlebat in https://github.com/GTNewHorizons/WitchingGadgets/pull/53 (1.7.10)
+>* Raw ore support + recipe registration split by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/54 (1.7.10)
+>* Fix bag slot handling by @Lyfts in https://github.com/GTNewHorizons/WitchingGadgets/pull/55 (1.7.10)
+>* Cleanup by @Lyfts in https://github.com/GTNewHorizons/WitchingGadgets/pull/56 (1.7.10)
+>* Infused Gem: Fixed too much durability use on blinding by @WaterShuriken in https://github.com/GTNewHorizons/WitchingGadgets/pull/57 (1.7.10)
+>* Fix the Ageing stone by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/58 (1.7.10)
+>* Fix the Ore Clusters only working for Stone ores by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/59 (1.7.10)
+>* renaming by @NotAPenguin0 in https://github.com/GTNewHorizons/WitchingGadgets/pull/60 (1.7.10)
+>* Fix stone ores to clusters (and NEI, thaumonomicon, etc) by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/61 (1.7.10)
+>* Blacklist Thaumcraft clusters + made the file more readable by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/63 (1.7.10)
+>* Thaumic boots dep + compat by @Nockyx in https://github.com/GTNewHorizons/WitchingGadgets/pull/65 (1.7.10)
+>* Add Localizations by @glowredman in https://github.com/GTNewHorizons/WitchingGadgets/pull/68 (1.7.10)
+>* Trying to get away from Travellers Gear by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/62 (1.7.10)
+>* Move Primordial Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/WitchingGadgets/pull/69 (1.7.10)
+>* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/WitchingGadgets/pull/71 (1.7.10)
+>* Made most deps optional by @JackOfNoneTrades in https://github.com/GTNewHorizons/WitchingGadgets/pull/70 (1.7.10)
+>* fix cloak issue by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/72 (1.7.10)
+>* Change `gregtech` in decorator for hazmat method to `gregtech_nh` for better compat by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/73 (1.7.10)
+>* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/75 (1.7.10)
+>* add back the vis discount tooltip. by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/77 (1.7.10)
+>* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76 (1.7.10)
+>* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78 (1.7.10)
+>* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76 (1.7.9-GTNH)
+>* add back the vis discount tooltip. by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/77 (1.7.7-GTNH)
+>* prevent infinite loader loop with other gt versions by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/75 (1.7.6-GTNH)
+>* Change `gregtech` in decorator for hazmat method to `gregtech_nh` for better compat by @felixfour in https://github.com/GTNewHorizons/WitchingGadgets/pull/73 (1.7.5-GTNH)
+>* fix cloak issue by @RubilaxXxx in https://github.com/GTNewHorizons/WitchingGadgets/pull/72 (1.7.4-GTNH)
+>* Change 'Void metal' -> 'Void Metal' by @serenibyss in https://github.com/GTNewHorizons/WitchingGadgets/pull/71 (1.7.2-GTNH)
+>* Made most deps optional by @JackOfNoneTrades in https://github.com/GTNewHorizons/WitchingGadgets/pull/70 (1.7.2-GTNH)
+>* Move Primordial Armor to GT Hazard API by @2ndDerivative in https://github.com/GTNewHorizons/WitchingGadgets/pull/69 (1.7.1-GTNH)
+>* Trying to get away from Travellers Gear by @Ethryan in https://github.com/GTNewHorizons/WitchingGadgets/pull/62 (1.7.0-GTNH)
+>* Fix Vambraces of Steady Progression by @YannickMG in https://github.com/GTNewHorizons/WitchingGadgets/pull/67 (1.5.21-GTNH.pre)
 
 # Updated - Yamcl - 0.6.0 --> 0.7.1
-## *0.7.1*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Yamcl/pull/6
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/Yamcl/pull/6
->
->**Full Changelog**: https://github.com/GTNewHorizons/Yamcl/compare/0.7.0...0.7.1
->
+**Full Changelog**: https://github.com/GTNewHorizons/Yamcl/compare/0.6.0...0.7.1
 
-## *0.7.0*
->## What's Changed
->* Add missing localization by @Discreater in https://github.com/GTNewHorizons/Yamcl/pull/5
->
->## New Contributors
->* @Discreater made their first contribution in https://github.com/GTNewHorizons/Yamcl/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/Yamcl/compare/0.6.0...0.7.0
->
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/Yamcl/pull/6 (0.7.1)
+>* Add missing localization by @Discreater in https://github.com/GTNewHorizons/Yamcl/pull/5 (0.7.0)
 
 # Updated - ae2stuff - 0.8.6-GTNH --> 0.9.6-GTNH
-## *0.9.6-GTNH*
->## What's Changed
->* Fix wording for Wireless Kit by @Yoshy2002 in https://github.com/GTNewHorizons/ae2stuff/pull/29
->
->## New Contributors
->* @Yoshy2002 made their first contribution in https://github.com/GTNewHorizons/ae2stuff/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.9.5-GTNH...0.9.6-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.8.6-GTNH...0.9.6-GTNH
 
-## *0.9.5-GTNH*
->## What's Changed
->* sneak sprint inverse fix :: tested (Y) by @PantACRO4life in https://github.com/GTNewHorizons/ae2stuff/pull/28
->
->## New Contributors
->* @PantACRO4life made their first contribution in https://github.com/GTNewHorizons/ae2stuff/pull/28
->
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.9.4-GTNH...0.9.5-GTNH
->
-
-## *0.9.4-GTNH*
->## What's Changed
->* Fix server-side keybind handling by @serenibyss in https://github.com/GTNewHorizons/ae2stuff/pull/27
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/ae2stuff/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.9.3-GTNH...0.9.4-GTNH
->
-
-## *0.9.3-GTNH*
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.9.2-GTNH...0.9.3-GTNH
->
-
-## *0.9.2-GTNH*
->## What's Changed
->* Wirelesshub by @lordIcocain in https://github.com/GTNewHorizons/ae2stuff/pull/24
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.9.0-GTNH...0.9.2-GTNH
->
-
-## *0.9.0-GTNH*
->## What's Changed
->* Fix ghost TE creation on breaking wireless in survival mode. by @lordIcocain in https://github.com/GTNewHorizons/ae2stuff/pull/26
->
->## New Contributors
->* @lordIcocain made their first contribution in https://github.com/GTNewHorizons/ae2stuff/pull/26
->
->**Full Changelog**: https://github.com/GTNewHorizons/ae2stuff/compare/0.8.5-GTNH...0.9.0-GTNH
->
+## What's Changed:
+>* Fix wording for Wireless Kit by @Yoshy2002 in https://github.com/GTNewHorizons/ae2stuff/pull/29 (0.9.6-GTNH)
+>* sneak sprint inverse fix :: tested (Y) by @PantACRO4life in https://github.com/GTNewHorizons/ae2stuff/pull/28 (0.9.5-GTNH)
+>* Fix server-side keybind handling by @serenibyss in https://github.com/GTNewHorizons/ae2stuff/pull/27 (0.9.4-GTNH)
+>* Wirelesshub by @lordIcocain in https://github.com/GTNewHorizons/ae2stuff/pull/24 (0.9.2-GTNH)
+>* Fix ghost TE creation on breaking wireless in survival mode. by @lordIcocain in https://github.com/GTNewHorizons/ae2stuff/pull/26 (0.9.0-GTNH)
 
 # Updated - amunra - 0.8.1 --> 0.8.2
-## *0.8.2*
->## What's Changed
->* Re-encode `pl_PL.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/amunra/pull/35
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/amunra/pull/35
->
->**Full Changelog**: https://github.com/GTNewHorizons/amunra/compare/0.8.1...0.8.2
->
+**Full Changelog**: https://github.com/GTNewHorizons/amunra/compare/0.8.1...0.8.2
+
+## What's Changed:
+>* Re-encode `pl_PL.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/amunra/pull/35 (0.8.2)
 
 # Updated - bdlib - 1.10.0-GTNH --> 1.11.0-GTNH
-## *1.11.0-GTNH*
->## What's Changed
->* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/bdlib/pull/5
->
->## New Contributors
->* @koolkrafter5 made their first contribution in https://github.com/GTNewHorizons/bdlib/pull/5
->
->**Full Changelog**: https://github.com/GTNewHorizons/bdlib/compare/1.10.0-GTNH...1.11.0-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/bdlib/compare/1.10.0-GTNH...1.11.0-GTNH
+
+## What's Changed:
+>* Update dev username by @koolkrafter5 in https://github.com/GTNewHorizons/bdlib/pull/5 (1.11.0-GTNH)
 
 # Updated - gendustry - 1.9.0-GTNH --> 1.9.3-GTNH
-## *1.9.3-GTNH*
->## What's Changed
->* Fix electric tool discharge behavior by @serenibyss in https://github.com/GTNewHorizons/gendustry/pull/17
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/gendustry/pull/17
->
->**Full Changelog**: https://github.com/GTNewHorizons/gendustry/compare/1.9.1-GTNH...1.9.3-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/gendustry/compare/1.9.0-GTNH...1.9.3-GTNH
 
-## *1.9.1-GTNH*
->## What's Changed
->* Fixes for non-GTNH environment by @miozune in https://github.com/GTNewHorizons/gendustry/pull/16
->
->## New Contributors
->* @miozune made their first contribution in https://github.com/GTNewHorizons/gendustry/pull/16
->
->**Full Changelog**: https://github.com/GTNewHorizons/gendustry/compare/1.9.0-GTNH...1.9.1-GTNH
->
+## What's Changed:
+>* Fix electric tool discharge behavior by @serenibyss in https://github.com/GTNewHorizons/gendustry/pull/17 (1.9.3-GTNH)
+>* Fixes for non-GTNH environment by @miozune in https://github.com/GTNewHorizons/gendustry/pull/16 (1.9.1-GTNH)
 
 # Updated - harvestcraft - 1.2.3-GTNH --> 1.3.2-GTNH
-## *1.3.2-GTNH*
->## What's Changed
->* Fix spaghetti typo by @Taskeren in https://github.com/GTNewHorizons/harvestcraft/pull/65
->
->## New Contributors
->* @Taskeren made their first contribution in https://github.com/GTNewHorizons/harvestcraft/pull/65
->
->**Full Changelog**: https://github.com/GTNewHorizons/harvestcraft/compare/1.3.1-GTNH...1.3.2-GTNH
->
+**Full Changelog**: https://github.com/GTNewHorizons/harvestcraft/compare/1.2.3-GTNH...1.3.2-GTNH
 
-## *1.3.1-GTNH*
->## What's Changed
->* Add NEI Handlers for Traps by @glowredman in https://github.com/GTNewHorizons/harvestcraft/pull/64
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/harvestcraft/compare/1.3.0-GTNH...1.3.1-GTNH
->
-
-## *1.3.0-GTNH*
->## What's Changed
->* Cleanup by @glowredman in https://github.com/GTNewHorizons/harvestcraft/pull/63
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/harvestcraft/compare/1.2.3-GTNH...1.3.0-GTNH
->
+## What's Changed:
+>* Fix spaghetti typo by @Taskeren in https://github.com/GTNewHorizons/harvestcraft/pull/65 (1.3.2-GTNH)
+>* Add NEI Handlers for Traps by @glowredman in https://github.com/GTNewHorizons/harvestcraft/pull/64 (1.3.1-GTNH)
+>* Cleanup by @glowredman in https://github.com/GTNewHorizons/harvestcraft/pull/63 (1.3.0-GTNH)
 
 # Updated - ironchest - 6.1.1 --> 6.1.6
-## *6.1.6*
->## What's Changed
->* Update IronChest_at.cfg by @Caedis in https://github.com/GTNewHorizons/ironchest/pull/32
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.1.5...6.1.6
->
+**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.1.1...6.1.6
 
-## *6.1.5*
->## What's Changed
->* Small cleanups by @Charsy89 in https://github.com/GTNewHorizons/ironchest/pull/31
->* Implemented Ocelots sitting on Iron Chests, with configurable chest-blocking behavior by @Charsy89 in https://github.com/GTNewHorizons/ironchest/pull/30
->
->## New Contributors
->* @Charsy89 made their first contribution in https://github.com/GTNewHorizons/ironchest/pull/31
->
->**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.1.3...6.1.5
->
-
-## *6.1.3*
->## What's Changed
->* Add missing language key by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ironchest/pull/29
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/ironchest/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.1.2...6.1.3
->
-
-## *6.1.2*
->## What's Changed
->* New textures by krezhvick by @Caedis in https://github.com/GTNewHorizons/ironchest/pull/27
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/ironchest/compare/6.1.1...6.1.2
->
+## What's Changed:
+>* Update IronChest_at.cfg by @Caedis in https://github.com/GTNewHorizons/ironchest/pull/32 (6.1.6)
+>* Small cleanups by @Charsy89 in https://github.com/GTNewHorizons/ironchest/pull/31 (6.1.5)
+>* Implemented Ocelots sitting on Iron Chests, with configurable chest-blocking behavior by @Charsy89 in https://github.com/GTNewHorizons/ironchest/pull/30 (6.1.5)
+>* Add missing language key by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/ironchest/pull/29 (6.1.3)
+>* New textures by krezhvick by @Caedis in https://github.com/GTNewHorizons/ironchest/pull/27 (6.1.2)
 
 # Updated - lwjgl3ify - 2.1.9 --> 2.1.14
-## *2.1.14*
->**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.13...2.1.14
->
+**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.9...2.1.14
 
-## *2.1.13*
->## What's Changed
->* Fix unicode by @QuanhuZeYu in https://github.com/GTNewHorizons/lwjgl3ify/pull/222
->
->## New Contributors
->* @QuanhuZeYu made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/222
->
->**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.12...2.1.13
->
-
-## *2.1.12*
->## What's Changed
->* Remove -XstartOnFirstThread in version.json for macOS by @k0michi in https://github.com/GTNewHorizons/lwjgl3ify/pull/217
->
->## New Contributors
->* @k0michi made their first contribution in https://github.com/GTNewHorizons/lwjgl3ify/pull/217
->
->**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.11...2.1.12
->
-
-## *2.1.11*
->**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.10...2.1.11
->
-
-## *2.1.10*
->## What's Changed
->* Remove unsupported jvm versions from the prism launcher manifest by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/207
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/lwjgl3ify/compare/2.1.9...2.1.10
->
+## What's Changed:
+>* Fix unicode by @QuanhuZeYu in https://github.com/GTNewHorizons/lwjgl3ify/pull/222 (2.1.13)
+>* Remove -XstartOnFirstThread in version.json for macOS by @k0michi in https://github.com/GTNewHorizons/lwjgl3ify/pull/217 (2.1.12)
+>* Remove unsupported jvm versions from the prism launcher manifest by @eigenraven in https://github.com/GTNewHorizons/lwjgl3ify/pull/207 (2.1.10)
 
 # Updated - nei-custom-diagram - 1.6.8 --> 1.7.5
-## *1.7.5*
->## What's Changed
->* Remove multi-ingots from NEI material page by @StaffiX in https://github.com/GTNewHorizons/nei-custom-diagram/pull/47
->
->## New Contributors
->* @StaffiX made their first contribution in https://github.com/GTNewHorizons/nei-custom-diagram/pull/47
->
->**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.7.3...1.7.5
->
+**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.6.8...1.7.5
 
-## *1.7.3*
->**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.7.2...1.7.3
->
-
-## *1.7.2*
->## What's Changed
->* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/nei-custom-diagram/pull/46
->
->## New Contributors
->* @YannickMG made their first contribution in https://github.com/GTNewHorizons/nei-custom-diagram/pull/46
->
->**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.7.1...1.7.2
->
-
-## *1.7.1*
->**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.7.0...1.7.1
->
-
-## *1.7.0*
->## What's Changed
->* Remove unused tool bits by @Connor-Colenso in https://github.com/GTNewHorizons/nei-custom-diagram/pull/44
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/nei-custom-diagram/compare/1.6.8...1.7.0
->
+## What's Changed:
+>* Remove multi-ingots from NEI material page by @StaffiX in https://github.com/GTNewHorizons/nei-custom-diagram/pull/47 (1.7.5)
+>* com.dreammaster.item.ItemList -> NHItemList by @YannickMG in https://github.com/GTNewHorizons/nei-custom-diagram/pull/46 (1.7.2)
+>* Remove unused tool bits by @Connor-Colenso in https://github.com/GTNewHorizons/nei-custom-diagram/pull/44 (1.7.0)
 
 # Updated - supersolarpanels - 1.1.3 --> 1.1.4
-## *1.1.4*
->## What's Changed
->* Update buildscript, fix in-game version and mcmod.info by @serenibyss in https://github.com/GTNewHorizons/supersolarpanels/pull/1
->
->## New Contributors
->* @serenibyss made their first contribution in https://github.com/GTNewHorizons/supersolarpanels/pull/1
->
->**Full Changelog**: https://github.com/GTNewHorizons/supersolarpanels/compare/1.1.3...1.1.4
->
+**Full Changelog**: https://github.com/GTNewHorizons/supersolarpanels/compare/1.1.3...1.1.4
+
+## What's Changed:
+>* Update buildscript, fix in-game version and mcmod.info by @serenibyss in https://github.com/GTNewHorizons/supersolarpanels/pull/1 (1.1.4)
 
 # Updated - thaumcraft-research-tweaks - 1.2.0 --> 1.3.0
-## *1.3.0*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/thaumcraft-research-tweaks/pull/16
->
->## New Contributors
->* @Caedis made their first contribution in https://github.com/GTNewHorizons/thaumcraft-research-tweaks/pull/16
->
->**Full Changelog**: https://github.com/GTNewHorizons/thaumcraft-research-tweaks/compare/1.2.0...1.3.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/thaumcraft-research-tweaks/compare/1.2.0...1.3.0
+
+## What's Changed:
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/thaumcraft-research-tweaks/pull/16 (1.3.0)
 
 # Updated - thaumicinsurgence - 0.3.1 --> 0.4.0
-## *0.4.0*
->## What's Changed
->* updating the soap use tick times by @Rafadaz in https://github.com/GTNewHorizons/thaumicinsurgence/pull/41
->* Revert "updating the soap use tick times" by @boubou19 in https://github.com/GTNewHorizons/thaumicinsurgence/pull/43
->* Add Localization by @glowredman in https://github.com/GTNewHorizons/thaumicinsurgence/pull/45
->
->## New Contributors
->* @Rafadaz made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/41
->* @boubou19 made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/43
->* @glowredman made their first contribution in https://github.com/GTNewHorizons/thaumicinsurgence/pull/45
->
->**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.3.1...0.4.0
->
+**Full Changelog**: https://github.com/GTNewHorizons/thaumicinsurgence/compare/0.3.1...0.4.0
+
+## What's Changed:
+>* updating the soap use tick times by @Rafadaz in https://github.com/GTNewHorizons/thaumicinsurgence/pull/41 (0.4.0)
+>* Revert "updating the soap use tick times" by @boubou19 in https://github.com/GTNewHorizons/thaumicinsurgence/pull/43 (0.4.0)
+>* Add Localization by @glowredman in https://github.com/GTNewHorizons/thaumicinsurgence/pull/45 (0.4.0)
 
 # Updated - twilightforest - 2.6.37 --> 2.7.8
-## *2.7.8*
->## What's Changed
->* Fix an incorrect asset path for the mob.yeti.pant sound by @Charsy89 in https://github.com/GTNewHorizons/twilightforest/pull/114
->
->## New Contributors
->* @Charsy89 made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/114
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.7...2.7.8
->
+**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.6.37...2.7.8
 
-## *2.7.7*
->## What's Changed
->* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/twilightforest/pull/111
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.6...2.7.7
->
-
-## *2.7.6*
->## What's Changed
->* Don't leak player inventory map by @DarkShadow44 in https://github.com/GTNewHorizons/twilightforest/pull/109
->
->## New Contributors
->* @DarkShadow44 made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/109
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.5...2.7.6
->
-
-## *2.7.5*
->## What's Changed
->* Fix Druid Hut Wood Slabs Being Stone by @Ruling-0 in https://github.com/GTNewHorizons/twilightforest/pull/104
->
->## New Contributors
->* @Ruling-0 made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/104
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.4...2.7.5
->
-
-## *2.7.4*
->## What's Changed
->* Raven's Raven Protection PR by @eigenraven in https://github.com/GTNewHorizons/twilightforest/pull/102
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.3...2.7.4
->
-
-## *2.7.3*
->## What's Changed
->* Fix biome IDs over 255 not working for Magic Map and the Stream biome by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/twilightforest/pull/97
->
->## New Contributors
->* @48a3efa65c881ef567345b17f3910e06 made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/97
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.2...2.7.3
->
-
-## *2.7.2*
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.1...2.7.2
->
-
-## *2.7.1*
->## What's Changed
->* Reuse modelview in firefly render by @charagarlnad in https://github.com/GTNewHorizons/twilightforest/pull/95
->
->## New Contributors
->* @charagarlnad made their first contribution in https://github.com/GTNewHorizons/twilightforest/pull/95
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.7.0...2.7.1
->
-
-## *2.7.0*
->## What's Changed
->* Add conquered mark into the magic map by @zhehedream in https://github.com/GTNewHorizons/twilightforest/pull/92
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/twilightforest/compare/2.6.35...2.7.0
->
+## What's Changed:
+>* Fix an incorrect asset path for the mob.yeti.pant sound by @Charsy89 in https://github.com/GTNewHorizons/twilightforest/pull/114 (2.7.8)
+>* Replace Baubles with Baubles Expanded by @Caedis in https://github.com/GTNewHorizons/twilightforest/pull/111 (2.7.7)
+>* Don't leak player inventory map by @DarkShadow44 in https://github.com/GTNewHorizons/twilightforest/pull/109 (2.7.6)
+>* Fix Druid Hut Wood Slabs Being Stone by @Ruling-0 in https://github.com/GTNewHorizons/twilightforest/pull/104 (2.7.5)
+>* Raven's Raven Protection PR by @eigenraven in https://github.com/GTNewHorizons/twilightforest/pull/102 (2.7.4)
+>* Fix biome IDs over 255 not working for Magic Map and the Stream biome by @48a3efa65c881ef567345b17f3910e06 in https://github.com/GTNewHorizons/twilightforest/pull/97 (2.7.3)
+>* Reuse modelview in firefly render by @charagarlnad in https://github.com/GTNewHorizons/twilightforest/pull/95 (2.7.1)
+>* Add conquered mark into the magic map by @zhehedream in https://github.com/GTNewHorizons/twilightforest/pull/92 (2.7.0)
 
 # Updated - waila - 1.8.2 --> 1.8.12
-## *1.8.12*
->## What's Changed
->* Fix FMLLoadCompleteEvent using wrong annotation by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/37
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.11...1.8.12
->
+**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.2...1.8.12
 
-## *1.8.11*
->## What's Changed
->* Delete redundant registration via reflection by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/36
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.10...1.8.11
->
+## What's Changed:
+>* Fix FMLLoadCompleteEvent using wrong annotation by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/37 (1.8.12)
+>* Delete redundant registration via reflection by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/36 (1.8.11)
+>* [Memory-opti:fix leak] Fix WorldClient leak in WailaTickHandler and RayTracing by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/31 (1.8.10)
+>* Re-encode `cs_CZ.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/waila/pull/32 (1.8.8)
+>* Make strings rendering ignore transparency by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/33 (1.8.8)
+>* Add config to show icon on HUD or not by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/35 (1.8.8)
+>* Stop running tick events twice per tick by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/30 (1.8.7)
+>* Remove unused EnderIO module by @dibbydoda in https://github.com/GTNewHorizons/waila/pull/29 (1.8.6)
+>* add more information to help debug weird NPE by @Glease in https://github.com/GTNewHorizons/waila/pull/26 (1.8.4)
+>* Add a total size counter to thaumcraft nodes by @EmperorSuper in https://github.com/GTNewHorizons/waila/pull/27 (1.8.4)
+>* Fix thaumcraft node aspects overflowing out of the tooltip bounding box by @EmperorSuper in https://github.com/GTNewHorizons/waila/pull/28 (1.8.4)
 
-## *1.8.10*
->## What's Changed
->* [Memory-opti:fix leak] Fix WorldClient leak in WailaTickHandler and RayTracing by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/31
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.8...1.8.10
->
-
-## *1.8.8*
->## What's Changed
->* Re-encode `cs_CZ.lang` into UTF-8 by @Nikolay-Sitnikov in https://github.com/GTNewHorizons/waila/pull/32
->* Make strings rendering ignore transparency by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/33
->* Add config to show icon on HUD or not by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/35
->
->## New Contributors
->* @Nikolay-Sitnikov made their first contribution in https://github.com/GTNewHorizons/waila/pull/32
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.7...1.8.8
->
-
-## *1.8.7*
->## What's Changed
->* Stop running tick events twice per tick by @Alexdoru in https://github.com/GTNewHorizons/waila/pull/30
->
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.6...1.8.7
->
-
-## *1.8.6*
->## What's Changed
->* Remove unused EnderIO module by @dibbydoda in https://github.com/GTNewHorizons/waila/pull/29
->
->## New Contributors
->* @dibbydoda made their first contribution in https://github.com/GTNewHorizons/waila/pull/29
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.4...1.8.6
->
-
-## *1.8.4*
->## What's Changed
->* add more information to help debug weird NPE by @Glease in https://github.com/GTNewHorizons/waila/pull/26
->* Add a total size counter to thaumcraft nodes by @EmperorSuper in https://github.com/GTNewHorizons/waila/pull/27
->* Fix thaumcraft node aspects overflowing out of the tooltip bounding box by @EmperorSuper in https://github.com/GTNewHorizons/waila/pull/28
->
->## New Contributors
->* @Glease made their first contribution in https://github.com/GTNewHorizons/waila/pull/26
->* @EmperorSuper made their first contribution in https://github.com/GTNewHorizons/waila/pull/27
->
->**Full Changelog**: https://github.com/GTNewHorizons/waila/compare/1.8.2...1.8.4
->
-
+# Credits
+Special thanks to @0hwx, @2ndDerivative, @48a3efa65c881ef567345b17f3910e06, @54M44R, @70000hp, @AbdielKavash, @abel1502, @ABKQPO, @Ableytner, @AdityaVG13, @ah-OOG-ah, @Akeianova, @Alexdoru, @amyavi, @Andthehand, @Anonymagpie, @AnrDaemon, @Apeiria01, @apia46, @asiekierka, @asquared31415, @Astatine5985, @AzodFR, @bartimaeusnek, @basdxz, @benjamin-kirkbride, @benTicks, @Bjdufre1, @BlueHero233, @bluhbipo, @bombcar, @boubou19, @brachy84, @brandyyn, @Breviel, @C-Remilian, @C0bra5, @Caedis, @calreveraster, @Cardinalstars, @cargocats, @charagarlnad, @Charsy89, @ChenMoFeiJin, @ChibiChoko, @chochem, @ChrisJStone, @ChromaPIE, @chrombread, @ClassixX, @Cleptomania, @Coffee-beans-Pi, @combusterf, @Connor-Colenso, @cons-tan-tan, @CookieBrigade, @CrystieColon3, @Csstform, @ctrlaltmilk, @czerwonogrodzki, @D-Cysteine, @DancingSnow0517, @DangerousMilk, @DarkShadow44, @DCNick3, @DeckerCHAN, @Demiu, @DerekChan65535, @des-cuddlebat, @Diamantino-Op, @dibbydoda, @Dioxop, @Discreater, @Dream-Master, @DrParadox7, @dvdmandt, @DylanTaylor1, @eigenraven, @Eldrinn-Elantey, @Elisis, @ElNounch, @embeddedt, @EmperorSuper, @EnderProyects, @Eraldoe, @Ethryan, @EverNife, @evgengoldwar, @Fabboz, @FalsePattern, @felixfour, @flamingowrangler2869, @FourIsTheNumber, @FrostyFire1, @Gamingb3ast, @gaseet, @GDCloudstrike, @Georggi, @Ghostipedia, @giantcavespider, @github-actions, @Glease, @glektarssza, @glowredman, @godrja, @Gordon-Frohman, @guid118, @hiroscho, @HoleFish, @hpotter02, @huihiuhuai, @iamcsharper, @ihfuhgljclhflhc, @Impos913, @Inphysible, @IntQuant, @iouter, @istreee, @JackOfNoneTrades, @jahtim, @jss2a98aj, @JuanICasareski, @jude123412, @Juknum, @jurrejelle, @k0michi, @kamenskyi, @Keridos, @Kiwi233, @Kogepan229, @koolkrafter5, @Kortako, @kotmatross28729, @kstvr32, @kuba6000, @kumquat-ir, @kurrycat2004, @Kynake, @lailani-f, @LazyFleshWasTaken, @lc-1337, @leagris, @leumasme, @lordIcocain, @lucythebean, @Lyfts, @mak8427, @MalTeeez, @Maratons4, @MathiasDeWeerdt, @MCTBL, @MeiTianyou, @MellowArpeggiation, @miaowwwwww, @michaeldoylecs, @Midnight145, @miozune, @MissBismuth, @mitchej123, @mM4ri, @MysticalBlade, @NeOzay, @Nikolay-Sitnikov, @Nockyx, @norbby42, @NotAPenguin0, @nshepperd, @OBlankenship, @OmdaCZ, @OpusC, @PantACRO4life, @paulzzh, @Pilzinsel64, @POPlol333, @purebluez, @Pxx500, @qqqqqq452, @QuanhuZeYu, @Quarri6343, @querns, @Quetz4l, @Radk6, @Rafadaz, @raylras, @RecursivePineapple, @redspah, @ReignOfFROZE, @reobf, @repo-alt, @riggzh, @RubilaxXxx, @Ruling-0, @S4mpsa, @SafariXiu, @Sanduhr32, @SarcasticMax, @serenibyss, @Shadow1590, @shadoxxhd, @Sheodar, @Shibva, @Shinusei, @Simolater, @SinTh0r4s, @SKProCH, @slprime, @Sonnicon, @Sopel97, @spacebuilder2020, @Spicierspace153, @srdr2k3, @StaffiX, @szuend, @t3435ryt, @Taskeren, @TechnicianLP, @thedarkcolour, @TheEpicGamer274, @ThexXTURBOXx, @tiflu, @TimeConqueror, @TotallyNotOndre, @TwoDCube, @tyrannus00, @UltraProdigy, @v3ect0rgames, @VendoAU, @Viptunbeqwfwew, @Vlamonster, @WanderingHero, @WaterOtter86, @WaterShuriken, @wlhlm, @Worive, @Xeno-Ra, @xgpjun, @xronin01, @YamiKami-Sama, @YannickMG, @Yoshy2002, @YoungOnionMC, @YueLengM, @zhehedream, @Zorbatron, @zyf051520, for their code contributions listed above, and to everyone else who helped, including all of our beta testers! <3

--- a/src/gtnh/assembler/assembler.py
+++ b/src/gtnh/assembler/assembler.py
@@ -220,6 +220,6 @@ class ReleaseAssembler:
                     except UnicodeEncodeError:
                         file.write((item + "\n").encode("ascii", "ignore").decode())
 
-        compress_changelog(changelog_path)
+        # compress_changelog(changelog_path)
 
         return changelog_path

--- a/src/gtnh/assembler/assembler.py
+++ b/src/gtnh/assembler/assembler.py
@@ -16,7 +16,6 @@ from gtnh.defs import (
 from gtnh.gtnh_logger import get_logger
 from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.modpack_manager import GTNHModpackManager
-from gtnh.utils import compress_changelog
 
 log = get_logger(__name__)
 
@@ -219,7 +218,5 @@ class ReleaseAssembler:
                         file.write(item + "\n")
                     except UnicodeEncodeError:
                         file.write((item + "\n").encode("ascii", "ignore").decode())
-
-        # compress_changelog(changelog_path)
 
         return changelog_path

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -178,7 +178,10 @@ class ChangelogCollection:
         # spacer between changelog and new contributors
         version_changelog.append("")
 
-        lines.extend(version_changelog)
+        if len([s.strip() for s in version_changelog if len(s.strip()) > 0]) == 0:
+            lines.append("DreamAssemblerXXL wasn't able to find the changelog related to this update. It is usually caused by updates done outside of pull-requests or if the mod is maintained by a 3rd party.")
+        else: # normally add
+            lines.extend(version_changelog)
 
         if not compressed:
             # New contributor section

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -121,7 +121,7 @@ class ChangelogCollection:
         # full changelog:
         url = self.generate_full_comparison_url(self.oldest, self.newest)
         if url is not None:
-            lines.append(f"Full changelog: {url}")
+            lines.append(f"{url}")
             lines.append("") # spacer
 
         # what's changed text:

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -30,10 +30,30 @@ class ChangelogEntry:
         self.full_comparison_url: Optional[str] = None
 
         if changelog_str is not None:
-            self.changelog_categories = changelog_str.split("\n\n")
-            self.changelog_entries = self.changelog_categories[0].split("\n")[1:]
-            if len(self.changelog_categories) == 3:
-                self.new_contributors = self.changelog_categories[1].split("\n")[1:]
+            lines = changelog_str.split("\n")
+            index = 0
+
+        if "What's Changed" in changelog_str:
+            while not "##" in lines[index]:
+                index+=1
+
+            index+=1 # skip the what's changed line
+
+            while lines[index].startswith("*"):
+                self.changelog_entries.append(lines[index])
+                index+=1
+
+        if "New Contributors" in changelog_str:
+            while "New Contributors" not in lines[index]:
+                index+=1
+
+            while lines[index].startswith("*"):
+                self.new_contributors.append(lines[index])
+                index += 1
+        if "Full Changelog" in changelog_str:
+            while not "Full Changelog" in lines[index]:
+                index += 1
+            self.full_comparison_url=lines[index]
 
 
 class ChangelogCollection:

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -2,24 +2,6 @@ from typing import List, Optional
 
 from gtnh.defs import Side
 
-a = """## What's Changed
-* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
-
-## New Contributors
-* @ChibiChoko made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
-
-**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.9-GTNH...1.7.10-GTNH
-"""
-
-b = """## What's Changed
-* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
-
-## New Contributors
-* @70000hp made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
-
-**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.7-GTNH...1.7.9-GTNH
-"""
-
 class ChangelogEntry:
     def __init__(self,version:str, changelog_str:Optional[str], prerelease=False)->None:
         self.version = version
@@ -159,10 +141,4 @@ class ChangelogCollection:
         lines.extend(new_contributors)
 
         return "\n".join(lines)
-
-if __name__ == "__main__":
-    entry_a = ChangelogEntry(version="1.7.10-GTNH", changelog_str=a, side=Side.BOTH)
-    entry_b = ChangelogEntry(version="1.7.9-GTNH", changelog_str=b, side=Side.BOTH)
-
-    print(ChangelogCollection(pack_release_version="Daily",mod_name="WitchingGadget", changelog_entries=[entry_a, entry_b]).generate_changelog())
 

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -1,0 +1,144 @@
+from typing import List, Optional
+
+from gtnh.defs import Side
+
+a = """## What's Changed
+* Corrected Aluminum to Aluminium by @ChibiChoko in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
+
+## New Contributors
+* @ChibiChoko made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/78
+
+**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.9-GTNH...1.7.10-GTNH
+"""
+
+b = """## What's Changed
+* Fixed IBF particle crash due to particle entities by @70000hp in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
+
+## New Contributors
+* @70000hp made their first contribution in https://github.com/GTNewHorizons/WitchingGadgets/pull/76
+
+**Full Changelog**: https://github.com/GTNewHorizons/WitchingGadgets/compare/1.7.7-GTNH...1.7.9-GTNH
+"""
+
+class ChangelogEntry:
+    def __init__(self,version:str, changelog_str:Optional[str], prerelease=False)->None:
+        self.version = version
+        self.no_changelog: bool = changelog_str is None
+        self.prerelease = prerelease
+        self.changelog_entries = []
+        self.new_contributors = []
+        self.full_comparison_url: Optional[str] = None
+
+        if changelog_str is not None:
+            self.changelog_categories = changelog_str.split("\n\n")
+            self.changelog_entries = self.changelog_categories[0].split("\n")[1:]
+            if len(self.changelog_categories) == 3:
+                self.new_contributors = self.changelog_categories[1].split("\n")[1:]
+
+
+class ChangelogCollection:
+    def __init__(self,pack_release_version:str, mod_name:str, changelog_entries:List[ChangelogEntry],oldest_side:Optional[Side], newest_side:Side, new_mod = False) -> None:
+        self.pack_release_version: str = pack_release_version
+        self.mod_name: str = mod_name
+        self.new_mod: bool = new_mod
+        self.oldest_side:Optional[Side]=oldest_side
+        self.newest_side:Side=newest_side
+        self.changelog_entries: List[ChangelogEntry] = sorted(changelog_entries,key=lambda x: x.version, reverse=True)
+        self.oldest = self.changelog_entries[0]
+        self.newest = self.changelog_entries[-1]
+
+    @classmethod
+    def get_pretty_side_string(cls, side: Optional[Side]) -> str:
+        if side == Side.CLIENT:
+            return "client-side only"
+        if side == Side.CLIENT_JAVA9:
+            return "client-side Java 9+ only"
+        elif side == Side.SERVER:
+            return "server-side only"
+        elif side == Side.SERVER_JAVA9:
+            return "server-side Java 9+ only"
+        elif side == Side.BOTH:
+            return "on both sides"
+        elif side == Side.BOTH_JAVA9:
+            return "on both sides, Java 9+ only"
+        elif side is None:
+            return "unknown"
+        else:
+            return str(side)
+
+    @classmethod
+    def blockquote(cls, strs:List[str])->List[str]:
+        return [f">{s}" for s in strs]
+
+    def generate_changelog(self) -> str:
+        lines = []
+        # define the header for the changelog of the mod
+        if self.new_mod:
+            header = f"# New Mod - {self.mod_name}:{self.newest.version}"
+        else:
+            header = f"# Updated - {self.mod_name} - {self.oldest.version} --> {self.newest.version}"
+        lines.append(header)
+
+        # side detection: only comparing oldest and newest version, as it's the only thing that matter for the release
+        if not self.new_mod and self.oldest_side != self.newest_side:
+            side_change = f"Mod side changed from {self.get_pretty_side_string(self.oldest_side)} to {self.get_pretty_side_string(self.newest_side)}."
+            lines.append(side_change)
+
+        # side precision:
+        if self.newest_side not in [Side.BOTH, Side.BOTH_JAVA9]:
+            side_precision = f"Mod is {self.get_pretty_side_string(self.newest_side)}."
+            lines.append(side_precision)
+
+        # what's changed text:
+        lines.append("## What's Changed:")
+
+        version_changelog: List[str] = []
+        new_contributors: List[str] = []
+
+        # actual mod version processing:
+        for i, changelog_entry in enumerate(self.changelog_entries):
+            if (
+                    i != 0
+                    and self.pack_release_version != "experimental"
+                    and (
+                    changelog_entry.prerelease
+                    or (changelog_entry.version.endswith("-pre") or changelog_entry.version.endswith("-dev"))
+            )
+            ):
+                # Only include prerelease changes if it's the latest release
+                continue
+
+
+            if not self.new_mod and changelog_entry.version == self.oldest.version:
+                # skipping the oldest version as it has already been released in the previous pack release
+                continue
+
+            version_changelog.append((f"## *{changelog_entry.version}*"))
+            if changelog_entry.no_changelog or len(changelog_entry.changelog_entries) == 0:
+                version_changelog.append("**No Changelog Found for this version**")
+            else:
+                version_changelog.extend(self.blockquote(changelog_entry.changelog_entries))
+
+            # add potential new contributors if any
+            new_contributors.extend(changelog_entry.new_contributors)
+
+            # spacer between releases
+            version_changelog.append("")
+
+        # spacer between changelog and new contributors
+        version_changelog.append("")
+
+        lines.extend(version_changelog)
+
+        # New contributor section
+        lines.append('## New contributors on the mod:')
+        lines.extend(new_contributors)
+
+        return "\n".join(lines)
+
+if __name__ == "__main__":
+    entry_a = ChangelogEntry(version="1.7.10-GTNH", changelog_str=a, side=Side.BOTH)
+    entry_b = ChangelogEntry(version="1.7.9-GTNH", changelog_str=b, side=Side.BOTH)
+
+    print(ChangelogCollection(pack_release_version="Daily",mod_name="WitchingGadget", changelog_entries=[entry_a, entry_b]).generate_changelog())
+

--- a/src/gtnh/assembler/changelog.py
+++ b/src/gtnh/assembler/changelog.py
@@ -40,7 +40,7 @@ class ChangelogEntry:
             index+=1 # skip the what's changed line
 
             while lines[index].startswith("*"):
-                self.changelog_entries.append(lines[index])
+                self.changelog_entries.append(lines[index].strip())
                 index+=1
 
         if "New Contributors" in changelog_str:
@@ -48,12 +48,12 @@ class ChangelogEntry:
                 index+=1
 
             while lines[index].startswith("*"):
-                self.new_contributors.append(lines[index])
+                self.new_contributors.append(lines[index].strip())
                 index += 1
         if "Full Changelog" in changelog_str:
             while not "Full Changelog" in lines[index]:
                 index += 1
-            self.full_comparison_url=lines[index]
+            self.full_comparison_url=lines[index].strip()
 
 
 class ChangelogCollection:
@@ -63,9 +63,9 @@ class ChangelogCollection:
         self.new_mod: bool = new_mod
         self.oldest_side:Optional[Side]=oldest_side
         self.newest_side:Side=newest_side
-        self.changelog_entries: List[ChangelogEntry] = sorted(changelog_entries,key=lambda x: x.version, reverse=True)
-        self.oldest = self.changelog_entries[0]
-        self.newest = self.changelog_entries[-1]
+        self.changelog_entries: List[ChangelogEntry] = changelog_entries[::-1]
+        self.oldest = self.changelog_entries[-1]
+        self.newest = self.changelog_entries[0]
 
     @classmethod
     def get_pretty_side_string(cls, side: Optional[Side]) -> str:
@@ -134,8 +134,12 @@ class ChangelogCollection:
                 continue
 
             version_changelog.append((f"## *{changelog_entry.version}*"))
-            if changelog_entry.no_changelog or len(changelog_entry.changelog_entries) == 0:
+            if changelog_entry.no_changelog:
                 version_changelog.append("**No Changelog Found for this version**")
+            elif len(changelog_entry.changelog_entries) == 0:
+                version_changelog.append("**No PR detected for this version, check commit history for more details.**")
+                if changelog_entry.full_comparison_url is not None:
+                    version_changelog.append(changelog_entry.full_comparison_url)
             else:
                 version_changelog.extend(self.blockquote(changelog_entry.changelog_entries))
 

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1153,30 +1153,12 @@ class GTNHModpackManager:
         return changed_github_mods | changed_external_mods
 
     def generate_changelog(
-        self, release: GTNHRelease, previous_release: GTNHRelease | None = None, include_no_changelog: bool = False
+        self, release: GTNHRelease, previous_release: GTNHRelease | None = None
     ) -> dict[str, list[str]]:
         """
         Generate a changelog between two releases.  If the `previous_release` is None, generate it for all of history
         :returns: dict[mod_name, list[version_changes]]
         """
-
-        def get_pretty_side_string(side: Optional[Side]) -> str:
-            if side == Side.CLIENT:
-                return "client-side only"
-            if side == Side.CLIENT_JAVA9:
-                return "client-side Java 9+ only"
-            elif side == Side.SERVER:
-                return "server-side only"
-            elif side == Side.SERVER_JAVA9:
-                return "server-side Java 9+ only"
-            elif side == Side.BOTH:
-                return "on both sides"
-            elif side == Side.BOTH_JAVA9:
-                return "on both sides, Java 9+ only"
-            elif side is None:
-                return "unknown"
-            else:
-                return str(side)
 
         removed_mods = set()
         new_mods = set()
@@ -1232,7 +1214,7 @@ class GTNHModpackManager:
             is_new_mod = old_version is None
             mod_changelog = ChangelogCollection(pack_release_version=release.version, mod_name=mod_name, changelog_entries=mod_version_changelogs, oldest_side=None if is_new_mod else old_version.side, newest_side=new_version.side, new_mod=is_new_mod)
 
-            changes.append(mod_changelog.generate_changelog())
+            changes.append(mod_changelog.generate_mod_changelog())
 
         return changelog
 

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1166,6 +1166,7 @@ class GTNHModpackManager:
 
         changelog: dict[str, list[str]] = defaultdict(list)
 
+        contributors: Set[str] = set()
         if previous_release is not None:
             removed_mods |= set(previous_release.github_mods.keys() - release.github_mods.keys())
             removed_mods |= set(previous_release.external_mods.keys() - release.external_mods.keys())
@@ -1215,6 +1216,12 @@ class GTNHModpackManager:
             mod_changelog = ChangelogCollection(pack_release_version=release.version, mod_name=mod_name, changelog_entries=mod_version_changelogs, oldest_side=None if is_new_mod else old_version.side, newest_side=new_version.side, new_mod=is_new_mod)
 
             changes.append(mod_changelog.generate_mod_changelog())
+            contributors |= mod_changelog.contributors
+
+        changelog["credits"].append("# Credits")
+        changelog["credits"].append(f"Special thanks to {', '.join(sorted(list(contributors), key=str.casefold))}, "
+                "for their code contributions listed above, and to everyone else who helped, "
+                "including all of our beta testers! <3")
 
         return changelog
 

--- a/src/gtnh/modpack_manager.py
+++ b/src/gtnh/modpack_manager.py
@@ -1177,18 +1177,25 @@ class GTNHModpackManager:
             self.remove_false_positive_in_mod_removed(removed_mods, new_mods)
 
             changed_github_mods = set(release.github_mods.keys() & previous_release.github_mods.keys())
-            for mod_name in changed_github_mods | new_mods:
+            changed_external_mods = set(release.external_mods.keys() & previous_release.external_mods.keys())
+
+            for mod_name in changed_github_mods | changed_external_mods | new_mods:
                 # looks like here there are some shenanigans happening, so i'm just going to check for mod presence before anything
                 # i don't quite get what's happenning here.
-                if mod_name in release.github_mods:
-                    version_changes[mod_name] = (
-                        previous_release.github_mods.get(mod_name, None),
-                        release.github_mods[mod_name],
-                    )
+
+                previous_source = previous_release.github_mods if mod_name in release.github_mods else previous_release.external_mods
+                current_source = release.github_mods if mod_name in release.github_mods else release.external_mods
+
+                version_changes[mod_name] = (previous_source.get(mod_name, None),current_source[mod_name])
         else:
             changed_github_mods = set(release.github_mods.keys())
+            changed_external_mods = set(release.external_mods.keys())
+
             for mod_name in changed_github_mods:
                 version_changes[mod_name] = (None, release.github_mods[mod_name])
+
+            for mod_name in changed_external_mods:
+                version_changes[mod_name] = (None, release.external_mods[mod_name])
 
         if new_mods:
             changelog["new_mods"].append("# New Mods: ")


### PR DESCRIPTION
Reworked the changelog generation in DAXXL:
- Now it shows the version bumps for the external mods
- Now it directly generates an appropriate changelog, no more extra parsing hack to have it readable

an example of what this PR generates as changelog can be found here: https://github.com/GTNewHorizons/DreamAssemblerXXL/blob/changelog/releases/changelogs/changelog%20from%202.7.4%20to%20daily.md