### PR TITLE
Update daily release metadata

### DIFF
--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -334,8 +334,9 @@ jobs:
           if gh release view "$TAG" --repo "$RELEASE_REPOSITORY" >/dev/null 2>&1; then
             gh release upload "$TAG" "${assets[@]}" --repo "$RELEASE_REPOSITORY" --clobber
           else
-            gh release create "$TAG" "${assets[@]}" --repo "$RELEASE_REPOSITORY" --prerelease \
-              --title "GTNH daily ${{ needs.build.outputs.today }}"
+            gh release create "$TAG" "${assets[@]}" --repo "$RELEASE_REPOSITORY" \
+              --title "GTNH daily ${{ needs.build.outputs.today }}" \
+              --notes "Automated daily build. See [workflow run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for build details."$'\n\n'"To download a build, open the **Assets** section below and select the file you need."
           fi
 
       - name: Push daily changelog in commit to master


### PR DESCRIPTION
## Summary

Publishes daily builds as regular GitHub releases instead of prereleases. The release description now links to the originating workflow run and tells users to expand the **Assets** section to download a build.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
