### PR TITLE
Rename modern java from 17-25 to 17-26

### DIFF
--- a/.github/workflows/custom-modpack-build.yml
+++ b/.github/workflows/custom-modpack-build.yml
@@ -99,9 +99,9 @@ jobs:
         shell: bash
         run: |
           mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_8.zip" "GTNH-${DAXXL_TAG}-server-java8.zip"
-          mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_17-25.zip" "GTNH-${DAXXL_TAG}-server-java17-25.zip"
+          mv "releases/zip/GT_New_Horizons_${DAXXL_TAG}_Server_Java_17-26.zip" "GTNH-${DAXXL_TAG}-server-java17-26.zip"
           mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_8.zip" "GTNH-${DAXXL_TAG}-mmcprism-java8.zip"
-          mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_17-25.zip" "GTNH-${DAXXL_TAG}-mmcprism-java17-25.zip"
+          mv "releases/multi_poly/GT_New_Horizons_${DAXXL_TAG}_Java_17-26.zip" "GTNH-${DAXXL_TAG}-mmcprism-java17-26.zip"
 
       # Bundle everything the test/upload jobs need into a single internal artifact
       - name: Upload build bundle for downstream jobs
@@ -110,9 +110,9 @@ jobs:
           name: custom-build-bundle
           path: |
             GTNH-${{ inputs.daxxl-tag }}-server-java8.zip
-            GTNH-${{ inputs.daxxl-tag }}-server-java17-25.zip
+            GTNH-${{ inputs.daxxl-tag }}-server-java17-26.zip
             GTNH-${{ inputs.daxxl-tag }}-mmcprism-java8.zip
-            GTNH-${{ inputs.daxxl-tag }}-mmcprism-java17-25.zip
+            GTNH-${{ inputs.daxxl-tag }}-mmcprism-java17-26.zip
             releases/manifests/${{ inputs.daxxl-tag }}.json
           if-no-files-found: error
           retention-days: 1
@@ -166,7 +166,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-${{ inputs.daxxl-tag }}-server-java17-25.zip
+          path: GTNH-${{ inputs.daxxl-tag }}-server-java17-26.zip
           archive: false
 
       - name: Upload MMC zip
@@ -182,5 +182,5 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-java17-25.zip
+          path: GTNH-${{ inputs.daxxl-tag }}-mmcprism-java17-26.zip
           archive: false

--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -122,9 +122,9 @@ jobs:
         shell: bash
         run: |
           mv releases/zip/GT_New_Horizons_daily_Server_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-java8.zip"
-          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-java17-25.zip"
+          mv releases/zip/GT_New_Horizons_daily_Server_Java_17-26.zip "GTNH-daily-${{ steps.date.outputs.today }}-server-java17-26.zip"
           mv releases/multi_poly/GT_New_Horizons_daily_Java_8.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-25.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip"
+          mv releases/multi_poly/GT_New_Horizons_daily_Java_17-26.zip "GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-26.zip"
 
       # Pulls the newest changelog filename and stores it in an env variable
       # so we can use it in the commit
@@ -142,9 +142,9 @@ jobs:
           name: daily-build-bundle
           path: |
             GTNH-daily-${{ steps.date.outputs.today }}-server-java8.zip
-            GTNH-daily-${{ steps.date.outputs.today }}-server-java17-25.zip
+            GTNH-daily-${{ steps.date.outputs.today }}-server-java17-26.zip
             GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java8.zip
-            GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip
+            GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-26.zip
             releases/manifests/daily.json
             releases/changelogs/
             gtnh-assets.json
@@ -265,7 +265,7 @@ jobs:
       - name: Upload modern java server zip
         uses: actions/upload-artifact@v7
         with:
-          path: GTNH-daily-${{ needs.build.outputs.today }}-server-java17-25.zip
+          path: GTNH-daily-${{ needs.build.outputs.today }}-server-java17-26.zip
           archive: false
 
       - name: Upload MMC zip
@@ -277,7 +277,7 @@ jobs:
       - name: Upload modern java Prism zip
         uses: actions/upload-artifact@v7
         with:
