### PR TITLE
Update Horizon-QA to version 0.14.1

### DIFF
--- a/.github/workflows/modpack-test.yml
+++ b/.github/workflows/modpack-test.yml
@@ -198,10 +198,10 @@ jobs:
         working-directory: ${{ env.WORK_DIR }}
         run: |
           set -euo pipefail
-          curl -sSL -o horizonqa-0.14.0.jar https://github.com/GTNewHorizons/Horizon-QA/releases/download/0.14.0/horizonqa-0.14.0.jar
-          echo "1de4cd8bf796197cc029500f9c992386cbd2e811da4f954624c192bfc63a2a07  horizonqa-0.14.0.jar" | sha256sum -c -
-          cp -v horizonqa-0.14.0.jar ${{ env.WORK_DIR }}/client/.minecraft/mods/
-          cp -v horizonqa-0.14.0.jar ${{ env.WORK_DIR }}/server/mods/
+          curl -sSL -o horizonqa-0.14.1.jar https://github.com/GTNewHorizons/Horizon-QA/releases/download/0.14.1/horizonqa-0.14.1.jar
+          echo "9544eb68e35cbd93b77174faab02673f9c46d2eec5c96a2f4a5cf173861b3f65  horizonqa-0.14.1.jar" | sha256sum -c -
+          cp -v horizonqa-0.14.1.jar ${{ env.WORK_DIR }}/client/.minecraft/mods/
+          cp -v horizonqa-0.14.1.jar ${{ env.WORK_DIR }}/server/mods/
 
       - name: Start server
         id: start-server


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Updates the Horizon-QA CI dependency from 0.14.0 to 0.14.1, including the downloaded JAR filename, release URL, and verified SHA-256 checksum.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge