### PR TITLE
Fix Daily & Previous Daily MD Commits

### DIFF
--- a/.github/workflows/daily-modpack-build.yml
+++ b/.github/workflows/daily-modpack-build.yml
@@ -152,6 +152,8 @@ jobs:
             GTNH-daily-${{ steps.date.outputs.today }}-mmcprism-java17-26.zip
             GTNH-daily-${{ steps.date.outputs.today }}-android-java17-26.mrpack
             releases/manifests/daily.json
+            releases/manifests/previous_daily.json
+            releases/readmes/README_daily.MD
             releases/changelogs/
             gtnh-assets.json
           if-no-files-found: error
@@ -349,6 +351,8 @@ jobs:
           git add "$daily_non_daily_changelog_file"
           git add "./releases/changelogs/daily builds"
           git add ./releases/manifests/daily.json
+          git add ./releases/manifests/previous_daily.json
+          git add ./releases/readmes/README_daily.MD
           git add ./gtnh-assets.json
           git commit -m "Upload daily $changelog_name"
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Both files were generated during the build job but omitted from the upload job which performs the commit. This will make it so Dream no longer has to update these manually and the workflow will do it on it's own. 

Example of what Dream does: https://github.com/GTNewHorizons/DreamAssemblerXXL/commit/947e93505bd639ac3fba9c4642fd2ffb6dd1c87c

## Checklist
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
