### PR TITLE
Try to fix permissions in zip for linux users

### DIFF
--- a/src/gtnh/assembler/curse.py
+++ b/src/gtnh/assembler/curse.py
@@ -18,6 +18,7 @@ from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.modpack_manager import GTNHModpackManager
+from gtnh.utils import normalize_archive_permissions
 
 log = get_logger(__name__)
 
@@ -178,6 +179,7 @@ class CurseAssembler(GenericAssembler):
             self.add_overrides(side, archive)
             log.info("Adding locales to the archive")
             self.add_localisation_files(archive, str(self.overrides_folder))
+            normalize_archive_permissions(archive)
             log.info("Archive created successfully!")
 
     def add_overrides(self, side: Side, archive: ZipFile) -> None:
@@ -264,6 +266,7 @@ class CurseAssembler(GenericAssembler):
                         progress, f"Adding {mod.name} to the archives of the mods to be uploaded"
                     )
                 file.write(path, arcname=path.name)
+            normalize_archive_permissions(file)
         if task_progressbar is not None:
             task_progressbar.add_progress(1, "Done!")
 

--- a/src/gtnh/assembler/generic_assembler.py
+++ b/src/gtnh/assembler/generic_assembler.py
@@ -16,6 +16,7 @@ from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.models.mod_version_info import ModVersionInfo
 from gtnh.modpack_manager import GTNHModpackManager
+from gtnh.utils import normalize_archive_permissions
 
 log = get_logger(__name__)
 
@@ -247,6 +248,7 @@ class GenericAssembler:
             self.add_config(side, self.get_config(), archive, verbose=verbose)
             log.info("Generating the readme for the modpack repo")
             self.generate_readme()
+            normalize_archive_permissions(archive)
             log.info("Archive created successfully!")
 
     def get_archive_path(self, side: Side) -> Path:

--- a/src/gtnh/assembler/multi_poly.py
+++ b/src/gtnh/assembler/multi_poly.py
@@ -11,6 +11,7 @@ from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.modpack_manager import GTNHModpackManager
+from gtnh.utils import normalize_archive_permissions
 
 
 class MMCAssembler(GenericAssembler):
@@ -124,6 +125,7 @@ class MMCAssembler(GenericAssembler):
         with ZipFile(self.get_archive_path(side), "a", compression=ZIP_DEFLATED) as archive:
             self.add_localisation_files(archive, str(self.mmc_modpack_files.as_posix()))  # otherwise file check fails
             # on windows
+            normalize_archive_permissions(archive)
 
         self.add_mmc_meta_data(side)
 
@@ -146,3 +148,4 @@ class MMCAssembler(GenericAssembler):
             with archive.open(str(self.mmc_archive_root) + "/gtnh_icon.png", "w") as target:
                 with open(MMC_ASSETS_DIR / "gtnh_icon.png", "rb") as icon:
                     shutil.copyfileobj(icon, target)
+            normalize_archive_permissions(archive)

--- a/src/gtnh/assembler/technic.py
+++ b/src/gtnh/assembler/technic.py
@@ -17,6 +17,7 @@ from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.modpack_manager import GTNHModpackManager
+from gtnh.utils import normalize_archive_permissions
 
 log = get_logger("technic process")
 
@@ -113,6 +114,7 @@ class TechnicAssembler(GenericAssembler):
             self.add_config(side, self.get_config(), archive, verbose=verbose)
             log.info("Generating the readme for the modpack repo")
             self.generate_readme()
