### PR TITLE
Remove run number override set for testing

### DIFF
--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_GITHUB_TOKEN }}
         run: |
-          uv run python -m daxxl.cli.generate_daily --id "$((${{ github.run_number }} + 1000))" --update-available
+          uv run python -m daxxl.cli.generate_daily --id "${{ github.run_number }}" --update-available
           uv run python -m daxxl.cli.assemble_daily
 
       - name: Save cached mod zips


### PR DESCRIPTION
Accidentally included in #285, which had to be set for running test runs on fork.