### PR TITLE
Fix mod download link validation

### DIFF
--- a/src/daxxl/gui/external/mod_adder_window.py
+++ b/src/daxxl/gui/external/mod_adder_window.py
@@ -175,9 +175,6 @@ class ModAdderWindow(LabelFrame, TtkLabelFrame):
         except ValueError:
             pass
 
-        if download_url.startswith("http://") or download_url.startswith("https://"):
-            check_results["download_url"] = True
-
         return check_results
 
     async def add_mod_and_version(self) -> None:


### PR DESCRIPTION
## Summary
There is a secondary check in check_inputs in mod_adder_window that overrides the first. The first check checks the http/https and the .jar ending just fine but then the second check only checks the http/https and overrides the result of the first.

Essentially, the first correct check is ignored and the second check that doesn’t check the .jar ending overwrites it.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