+            normalize_archive_permissions(archive)
             log.info("Archive created successfully!")
 
         log.info(
@@ -124,6 +126,7 @@ class TechnicAssembler(GenericAssembler):
             self.add_mods(
                 side, self.differential_update(side, DifferentialUpdateMode.NEW_MODS), archive, verbose=verbose
             )
+            normalize_archive_permissions(archive)
             log.info("Archive created successfully!")
 
         with open(removed_modlist_name, "w") as file:
@@ -195,6 +198,7 @@ class TechnicAssembler(GenericAssembler):
             # set up temp zip
             with ZipFile(temp_zip_path, "w", compression=ZIP_DEFLATED) as temp_zip:
                 temp_zip.write(source_file, arcname=archive_path)
+                normalize_archive_permissions(temp_zip)
 
             archive.write(
                 temp_zip_path,
@@ -249,6 +253,8 @@ class TechnicAssembler(GenericAssembler):
             self.add_localisation_files(temp_zip)
 
             self.add_changelog(temp_zip)
+
+            normalize_archive_permissions(temp_zip)
 
         # writing the config zip in the technic archive
         archive.write(

--- a/src/gtnh/assembler/zip_assembler.py
+++ b/src/gtnh/assembler/zip_assembler.py
@@ -12,6 +12,7 @@ from gtnh.models.gtnh_release import GTNHRelease
 from gtnh.models.gtnh_version import GTNHVersion
 from gtnh.models.mod_info import GTNHModInfo
 from gtnh.modpack_manager import GTNHModpackManager
+from gtnh.utils import normalize_archive_permissions
 
 log = get_logger(__name__)
 
@@ -134,10 +135,12 @@ class ZipAssembler(GenericAssembler):
             log.info("Adding server assets to the server release.")
             with ZipFile(self.get_archive_path(side), "a", compression=ZIP_DEFLATED) as archive:
                 self.add_server_assets(archive, server_brand, side)
+                normalize_archive_permissions(archive)
         if side.is_client():
             log.info("Adding locales to client release.")
             with ZipFile(self.get_archive_path(side), "a", compression=ZIP_DEFLATED) as archive:
                 self.add_localisation_files(archive)
+                normalize_archive_permissions(archive)
 
     def get_server_assets(self, server_brand: ServerBrand, side: Side) -> List[Path]:
         """

--- a/src/gtnh/utils.py
+++ b/src/gtnh/utils.py
@@ -1,11 +1,13 @@
 import itertools
 import os
+import stat
 from bisect import bisect_left
 from functools import cache
 from pathlib import Path
 from shutil import copy, rmtree
 from typing import Any, Iterable, Iterator, List
 from urllib import parse
+from zipfile import ZipFile
 
 from gtnh.defs import CLIENT_WORKING_DIR, SERVER_WORKING_DIR
 
@@ -125,3 +127,21 @@ def index(elements_list: List[Any], element: Any) -> int:
     if i != len(elements_list) and elements_list[i] == element:
         return i
     raise ValueError
+
+
+def normalize_archive_permissions(archive: ZipFile) -> None:
+    """
+    Normalize a ZipFile with canonical unix permissions.
+    Directories become 0o777 and files 0o644 (Or 0o755 if file is flagged as executable).
+    If a file was flagged as executable it's
+
+    :param archive: the ZipFile object to be normalized
+    :return: None
+    """
+    for zinfo in archive.infolist():
+        source_perm = (zinfo.external_attr >> 16) & 0o777
+        if zinfo.is_dir():
+            zinfo.external_attr = ((stat.S_IFDIR | 0o755) << 16) | 0x10
+        else:
+            perm = 0o755 if source_perm & 0o111 else 0o644
+            zinfo.external_attr = (stat.S_IFREG | perm) << 16


### PR DESCRIPTION
Linux permissions flags inside the release zip are currently a bit broken.
If you try to unzip and run the server on a linux you first have to reset permissions on the whole folder. If you try to rm the directory right after unzip it will just error out on permissions even as root.

This is an attempt at fixing this.

Before:
<img width="900" height="360" alt="image" src="https://github.com/user-attachments/assets/db641d3b-dde5-44a6-b5ab-3505cec5995c" />

After:
<img width="846" height="352" alt="image" src="https://github.com/user-attachments/assets/9de8debc-1147-4b7a-9831-bec062fa2de9" />
Note: the .sh not being flagged as runnable is probably because I ran that build on windows. Should be properly preserved on a github build.

