### PR TITLE
Publish GregTech.lang from the Java 26 client test run

### DIFF
--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -218,23 +218,13 @@ jobs:
         if: always() && steps.start-server.outcome == 'success'
         run: bash scripts/tests/orchestrator.sh stop-server
 
-      - name: Upload GregTech.lang
-        if: matrix.java-version == 26
-        shell: bash
-        run: |
-          set -euo pipefail
-          src="${{ env.WORK_DIR }}/client/.minecraft/GregTech.lang"
-          [ -f "$src" ] || { echo "GregTech.lang not found, skipping upload"; exit 0; }
-          mkdir -p /tmp/gregtech-lang
-          cp "$src" /tmp/gregtech-lang/GregTech.lang
-          echo "GREGTECH_LANG_FOUND=true" >> "$GITHUB_ENV"
-
       - name: Publish GregTech.lang artifact
-        if: matrix.java-version == 26 && env.GREGTECH_LANG_FOUND == 'true'
+        if: matrix.java-version == 26 && github.event_name == 'schedule'
         uses: actions/upload-artifact@v7
         with:
           name: gregtech-lang
-          path: /tmp/gregtech-lang/GregTech.lang
+          path: ${{ env.WORK_DIR }}/client/.minecraft/GregTech.lang
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Print logs from dual run

--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -219,7 +219,7 @@ jobs:
         run: bash scripts/tests/orchestrator.sh stop-server
 
       - name: Upload GregTech.lang
-        if: (success() || failure()) && matrix.java-version == 26
+        if: matrix.java-version == 26
         shell: bash
         run: |
           set -euo pipefail
@@ -230,7 +230,7 @@ jobs:
           echo "GREGTECH_LANG_FOUND=true" >> "$GITHUB_ENV"
 
       - name: Publish GregTech.lang artifact
-        if: (success() || failure()) && matrix.java-version == 26 && env.GREGTECH_LANG_FOUND == 'true'
+        if: matrix.java-version == 26 && env.GREGTECH_LANG_FOUND == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: gregtech-lang

--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -218,6 +218,25 @@ jobs:
         if: always() && steps.start-server.outcome == 'success'
         run: bash scripts/tests/orchestrator.sh stop-server
 
+      - name: Upload GregTech.lang
+        if: (success() || failure()) && matrix.java-version == 26
+        shell: bash
+        run: |
+          set -euo pipefail
+          src="${{ env.WORK_DIR }}/client/.minecraft/GregTech.lang"
+          [ -f "$src" ] || { echo "GregTech.lang not found, skipping upload"; exit 0; }
+          mkdir -p /tmp/gregtech-lang
+          cp "$src" /tmp/gregtech-lang/GregTech.lang
+          echo "GREGTECH_LANG_FOUND=true" >> "$GITHUB_ENV"
+
+      - name: Publish GregTech.lang artifact
+        if: (success() || failure()) && matrix.java-version == 26 && env.GREGTECH_LANG_FOUND == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: gregtech-lang
+          path: /tmp/gregtech-lang/GregTech.lang
+          retention-days: 14
+
       - name: Print logs from dual run
         if: success() || failure()
         run: |


### PR DESCRIPTION
GTNH-Translations currently requires a contributor to run the client by hand, grab the generated GregTech.lang, and upload it to the repo before it can sync to ParaTranz. The Java 26 leg of the modpack test already launches the client headless, so it can produce this file as a side effect.

Uploads .minecraft/GregTech.lang as a build artifact named "gregtech-lang" after the client run, skipping the step if the file isn't present (client run failed before generating it). Only the Java 26 leg publishes it, since the file's content doesn't depend on the Java version.

This is step 1 of 2. GTNH-Translations needs a matching PR to pick up this artifact daily and commit it to daily-history/GregTech.lang; that PR takes effect only after this one merges and a daily run produces the artifact.