### PR TITLE
Fix HQA result status verification

### DIFF
--- a/scripts/tests/verify_server.sh
+++ b/scripts/tests/verify_server.sh
@@ -87,13 +87,16 @@ fi
 
 # Server side of what was emitted during the dual tests
 if [ -e "$HQA_RESULT_JSON" ]; then
-  failed_tests=$(jq '.counts.failed // 0' "$HQA_RESULT_JSON")
-  if ! [[ "$failed_tests" =~ ^[0-9]+$ ]]; then
-    fail "could not read HQA test failure count from $HQA_RESULT_JSON (got: '$failed_tests')"
-  elif [ "$failed_tests" -ne 0 ]; then
-    fail "HQA tests had $failed_tests failures"
+  hqa_status=$(jq -r '.status // empty' "$HQA_RESULT_JSON")
+  if [ "$hqa_status" != "passed" ]; then
+    failed_tests=$(jq -r '.counts.failed // 0' "$HQA_RESULT_JSON")
+    if ! [[ "$failed_tests" =~ ^[0-9]+$ ]]; then
+      fail "could not read HQA test failure count from $HQA_RESULT_JSON (got: '$failed_tests')"
+    else
+      fail "HQA tests had $failed_tests failures (status: ${hqa_status:-missing})"
+    fi
   else
-    echo "HQA tests had no failures!"
+    echo "HQA tests passed!"
   fi
 else
   fail "HQA execution result json at $HQA_RESULT_JSON is missing"

--- a/scripts/tests/verify_server.sh
+++ b/scripts/tests/verify_server.sh
@@ -88,7 +88,7 @@ fi
 # Server side of what was emitted during the dual tests
 if [ -e "$HQA_RESULT_JSON" ]; then
   hqa_status=$(jq -r '.status // empty' "$HQA_RESULT_JSON")
-  if [ "$hqa_status" != "passed" ]; then
+  if [[ "$hqa_status" != "passed" ]]; then
     failed_tests=$(jq -r '.counts.failed // 0' "$HQA_RESULT_JSON")
     if ! [[ "$failed_tests" =~ ^[0-9]+$ ]]; then
       fail "could not read HQA test failure count from $HQA_RESULT_JSON (got: '$failed_tests')"

--- a/scripts/tests/verify_server.sh
+++ b/scripts/tests/verify_server.sh
@@ -99,7 +99,7 @@ if [ -e "$HQA_RESULT_JSON" ]; then
     echo "HQA tests passed!"
   fi
 else
-  fail "HQA execution result json at $HQA_RESULT_JSON is missing"
+  fail "HQA execution result json at $HQA_RESULT_JSON is missing - did the tests not get run because the client failed to start? (see the verify-client step)"
 fi
 
 


### PR DESCRIPTION
## Summary
Use status field instead of the count of failing tests as those could be optional failures.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
