### PR TITLE
Add flags to crash on uninjected mixins

### DIFF
--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -62,6 +62,7 @@ jobs:
               -Dfml.readTimeout=45
               -Dhorizonqa.mode=ci -Dhorizonqa.autoRun=false -Dhorizonqa.world=normal -Dhorizonqa.gridOrigin=0,128,0
               -Dhorizonqa.reportDir=/tmp/daily-test/run
+              -Dmixin.debug.countInjections=true -Dmixin.debug=true
               @java9args.txt
               -jar lwjgl3ify-forgePatches.jar
               nogui
@@ -79,6 +80,7 @@ jobs:
               -Dfml.readTimeout=45
               -Dhorizonqa.mode=ci -Dhorizonqa.autoRun=false -Dhorizonqa.world=normal -Dhorizonqa.gridOrigin=0,128,0
               -Dhorizonqa.reportDir=/tmp/daily-test/run
+              -Dmixin.debug.countInjections=true -Dmixin.debug=true
               -jar forge-1.7.10-10.13.4.1614-1.7.10-universal.jar
               nogui
             server-startup-timeout: 240


### PR DESCRIPTION
## Summary
This PR enables `mixin.debug.countInjections` which crashes on `expects` which dont hit their target count.

The pack will probably run into a lot of instances where this triggers, so we will have to fix those before merging.

List of mixins conflicts we have to solve:
- [ ] `@Redirect conflict. Skipping mixins.archaicfix.early.json:client.core.MixinMinecraft from mod archaicfix->@Redirect::displayWorkingScreen(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/GuiScreen;)V with priority 999, already redirected by mixins.etfuturum.early.json:worldthumbnail.client.MixinMinecraft_LoadingBridge from mod etfuturum->@Redirect::etfu$bridgeLoadingScreen(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/GuiScreen;)V with priority 1000
`

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
