### PR TITLE
Revert "Tag daily and experimental runs"

### DIFF
--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -200,12 +200,4 @@ jobs:
           git add ./gtnh-assets.json
           git commit -m "Upload daily $changelog_name"
           git push origin master
-
-      - name: Create and push build tag
-        shell: bash
-        if: success() || failure()
-        run: |
-          tag="daily-${{ github.run_number }}"
-          git tag "$tag"
-          git push origin "$tag"
-
+      

--- a/.github/workflows/experimental-modpack-build.yml
+++ b/.github/workflows/experimental-modpack-build.yml
@@ -198,12 +198,4 @@ jobs:
           git add ./gtnh-assets.json
           git commit -m "Upload experimental $changelog_name"
           git push origin master
-
-      - name: Create and push build tag
-        shell: bash
-        if: success() || failure()
-        run: |
-          tag="experimental-${{ github.run_number }}"
-          git tag "$tag"
-          git push origin "$tag"
-
+      


### PR DESCRIPTION
tags are meant for DAXXL only, no need to pollute tags like this, the daily updater is not officially supported by DAXXL.