### PR TITLE
Fix Double Zip Packing

### DIFF
--- a/.github/workflows/custom-modpack-build.yml
+++ b/.github/workflows/custom-modpack-build.yml
@@ -130,9 +130,9 @@ jobs:
         shell: bash
         run: |
           mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_8.zip" "GTNH-${DAXXL_TAG}-server.zip"
-          mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_17-25.zip" "GTNH-${DAXXL_TAG}-server-new-java.zip"
+          mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_17-25.zip" "GTNH-${DAXXL_TAG}-server-java17-25.zip"
           mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_8.zip" "GTNH-${DAXXL_TAG}-mmcprism-java8.zip"
-          mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_17-25.zip" "GTNH-${DAXXL_TAG}-mmcprism-new-java.zip"
+          mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_17-25.zip" "GTNH-${DAXXL_TAG}-mmcprism-java17-25.zip"
 
       - name: Upload server zip
         uses: actions/upload-artifact@v7
@@ -147,7 +147,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-${{ inputs.daxxl-tag }}-server-new-java.zip
+          path: GTNH-${{ inputs.daxxl-tag }}-server-java17-25.zip
           archive: false
 
       - name: Upload MMC zip
@@ -163,5 +163,5 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-new-java.zip
+          path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-java17-25.zip
           archive: false

--- a/.github/workflows/custom-modpack-build.yml
+++ b/.github/workflows/custom-modpack-build.yml
@@ -135,37 +135,33 @@ jobs:
           mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_17-25.zip" "GTNH-${DAXXL_TAG}-mmcprism-new-java.zip"
 
       - name: Upload server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-${{ inputs.daxxl-tag }}-${{ steps.date.outputs.today }}-server
           path: GTNH-${{ inputs.daxxl-tag }}-server.zip
-          compression-level: 0 # already compressed by Python
+          archive: false
 
       - name: Upload modern java server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-${{ inputs.daxxl-tag }}-${{ steps.date.outputs.today }}-server-new-java
           path: GTNH-${{ inputs.daxxl-tag }}-server-new-java.zip
-          compression-level: 0 # already compressed by Python
+          archive: false
 
       - name: Upload MMC zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-${{ inputs.daxxl-tag }}-${{ steps.date.outputs.today }}-mmcprism-java8
           path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-java8.zip
-          compression-level: 0 # already compressed by Python
+          archive: false
 
       - name: Upload modern java Prism zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-${{ inputs.daxxl-tag }}-${{ steps.date.outputs.today }}-mmcprism-new-java
           path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-new-java.zip
-          compression-level: 0 # already compressed by Python
+          archive: false

--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -142,46 +142,42 @@ jobs:
       - name: Relocate built zips
         shell: bash
         run: |
-          mv releases/zip/GT_New_Horizons_daily_Server_Java_8.zip "GTNH-${{ steps.date.outputs.today }}-server.zip"
-          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-25.zip "GTNH-${{ steps.date.outputs.today }}-server-new-java.zip"
-          mv releases/multi_poly/GT_New_Horizons_daily_Java_8.zip "GTNH-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-25.zip "GTNH-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
+          mv releases/zip/GT_New_Horizons_daily_Server_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-server.zip"
+          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-new-java.zip"
+          mv releases/multi_poly/GT_New_Horizons_daily_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
+          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
 
       - name: Upload server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-daily-${{ steps.date.outputs.today }}-server
-          path: GTNH-${{ steps.date.outputs.today }}-server.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-daily-${{ steps.date.outputs.today }}-server.zip
+          archive: false
 
       - name: Upload modern java server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-daily-${{ steps.date.outputs.today }}-server-new-java
-          path: GTNH-${{ steps.date.outputs.today }}-server-new-java.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-daily-${{ steps.date.outputs.today }}-server-new-java.zip
+          archive: false
 
       - name: Upload MMC zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-daily-${{ steps.date.outputs.today }}-mmcprism-java8
-          path: GTNH-${{ steps.date.outputs.today }}-mmcprism-java8.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java8.zip
+          archive: false
 
       - name: Upload modern java Prism zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-daily-${{ steps.date.outputs.today }}-mmcprism-new-java
