### PR TITLE
Automatic versionning

### DIFF
--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -11,7 +11,7 @@ from colorama import Fore
 from daxxl.app_context import AppContext
 from daxxl.assembler.downloader import get_asset_version_cache_location
 from daxxl.assembler.exclusions import Exclusions
-from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, Side
+from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, DevRelease, Side
 from daxxl.exceptions import InvalidConfigException
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.gtnh_config import GTNHConfig
@@ -35,6 +35,7 @@ class GenericAssembler:
     modified_config_files: frozenset[str] = frozenset({
         "config/txloader/load/mainmenu/version.txt",
         "config/GTNewHorizons/dreamcraft.cfg",
+        "config/DreamCoreMod.properties",
     })
 
     def __init__(
@@ -234,6 +235,20 @@ class GenericAssembler:
             return f"GTNH {display_version} ({date_str})".encode("utf-8")
         if filename == "config/GTNewHorizons/dreamcraft.cfg":
             return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
+        if filename == "config/DreamCoreMod.properties":
+            text = data.decode("utf-8")
+            try:
+                DevRelease(self.release.version)
+            except ValueError:
+                value = display_version
+            else:
+                date_str = self.release.last_updated.strftime("%Y-%m-%d")
+                value = f"{display_version} - {date_str}"
+            if re.search(r"^displayedModpackVersion=.*$", text, flags=re.MULTILINE):
+                text = re.sub(r"^displayedModpackVersion=.*$", f"displayedModpackVersion={value}", text, count=1, flags=re.MULTILINE)
+            else:
+                text = text.rstrip("\n\r") + "\n" + f"displayedModpackVersion={value}" + "\n"
+            return text.encode("utf-8")
         return data
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -11,7 +11,8 @@ from colorama import Fore
 from daxxl.app_context import AppContext
 from daxxl.assembler.downloader import get_asset_version_cache_location
 from daxxl.assembler.exclusions import Exclusions
-from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, Side
+from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, Side, NHCORE_CONFIG_VERSION_ENTRY, \
+    NHCOREMOD_WINDOW_VERSION_ENTRY
 from daxxl.exceptions import InvalidConfigException
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.gtnh_config import GTNHConfig
@@ -235,15 +236,24 @@ class GenericAssembler:
 
     def _modify_welcome_message_version(self, data: bytes) -> bytes:
         display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
-        return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
+        text, replacements = re.subn(rf"^(\s*{NHCORE_CONFIG_VERSION_ENTRY}).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE)
+
+        if replacements == 0:
+            raise ValueError(
+                f"Could not find '{NHCORE_CONFIG_VERSION_ENTRY}' entry in config/GTNewHorizons/dreamcraft.cfg; "
+                "the config format may have changed."
+            )
+
+        return text.encode("utf-8")
+
 
     def _modify_window_version(self, data: bytes) -> bytes:
         text = data.decode("utf-8")
         display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
-        replaced_str = f"displayedModpackVersion={display_version}"
-
-        if re.search(r"^displayedModpackVersion=.*$", text, flags=re.MULTILINE):
-            text = re.sub(r"^displayedModpackVersion=.*$", replaced_str, text, count=1, flags=re.MULTILINE)
+        replaced_str = f"{NHCOREMOD_WINDOW_VERSION_ENTRY}{display_version}"
+        search_pattern = rf"^{NHCOREMOD_WINDOW_VERSION_ENTRY}.*$"
+        if re.search(search_pattern, text, flags=re.MULTILINE):
+            text = re.sub(search_pattern, replaced_str, text, count=1, flags=re.MULTILINE)
         else:
             text = text.rstrip("\n\r") + "\n" + replaced_str + "\n"
         return text.encode("utf-8")

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -30,6 +30,9 @@ class GenericAssembler:
     # config entries dropped regardless of the side's exclusions
     excluded_config_files: frozenset[str] = frozenset()
 
+    # config entries whose content is modified before being added to the archive
+    modified_config_files: frozenset[str] = frozenset()
+
     def __init__(
         self,
         context: AppContext,
@@ -208,12 +211,20 @@ class GenericAssembler:
                 # zipfile to know if it's a file or a folder. If used here, Path objects will lead to
                 # the creation of empty files for every folder.
                 arcname = f"{root.as_posix()}/{item}" if root is not None else item
-                with config_zip.open(item) as config_item:
-                    with destination.open(arcname, "w") as target:
-                        shutil.copyfileobj(config_item, target)
-                        if self.task_progress_callback is not None:
-                            self.task_progress_callback(self.delta_progress, f"adding {item} to the archive")
+                if item in self.modified_config_files:
+                    data = config_zip.read(item)
+                    data = self._modify_config_file(item, data)
+                    destination.writestr(arcname, data)
+                else:
+                    with config_zip.open(item) as config_item:
+                        with destination.open(arcname, "w") as target:
+                            shutil.copyfileobj(config_item, target)
+                if self.task_progress_callback is not None:
+                    self.task_progress_callback(self.delta_progress, f"adding {item} to the archive")
                 await self.yield_to_event_loop()
+
+    def _modify_config_file(self, filename: str, data: bytes) -> bytes:
+        return data
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:
         """

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -11,8 +11,7 @@ from colorama import Fore
 from daxxl.app_context import AppContext
 from daxxl.assembler.downloader import get_asset_version_cache_location
 from daxxl.assembler.exclusions import Exclusions
-from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, Side, NHCORE_CONFIG_VERSION_ENTRY, \
-    NHCOREMOD_WINDOW_VERSION_ENTRY
+from daxxl.defs import NHCOREMOD_WINDOW_VERSION_ENTRY, NHCORE_CONFIG_VERSION_ENTRY, README_TEMPLATE, RELEASE_README_DIR, Side
 from daxxl.exceptions import InvalidConfigException
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.gtnh_config import GTNHConfig
@@ -240,12 +239,10 @@ class GenericAssembler:
 
         if replacements == 0:
             raise ValueError(
-                f"Could not find '{NHCORE_CONFIG_VERSION_ENTRY}' entry in config/GTNewHorizons/dreamcraft.cfg; "
-                "the config format may have changed."
+                f"Could not find '{NHCORE_CONFIG_VERSION_ENTRY}' entry in config/GTNewHorizons/dreamcraft.cfg; the config format may have changed."
             )
 
         return text.encode("utf-8")
-
 
     def _modify_window_version(self, data: bytes) -> bytes:
         text = data.decode("utf-8")
@@ -259,7 +256,7 @@ class GenericAssembler:
         return text.encode("utf-8")
 
     def _modify_config_file(self, filename: str, data: bytes) -> bytes:
-        if not filename in self.modified_config_files:
+        if filename not in self.modified_config_files:
             return data
         return self.modified_config_files[filename](data)
 

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import shutil
 from collections.abc import Callable
 from pathlib import Path
@@ -31,7 +32,10 @@ class GenericAssembler:
     excluded_config_files: frozenset[str] = frozenset()
 
     # config entries whose content is modified before being added to the archive
-    modified_config_files: frozenset[str] = frozenset({"config/txloader/load/mainmenu/version.txt"})
+    modified_config_files: frozenset[str] = frozenset({
+        "config/txloader/load/mainmenu/version.txt",
+        "config/GTNewHorizons/dreamcraft.cfg",
+    })
 
     def __init__(
         self,
@@ -224,10 +228,12 @@ class GenericAssembler:
                 await self.yield_to_event_loop()
 
     def _modify_config_file(self, filename: str, data: bytes) -> bytes:
+        display_version = self.release.get_display_version(self.context.counter)
         if filename == "config/txloader/load/mainmenu/version.txt":
-            display_version = self.release.get_display_version(self.context.counter)
             date_str = self.release.last_updated.strftime("%Y-%m-%d")
             return f"GTNH {display_version} ({date_str})".encode("utf-8")
+        if filename == "config/GTNewHorizons/dreamcraft.cfg":
+            return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
         return data
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -31,7 +31,7 @@ class GenericAssembler:
     excluded_config_files: frozenset[str] = frozenset()
 
     # config entries whose content is modified before being added to the archive
-    modified_config_files: frozenset[str] = frozenset()
+    modified_config_files: frozenset[str] = frozenset({"config/txloader/load/mainmenu/version.txt"})
 
     def __init__(
         self,
@@ -224,6 +224,10 @@ class GenericAssembler:
                 await self.yield_to_event_loop()
 
     def _modify_config_file(self, filename: str, data: bytes) -> bytes:
+        if filename == "config/txloader/load/mainmenu/version.txt":
+            display_version = self.release.get_display_version(self.context.counter)
+            date_str = self.release.last_updated.strftime("%Y-%m-%d")
+            return f"GTNH {display_version} ({date_str})".encode("utf-8")
         return data
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -11,7 +11,7 @@ from colorama import Fore
 from daxxl.app_context import AppContext
 from daxxl.assembler.downloader import get_asset_version_cache_location
 from daxxl.assembler.exclusions import Exclusions
-from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, DevRelease, Side
+from daxxl.defs import README_TEMPLATE, RELEASE_README_DIR, Side
 from daxxl.exceptions import InvalidConfigException
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.gtnh_config import GTNHConfig
@@ -32,11 +32,13 @@ class GenericAssembler:
     excluded_config_files: frozenset[str] = frozenset()
 
     # config entries whose content is modified before being added to the archive
-    modified_config_files: frozenset[str] = frozenset({
-        "config/txloader/load/mainmenu/version.txt",
-        "config/GTNewHorizons/dreamcraft.cfg",
-        "config/DreamCoreMod.properties",
-    })
+    modified_config_files: frozenset[str] = frozenset(
+        {
+            "config/txloader/load/mainmenu/version.txt",
+            "config/GTNewHorizons/dreamcraft.cfg",
+            "config/DreamCoreMod.properties",
+        }
+    )
 
     def __init__(
         self,
@@ -231,13 +233,13 @@ class GenericAssembler:
     def _modify_mainmenu_version(self, data: bytes) -> bytes:
         date_str = self.release.last_updated.strftime("%Y-%m-%d")
         display_version = self.release.get_display_version(self.context.counter, with_date=False)
-        return f"GTNH {display_version} ({date_str})".encode("utf-8")
+        return f"GTNH {display_version} ({date_str})".encode()
 
-    def _modify_welcome_message_version(self, data:bytes) -> bytes:
+    def _modify_welcome_message_version(self, data: bytes) -> bytes:
         display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
         return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
 
-    def _modify_window_version(self, data:bytes) -> bytes:
+    def _modify_window_version(self, data: bytes) -> bytes:
         text = data.decode("utf-8")
         display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
         replaced_str = f"displayedModpackVersion={display_version}"

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -228,27 +228,33 @@ class GenericAssembler:
                     self.task_progress_callback(self.delta_progress, f"adding {item} to the archive")
                 await self.yield_to_event_loop()
 
+    def _modify_mainmenu_version(self, data: bytes) -> bytes:
+        date_str = self.release.last_updated.strftime("%Y-%m-%d")
+        display_version = self.release.get_display_version(self.context.counter, with_date=False)
+        return f"GTNH {display_version} ({date_str})".encode("utf-8")
+
+    def _modify_welcome_message_version(self, data:bytes) -> bytes:
+        display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
+        return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
+
+    def _modify_window_version(self, data:bytes) -> bytes:
+        text = data.decode("utf-8")
+        display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
+        replaced_str = f"displayedModpackVersion={display_version}"
+
+        if re.search(r"^displayedModpackVersion=.*$", text, flags=re.MULTILINE):
+            text = re.sub(r"^displayedModpackVersion=.*$", replaced_str, text, count=1, flags=re.MULTILINE)
+        else:
+            text = text.rstrip("\n\r") + "\n" + replaced_str + "\n"
+        return text.encode("utf-8")
+
     def _modify_config_file(self, filename: str, data: bytes) -> bytes:
-        display_version = self.release.get_display_version(self.context.counter)
         if filename == "config/txloader/load/mainmenu/version.txt":
-            date_str = self.release.last_updated.strftime("%Y-%m-%d")
-            return f"GTNH {display_version} ({date_str})".encode("utf-8")
+            return self._modify_mainmenu_version(data)
         if filename == "config/GTNewHorizons/dreamcraft.cfg":
-            return re.sub(r"^(\s*S:ModPackVersion=).*$", rf"\g<1>{display_version}", data.decode("utf-8"), count=1, flags=re.MULTILINE).encode("utf-8")
+            return self._modify_welcome_message_version(data)
         if filename == "config/DreamCoreMod.properties":
-            text = data.decode("utf-8")
-            try:
-                DevRelease(self.release.version)
-            except ValueError:
-                value = display_version
-            else:
-                date_str = self.release.last_updated.strftime("%Y-%m-%d")
-                value = f"{display_version} - {date_str}"
-            if re.search(r"^displayedModpackVersion=.*$", text, flags=re.MULTILINE):
-                text = re.sub(r"^displayedModpackVersion=.*$", f"displayedModpackVersion={value}", text, count=1, flags=re.MULTILINE)
-            else:
-                text = text.rstrip("\n\r") + "\n" + f"displayedModpackVersion={value}" + "\n"
-            return text.encode("utf-8")
+            return self._modify_window_version(data)
         return data
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:

--- a/src/daxxl/assembler/platforms/generic_assembler.py
+++ b/src/daxxl/assembler/platforms/generic_assembler.py
@@ -31,15 +31,6 @@ class GenericAssembler:
     # config entries dropped regardless of the side's exclusions
     excluded_config_files: frozenset[str] = frozenset()
 
-    # config entries whose content is modified before being added to the archive
-    modified_config_files: frozenset[str] = frozenset(
-        {
-            "config/txloader/load/mainmenu/version.txt",
-            "config/GTNewHorizons/dreamcraft.cfg",
-            "config/DreamCoreMod.properties",
-        }
-    )
-
     def __init__(
         self,
         context: AppContext,
@@ -73,6 +64,13 @@ class GenericAssembler:
             Side.SERVER_JAVA9: Exclusions(mod_pack.server_exclusions + mod_pack.server_java9_exclusions),
         }
         self.delta_progress: float = 0.0
+
+        # config entries that must be modified on the fly
+        self.modified_config_files: dict[str, Callable[[bytes], bytes]] = {
+            "config/txloader/load/mainmenu/version.txt": self._modify_mainmenu_version,
+            "config/GTNewHorizons/dreamcraft.cfg": self._modify_welcome_message_version,
+            "config/DreamCoreMod.properties": self._modify_window_version,
+        }
 
     @property
     def config_root(self) -> Path | None:
@@ -251,13 +249,9 @@ class GenericAssembler:
         return text.encode("utf-8")
 
     def _modify_config_file(self, filename: str, data: bytes) -> bytes:
-        if filename == "config/txloader/load/mainmenu/version.txt":
-            return self._modify_mainmenu_version(data)
-        if filename == "config/GTNewHorizons/dreamcraft.cfg":
-            return self._modify_welcome_message_version(data)
-        if filename == "config/DreamCoreMod.properties":
-            return self._modify_window_version(data)
-        return data
+        if not filename in self.modified_config_files:
+            return data
+        return self.modified_config_files[filename](data)
 
     async def add_config(self, side: Side, config: tuple[GTNHConfig, GTNHVersion], archive: ZipFile, verbose: bool = False) -> None:
         """

--- a/src/daxxl/assembler/platforms/prism.py
+++ b/src/daxxl/assembler/platforms/prism.py
@@ -116,7 +116,7 @@ class PrismAssembler(GenericAssembler):
                 archive.writestr(str(self.prism_archive_root) + "/mmc-pack.json", MMC_PACK_JSON)
             archive.writestr(
                 str(self.prism_archive_root) + "/instance.cfg",
-                PRISM_PACK_INSTANCE.format(f"GTNH {self.release.version}"),
+                PRISM_PACK_INSTANCE.format(f"GTNH {self.release.get_display_version(self.context.counter)}"),
             )
             with archive.open(str(self.prism_archive_root) + "/gtnh_icon.png", "w") as target:
                 with open(PRISM_ASSETS_DIR / "gtnh_icon.png", "rb") as icon:

--- a/src/daxxl/assembler/platforms/prism.py
+++ b/src/daxxl/assembler/platforms/prism.py
@@ -116,7 +116,7 @@ class PrismAssembler(GenericAssembler):
                 archive.writestr(str(self.prism_archive_root) + "/mmc-pack.json", MMC_PACK_JSON)
             archive.writestr(
                 str(self.prism_archive_root) + "/instance.cfg",
-                PRISM_PACK_INSTANCE.format(f"GTNH {self.release.get_display_version(self.context.counter)}"),
+                PRISM_PACK_INSTANCE.format(f"GTNH {self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)}"),
             )
             with archive.open(str(self.prism_archive_root) + "/gtnh_icon.png", "w") as target:
                 with open(PRISM_ASSETS_DIR / "gtnh_icon.png", "rb") as icon:

--- a/src/daxxl/assembler/platforms/zip_assembler.py
+++ b/src/daxxl/assembler/platforms/zip_assembler.py
@@ -80,7 +80,8 @@ class ZipAssembler(GenericAssembler):
             await self.yield_to_event_loop()
 
         # server.properties
-        archive.writestr("server.properties", SERVER_PROPERTIES_FILE.format(self.release.version))
+        display_version = self.release.get_display_version(self.context.counter, with_date=self.release.is_dev_version)
+        archive.writestr("server.properties", SERVER_PROPERTIES_FILE.format(display_version))
 
     def get_archive_path(self, side: Side) -> Path:
         return RELEASE_ZIP_DIR / f"GT_New_Horizons_{self.release.version}_{side.archive_name()}.zip"

--- a/src/daxxl/defs.py
+++ b/src/daxxl/defs.py
@@ -138,7 +138,7 @@ spawn-protection=1
 motd=GT:New Horizons {0}"""
 
 JAVA_9_ARCHIVE_SUFFIX = "Java_17-26"
-
+GTNH_DEV_CYCLE = "2.9.x"
 
 class Side(str, Enum):
     SERVER = "SERVER"

--- a/src/daxxl/defs.py
+++ b/src/daxxl/defs.py
@@ -140,6 +140,7 @@ motd=GT:New Horizons {0}"""
 JAVA_9_ARCHIVE_SUFFIX = "Java_17-26"
 GTNH_DEV_CYCLE = "2.9.x"
 
+
 class Side(str, Enum):
     SERVER = "SERVER"
     CLIENT = "CLIENT"

--- a/src/daxxl/defs.py
+++ b/src/daxxl/defs.py
@@ -139,6 +139,8 @@ motd=GT:New Horizons {0}"""
 
 JAVA_9_ARCHIVE_SUFFIX = "Java_17-26"
 GTNH_DEV_CYCLE = "2.9.x"
+NHCORE_CONFIG_VERSION_ENTRY = "S:ModPackVersion="
+NHCOREMOD_WINDOW_VERSION_ENTRY = "displayedModpackVersion="
 
 
 class Side(str, Enum):

--- a/src/daxxl/models/gtnh_release.py
+++ b/src/daxxl/models/gtnh_release.py
@@ -70,9 +70,9 @@ class GTNHRelease(GTNHBaseModel):
         count = counter_service.get_dev_release_count(release_type)
 
         if not with_date:
-            return f"{GTNH_DEV_CYCLE} ({release_type.value} {count})"
+            return f"{GTNH_DEV_CYCLE} ({release_type.value.capitalize()} {count})"
         date_str = self.last_updated.strftime("%Y-%m-%d")
-        return f"{GTNH_DEV_CYCLE} ({release_type.value} {count}) - {date_str}"
+        return f"{GTNH_DEV_CYCLE} ({release_type.value.capitalize()} {count}) - {date_str}"
 
     @property
     def is_dev_version(self) -> bool:

--- a/src/daxxl/models/gtnh_release.py
+++ b/src/daxxl/models/gtnh_release.py
@@ -3,7 +3,8 @@ from datetime import UTC, datetime
 from colorama import Fore
 from pydantic import Field, ValidationError
 
-from daxxl.defs import RELEASE_MANIFEST_DIR, DevRelease, ModSource
+from daxxl.defs import RELEASE_MANIFEST_DIR, DevRelease, ModSource, GTNH_DEV_CYCLE
+from daxxl.services.counter_service import CounterService
 from daxxl.exceptions import InvalidReleaseException, NoModAssetFound
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.available_assets import AvailableAssets
@@ -60,6 +61,14 @@ class GTNHRelease(GTNHBaseModel):
 
         if errors:
             raise InvalidReleaseException(f"Invalid release {self.version!r}:\n- " + "\n- ".join(errors))
+
+    def get_display_version(self, counter_service: CounterService) -> str:
+        try:
+            release_type = DevRelease(self.version)
+        except ValueError:
+            return self.version
+        count = counter_service.get_dev_release_count(release_type)
+        return f"{GTNH_DEV_CYCLE} ({release_type.value} {count})"
 
 
 class __GTNHReleaseV1(GTNHBaseModel):

--- a/src/daxxl/models/gtnh_release.py
+++ b/src/daxxl/models/gtnh_release.py
@@ -62,14 +62,25 @@ class GTNHRelease(GTNHBaseModel):
         if errors:
             raise InvalidReleaseException(f"Invalid release {self.version!r}:\n- " + "\n- ".join(errors))
 
-    def get_display_version(self, counter_service: CounterService) -> str:
-        try:
-            release_type = DevRelease(self.version)
-        except ValueError:
+    def get_display_version(self, counter_service: CounterService, with_date:bool=False) -> str:
+        if not self.is_dev_version:
             return self.version
-        count = counter_service.get_dev_release_count(release_type)
-        return f"{GTNH_DEV_CYCLE} ({release_type.value} {count})"
 
+        release_type = DevRelease(self.version)
+        count = counter_service.get_dev_release_count(release_type)
+
+        if not with_date:
+            return f"{GTNH_DEV_CYCLE} ({release_type.value} {count})"
+        date_str = self.last_updated.strftime("%Y-%m-%d")
+        return f"{GTNH_DEV_CYCLE} ({release_type.value} {count}) - {date_str}"
+
+    @property
+    def is_dev_version(self) -> bool:
+        try:
+            DevRelease(self.version)
+            return True
+        except ValueError:
+            return False
 
 class __GTNHReleaseV1(GTNHBaseModel):
     version: str = Field(default=DevRelease.EXPERIMENTAL.value)

--- a/src/daxxl/models/gtnh_release.py
+++ b/src/daxxl/models/gtnh_release.py
@@ -3,13 +3,13 @@ from datetime import UTC, datetime
 from colorama import Fore
 from pydantic import Field, ValidationError
 
-from daxxl.defs import RELEASE_MANIFEST_DIR, DevRelease, ModSource, GTNH_DEV_CYCLE
-from daxxl.services.counter_service import CounterService
+from daxxl.defs import GTNH_DEV_CYCLE, RELEASE_MANIFEST_DIR, DevRelease, ModSource
 from daxxl.exceptions import InvalidReleaseException, NoModAssetFound
 from daxxl.gtnh_logger import get_logger
 from daxxl.models.available_assets import AvailableAssets
 from daxxl.models.base import GTNHBaseModel
 from daxxl.models.mod_version_info import ModVersionInfo
+from daxxl.services.counter_service import CounterService
 from daxxl.utils import atomic_write_text
 
 log = get_logger(__name__)
@@ -62,7 +62,7 @@ class GTNHRelease(GTNHBaseModel):
         if errors:
             raise InvalidReleaseException(f"Invalid release {self.version!r}:\n- " + "\n- ".join(errors))
 
-    def get_display_version(self, counter_service: CounterService, with_date:bool=False) -> str:
+    def get_display_version(self, counter_service: CounterService, with_date: bool = False) -> str:
         if not self.is_dev_version:
             return self.version
 
@@ -81,6 +81,7 @@ class GTNHRelease(GTNHBaseModel):
             return True
         except ValueError:
             return False
+
 
 class __GTNHReleaseV1(GTNHBaseModel):
     version: str = Field(default=DevRelease.EXPERIMENTAL.value)


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
finally insert the correct version of the assembled release instead of relying on manual file bumps in the modpack repo.
4 places which get automatically versionned now:
- the window title
- the main menu version
- the welcome version from NHCore
- the motd of the server.properties

For a normal release, the date is exclusively shown on the main screen like before.
For a daily / experimental release, the date is also appended to the release version.

Example with a daily:
- window title during loading screen
<img width="850" height="508" alt="image" src="https://github.com/user-attachments/assets/06abde43-9b13-418c-9298-54eeb75452e7" />

- main menu versioning
<img width="853" height="511" alt="image" src="https://github.com/user-attachments/assets/c714a3b3-b6bc-49c1-a50c-be614cdd6365" />

- when you join a map
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/9e2a09c6-44de-4f9c-9286-c1a79a59b20d" />

- the motd of the server
<img width="855" height="508" alt="image" src="https://github.com/user-attachments/assets/a1c907de-d0cf-489f-acab-fe6224201fae" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