-          path: GTNH-daily-${{ needs.build.outputs.today }}-mmcprism-java17-25.zip
+          path: GTNH-daily-${{ needs.build.outputs.today }}-mmcprism-java17-26.zip
           archive: false
 
       - name: Push daily changelog in commit to master

--- a/.github/workflows/experimental-modpack-build.yml
+++ b/.github/workflows/experimental-modpack-build.yml
@@ -112,9 +112,9 @@ jobs:
         shell: bash
         run: |
           mv releases/zip/GT_New_Horizons_experimental_Server_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-java8.zip"
-          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-25.zip"
+          mv releases/zip/GT_New_Horizons_experimental_Server_Java_17-26.zip "GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-26.zip"
           mv releases/multi_poly/GT_New_Horizons_experimental_Java_8.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java8.zip"
-          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-25.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip"
+          mv releases/multi_poly/GT_New_Horizons_experimental_Java_17-26.zip "GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-26.zip"
 
       # Pulls the newest changelog filename and stores it in an env variable
       # so we can use it in the commit
@@ -132,9 +132,9 @@ jobs:
           name: experimental-build-bundle
           path: |
             GTNH-experimental-${{ steps.date.outputs.today }}-server-java8.zip
-            GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-25.zip
+            GTNH-experimental-${{ steps.date.outputs.today }}-server-java17-26.zip
             GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java8.zip
-            GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-25.zip
+            GTNH-experimental-${{ steps.date.outputs.today }}-mmcprism-java17-26.zip
             releases/manifests/experimental.json
             releases/changelogs/
             gtnh-assets.json
@@ -199,7 +199,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-experimental-${{ needs.build.outputs.today }}-server-java17-25.zip
+          path: GTNH-experimental-${{ needs.build.outputs.today }}-server-java17-26.zip
           archive: false
 
       - name: Upload MMC zip
@@ -215,7 +215,7 @@ jobs:
         # Upload even if one of the zips fails to upload
         if: success() || failure()
         with:
-          path: GTNH-experimental-${{ needs.build.outputs.today }}-mmcprism-java17-25.zip
+          path: GTNH-experimental-${{ needs.build.outputs.today }}-mmcprism-java17-26.zip
           archive: false
 
       - name: Push experimental changelog in commit to master

--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -14,8 +14,8 @@ on:
       zip-prefix:
         description: >-
           Basename prefix of the built zips, such that the four variants are
-          "<zip-prefix>-server-java8.zip", "<zip-prefix>-server-java17-25.zip",
-          "<zip-prefix>-mmcprism-java8.zip" and "<zip-prefix>-mmcprism-java17-25.zip".
+          "<zip-prefix>-server-java8.zip", "<zip-prefix>-server-java17-26.zip",
+          "<zip-prefix>-mmcprism-java8.zip" and "<zip-prefix>-mmcprism-java17-26.zip".
         type: string
         required: true
       today:
@@ -55,8 +55,8 @@ jobs:
       matrix:
         include:
           - java-version: 25
-            server-zip-variant: server-java17-25
-            client-zip-variant: mmcprism-java17-25
+            server-zip-variant: server-java17-26
+            client-zip-variant: mmcprism-java17-26
             server-java-args: |
               -Xms1G -Xmx2G
               -Dfml.readTimeout=45

--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java-version: 25
+          - java-version: 26
             server-zip-variant: server-java17-26
             client-zip-variant: mmcprism-java17-26
             server-java-args: |

--- a/src/daxxl/defs.py
+++ b/src/daxxl/defs.py
@@ -136,7 +136,7 @@ view-distance=8
 spawn-protection=1
 motd=GT:New Horizons {0}"""
 
-JAVA_9_ARCHIVE_SUFFIX = "Java_17-25"
+JAVA_9_ARCHIVE_SUFFIX = "Java_17-26"
 
 
 class Side(str, Enum):


### PR DESCRIPTION
## Summary
For clarity, this renames the final name of release build files from java17-25 to java17-26.
lwjgl3ify has supported j26 for a while now and according to @eigenraven even supports early j27 builds


## Checklist
- ❌ I have tested this PR in DevEnv
- ❌ I have tested this PR in Fullpack
- ✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- ❌ This PR requires another PR in order to merge