-          path: GTNH-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
+          archive: false
 
       # Pulls the newest changelog filename and stores it in an env variable
       # so we can use it in the commit

--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -143,9 +143,9 @@ jobs:
         shell: bash
         run: |
           mv releases/zip/GT_New_Horizons_daily_Server_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-server.zip"
-          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-new-java.zip"
+          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-java17-25.zip"
           mv releases/multi_poly/GT_New_Horizons_daily_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
+          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip"
 
       - name: Upload server zip
         uses: actions/upload-artifact@v7
@@ -160,7 +160,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-daily-${{ steps.date.outputs.today }}-server-new-java.zip
+          path: GTNH-daily-${{ steps.date.outputs.today }}-server-java17-25.zip
           archive: false
 
       - name: Upload MMC zip
@@ -176,7 +176,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
+          path: GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip
           archive: false
 
       # Pulls the newest changelog filename and stores it in an env variable

--- a/.github/workflows/experimental-modpack-build.yml
+++ b/.github/workflows/experimental-modpack-build.yml
@@ -140,46 +140,42 @@ jobs:
       - name: Relocate built zips
         shell: bash
         run: |
-          mv releases/zip/GT_New_Horizons_experimental_Server_Java_8.zip "GTNH-${{ steps.date.outputs.today }}-server.zip"
-          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-25.zip "GTNH-${{ steps.date.outputs.today }}-server-new-java.zip"
-          mv releases/multi_poly/GT_New_Horizons_experimental_Java_8.zip "GTNH-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-25.zip "GTNH-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
+          mv releases/zip/GT_New_Horizons_experimental_Server_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server.zip"
+          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-new-java.zip"
+          mv releases/multi_poly/GT_New_Horizons_experimental_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
+          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
 
       - name: Upload server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-experimental-${{ steps.date.outputs.today }}-server
-          path: GTNH-${{ steps.date.outputs.today }}-server.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-server.zip
+          archive: false
 
       - name: Upload modern java server zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-experimental-${{ steps.date.outputs.today }}-server-new-java
-          path: GTNH-${{ steps.date.outputs.today }}-server-new-java.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-server-new-java.zip
+          archive: false
 
       - name: Upload MMC zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-experimental-${{ steps.date.outputs.today }}-mmcprism-java8
-          path: GTNH-${{ steps.date.outputs.today }}-mmcprism-java8.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java8.zip
+          archive: false
 
       - name: Upload modern java Prism zip
-        uses: actions/upload-artifact@v4
-        # Upload all archives even if one of the zips fails to upload
+        uses: actions/upload-artifact@v7
+        # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          name: gtnh-experimental-${{ steps.date.outputs.today }}-mmcprism-new-java
-          path: GTNH-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
-          compression-level: 0 # already compressed by Python
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
+          archive: false
 
       # Pulls the newest changelog filename and stores it in an env variable
       # so we can use it in the commit

--- a/.github/workflows/experimental-modpack-build.yml
+++ b/.github/workflows/experimental-modpack-build.yml
@@ -141,9 +141,9 @@ jobs:
         shell: bash
         run: |
           mv releases/zip/GT_New_Horizons_experimental_Server_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server.zip"
-          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-new-java.zip"
+          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-25.zip"
           mv releases/multi_poly/GT_New_Horizons_experimental_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-new-java.zip"
+          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip"
 
       - name: Upload server zip
         uses: actions/upload-artifact@v7
@@ -158,7 +158,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-experimental-${{ steps.date.outputs.today }}-server-new-java.zip
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-25.zip
           archive: false
 
       - name: Upload MMC zip
@@ -174,7 +174,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-new-java.zip
+          path: GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip
           archive: false
 
       # Pulls the newest changelog filename and stores it in an env variable


### PR DESCRIPTION
So funny enough it looks like GitHub made a fix on their own: https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/

So since GHA no longer needs to compress the file we should just be good to go? 

Will need to be tested of course 